### PR TITLE
Remove (minor): Unnecessary and invalid assert check for intervention…

### DIFF
--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -325,7 +325,6 @@ SimTime VectorModel::initIterate () {
         return sim::zero(); // no initialization to do
     }
     if( initIterations < 0 ){
-        assert( interventionMode = dynamicEIR );
         simulationMode = dynamicEIR;
         return sim::zero();
     }


### PR DESCRIPTION
… mode of vector model.

It does not seem this assert is needed since the code checks for != in a previous condition. Also, it appears that this assert is missing a '=' for comparing the equality; at the moment, this check seems to want to assign instead of compare values.