### PR TITLE
Guard against usage of log(dens) when specificity of diagnostic < 1

### DIFF
--- a/model/WithinHost/Diagnostic.cpp
+++ b/model/WithinHost/Diagnostic.cpp
@@ -107,6 +107,11 @@ bool Diagnostic::isPositive( double dens ) const {
     }
 }
 
+bool Diagnostic::allowsFalsePositives() const{
+    if( (boost::math::isnan)(specificity) ) return dens_lim <= 0.0;
+    return specificity < 1.0;
+}
+
 
 // ———  diagnostics (static)  ———
 

--- a/model/WithinHost/Diagnostic.h
+++ b/model/WithinHost/Diagnostic.h
@@ -45,7 +45,10 @@ public:
         return specificity != that.specificity ||
             dens_lim != that.dens_lim;
     }
-        
+    
+    /// True if false positives are possible
+    bool allowsFalsePositives() const;
+    
 private:
     /** Construct from XML parameters. */
     Diagnostic( const Parameters& parameters, const scnXml::Diagnostic& elt );

--- a/model/mon/mon.cpp
+++ b/model/mon/mon.cpp
@@ -23,6 +23,7 @@
 #include "mon/management.h"
 #define H_OM_mon_cpp
 #include "mon/OutputMeasures.h"
+#include "WithinHost/Diagnostic.h"
 #include "WithinHost/Genotypes.h"
 #include "Clinical/CaseManagementCommon.h"
 #include "Host/Human.h"
@@ -449,6 +450,14 @@ void internal::initReporting( const scnXml::Scenario& scenario ){
                 throw util::xml_scenario_error( (boost::format("obsolete "
                     "survey option: %1%") %optElt.getName()).str() );
             } else TRACED_EXCEPTION_DEFAULT("invalid measure code");
+        }
+        
+        if( om.m == MHF_LOG_DENSITY || om.m == MHF_LOG_DENSITY_GENOTYPE){
+            if( WithinHost::diagnostics::monitoringDiagnostic().allowsFalsePositives() ){
+                throw util::xml_scenario_error( (boost::format("measure %1% "
+                    "may not be used when monitoring diagnostic sensitivity "
+                    "< 1") %optElt.getName()).str() );
+            }
         }
         
         // Categorisation can be disabled but not enabled. We check each now.


### PR DESCRIPTION
Fix #203 