### PR TITLE
Add: Initial Travis-CI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: cpp
+
+compiler: gcc
+
+before_install:
+  - sudo apt-get -qq install cmake build-essential python libgsl0-dev libboost-all-dev libxerces-c2-dev xsdcxx zlib1g-dev
+
+install:
+  - mkdir build && cd build
+  - cmake ..
+
+script:
+  - make -j2
+  - ctest -j2


### PR DESCRIPTION
This currently only supports gcc (ran into some compilation errors with clang on the Travis build).

I am not sure whether or not you would like to have Travis CI support, but I thought I'd at least open this PR and give you the option. 

If you decide to merge this PR, you'll need to sign in with your GitHub account at https://travis-ci.org/. It will ask you for some permissions on your GH account, and then you can turn on Travis-CI support through the travis-ci.org website under your account profile.

Once you have turned on Travis-CI support, it should automatically find this PR and (eventually) build the project and run the test suite. If it succeeds (it did on my branch), then it should be safe to merge this PR into the main repo (if you decide to do so).

I hope this automatic testing can be of some help for the openmalaria project as it continues to be developed.

Thanks.