### PR TITLE
Add new --version output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
 
 script:
   - make -j2
+  - ./openMalaria --version
   - test "$TRAVIS_OS_NAME" == "linux" && ctest -j2 || echo "osx test follows"
   - test "$TRAVIS_OS_NAME" == "osx" && test/run.py 1 || echo "linux test has run"
   - md5sum openMalaria | tee openMalaria.md5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,9 @@ include_directories (
   ${CMAKE_SOURCE_DIR}/model ${CMAKE_BINARY_DIR}
 )
 
+file(STRINGS version.txt OM_VERSION)
+configure_file(model/util/version.h.in ../model/util/version.h	@ONLY)
+
 add_executable (openMalaria model/openMalaria.cpp)
 
 target_link_libraries (openMalaria

--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -24,6 +24,8 @@
 #include "util/BoincWrapper.h"
 #include "util/StreamValidator.h"
 #include "util/DocumentLoader.h"
+/* if you get compile errors like "version.h not found", run CMake first */
+#include "util/version.h"
 
 #include <sstream>
 #include <iostream>
@@ -203,14 +205,13 @@ namespace OM { namespace util {
 	}
 	
 	if (cloVersion || cloHelp){
-            cerr<<"OpenMalaria simulator of malaria epidemiology and control, schema version "
-                  <<DocumentLoader::SCHEMA_VERSION<<endl
-                  <<"(oldest compatible: "<<DocumentLoader::SCHEMA_VERSION_OLDEST_COMPATIBLE
-                  <<"). For more information, see"<<endl
-                  <<"https://github.com/SwissTPH/openmalaria/wiki"<<endl<<endl
-                  <<"OpenMalaria is copyright © 2005-2015 Swiss Tropical Institute and Liverpool"<<endl
-                  <<"School Of Tropical Medicine."<<endl
-                  <<"OpenMalaria comes with ABSOLUTELY NO WARRANTY. This is free software, and you"<<endl
+            cerr<<"OpenMalaria simulator of malaria epidemiology and control."<<endl<< endl
+                  <<"For more information, see https://github.com/SwissTPH/openmalaria/wiki"<<endl<<endl
+                  <<"\tschema version: \t"   <<DocumentLoader::SCHEMA_VERSION<<endl
+                  <<"\tprogram version:\t" << util::semantic_version <<endl<<endl
+                  <<"OpenMalaria is copyright © 2005-2015 Swiss Tropical Institute"<<endl
+                  <<"and Liverpool School Of Tropical Medicine."<<endl
+                  <<"OpenMalaria comes with ABSOLUTELY NO WARRANTY. This is free software, and you"<<endl<<endl
                   <<"are welcome to redistribute it under certain conditions. See the file COPYING"<<endl
                   <<"or http://www.gnu.org/licenses/gpl-2.0.html for details of warranty or terms of"<<endl
                   <<"redistribution."<<endl<<endl;

--- a/model/util/DocumentLoader.h
+++ b/model/util/DocumentLoader.h
@@ -39,7 +39,7 @@ public:
     /** Oldest which current code is potentially compatible with
     * (provided the scenario XML file references its schema version).
     */
-    static const int SCHEMA_VERSION_OLDEST_COMPATIBLE = 32;
+    static const int SCHEMA_VERSION_OLDEST_COMPATIBLE = 34;
     
     DocumentLoader () : documentChanged(false), scenario(NULL) {}
     

--- a/model/util/version.h.in
+++ b/model/util/version.h.in
@@ -1,0 +1,9 @@
+#include <string>
+
+#define SEMANTIC_VERSION_TAG "@OM_VERSION@"
+
+namespace OM {
+    namespace util{
+        static const std::string semantic_version = SEMANTIC_VERSION_TAG;
+    }
+}


### PR DESCRIPTION
This change introduces the new semantic versioning update.

* CMake takes version.txt and generates `model/util/version.h` from `model/util/version.h.in` with the respective semantic version.
* schema-34 will be incompatible with versions before thus set variable `SCHEMA_VERSION_OLDEST_COMPATIBLE` accordingly

@dhardy: What do you think of this?