### PR TITLE
Implement requested PKPD changes

### DIFF
--- a/model/PkPd/Drug/LSTMDrug.cpp
+++ b/model/PkPd/Drug/LSTMDrug.cpp
@@ -46,11 +46,10 @@ bool comp(pair<double,double> lhs, double rhs){
 // per day, but be able to handle more.
 // If two doses coincide, they can be combined but doing so is not essential.
 
-void LSTMDrug::medicate_vd (double time, double qty, double volDist) {
-    double conc = qty / volDist;        // mg / l
+void LSTMDrug::medicate_vd (double time, double qty) {
     // Insert in the right position to maintain sorting:
     DoseVec::iterator pos = lower_bound(doses.begin(), doses.end(), time, comp);
-    doses.insert(pos, make_pair (time, conc));
+    doses.insert(pos, make_pair (time, qty));
     //TODO (C++11 only, different comp): assert(is_sorted(doses.begin(), doses.end(), comp));
 }
 

--- a/model/PkPd/Drug/LSTMDrug.cpp
+++ b/model/PkPd/Drug/LSTMDrug.cpp
@@ -46,11 +46,11 @@ bool comp(pair<double,double> lhs, double rhs){
 // per day, but be able to handle more.
 // If two doses coincide, they can be combined but doing so is not essential.
 
-void LSTMDrug::medicate_vd (double time, double qty) {
+void LSTMDrug::medicate(double time, double qty){
     // Insert in the right position to maintain sorting:
     DoseVec::iterator pos = lower_bound(doses.begin(), doses.end(), time, comp);
     doses.insert(pos, make_pair (time, qty));
-    //TODO (C++11 only, different comp): assert(is_sorted(doses.begin(), doses.end(), comp));
+    assert(is_sorted(doses.begin(), doses.end(), comp));
 }
 
 }

--- a/model/PkPd/Drug/LSTMDrug.h
+++ b/model/PkPd/Drug/LSTMDrug.h
@@ -47,14 +47,13 @@ public:
     
     /** Indicate a new medication this time step.
      *
-     * Converts qty in mg to concentration, and stores along with time (delay past
-     * the start of the current time step) in the doses container.
+     * Stores (time, qty) pair in the doses container.
      * 
-     * @param time Time of administration, in days (should be at least 0 and
-     *  less than 1).
-     * @param qty Amount of active ingredient, in mg
+     * @param time Time of administration, as the delay since the start of the
+     *  current time step in units of days.
+     * @param qty Amount of active ingredient, in mg (total)
      */
-    virtual void medicate (double time, double qty) =0;
+    void medicate (double time, double qty);
     
     /** Get the concentration of the given drug contained in this model (only
      * compartments with active PD; zero if drug index doesn't match that used).
@@ -88,18 +87,6 @@ public:
     }
 
 protected:
-    /** Indicate a new medication this time step
-     *
-     * Stores (time, qty) pair in the doses container.
-     * along with time (delay past
-     * the start of the current time step) in the doses container.
-     * 
-     * @param time Time of administration, as the delay since the start of the
-     *  current time step in units of days.
-     * @param qty Amount of active ingredient, in mg
-     */
-    void medicate_vd (double time, double qty);
-    
     virtual void checkpoint (istream& stream){}
     virtual void checkpoint (ostream& stream){}
     

--- a/model/PkPd/Drug/LSTMDrug.h
+++ b/model/PkPd/Drug/LSTMDrug.h
@@ -53,9 +53,8 @@ public:
      * @param time Time of administration, in days (should be at least 0 and
      *  less than 1).
      * @param qty Amount of active ingredient, in mg
-     * @param bodyMass Body mass of patient, in kg
      */
-    virtual void medicate (double time, double qty, double bodyMass) =0;
+    virtual void medicate (double time, double qty) =0;
     
     /** Get the concentration of the given drug contained in this model (only
      * compartments with active PD; zero if drug index doesn't match that used).
@@ -89,18 +88,17 @@ public:
     }
 
 protected:
-    /** Indicate a new medication this time step, specifying volume of
-     * distribution directly.
+    /** Indicate a new medication this time step
      *
-     * Converts qty in mg to concentration, and stores along with time (delay past
+     * Stores (time, qty) pair in the doses container.
+     * along with time (delay past
      * the start of the current time step) in the doses container.
      * 
-     * @param time Time of administration, in days (should be at least 0 and
-     *  less than 1).
+     * @param time Time of administration, as the delay since the start of the
+     *  current time step in units of days.
      * @param qty Amount of active ingredient, in mg
-     * @param volDist Volume of distribution in l
      */
-    void medicate_vd (double time, double qty, double volDist);
+    void medicate_vd (double time, double qty);
     
     virtual void checkpoint (istream& stream){}
     virtual void checkpoint (ostream& stream){}

--- a/model/PkPd/Drug/LSTMDrugConversion.cpp
+++ b/model/PkPd/Drug/LSTMDrugConversion.cpp
@@ -64,12 +64,6 @@ double LSTMDrugConversion::getMetaboliteConcentration() const {
 }
 
 
-void LSTMDrugConversion::medicate(double time, double qty)
-{
-    // TODO: this is correct in AS unittest (qty = 200 = 4 * 50), but why is qty mg/kg not mg?
-    medicate_vd(time, qty);
-}
-
 /// Parameters for func_convFactor and LSTMDrugConversion::calculateFactor
 struct Params_convFactor {
     // Quantities of parent in gut, parent in circulation and metabolite in

--- a/model/PkPd/Drug/LSTMDrugConversion.cpp
+++ b/model/PkPd/Drug/LSTMDrugConversion.cpp
@@ -64,11 +64,10 @@ double LSTMDrugConversion::getMetaboliteConcentration() const {
 }
 
 
-void LSTMDrugConversion::medicate(double time, double qty, double bodyMass)
+void LSTMDrugConversion::medicate(double time, double qty)
 {
-    // Note: we use second value of dose pair as quanity (mg) not concentration
     // TODO: this is correct in AS unittest (qty = 200 = 4 * 50), but why is qty mg/kg not mg?
-    medicate_vd(time, qty, 1.0);
+    medicate_vd(time, qty);
 }
 
 /// Parameters for func_convFactor and LSTMDrugConversion::calculateFactor

--- a/model/PkPd/Drug/LSTMDrugConversion.h
+++ b/model/PkPd/Drug/LSTMDrugConversion.h
@@ -50,8 +50,6 @@ public:
     virtual size_t getIndex() const;
     virtual double getConcentration(size_t index) const;
     
-    virtual void medicate (double time, double qty);
-    
     virtual double calculateDrugFactor(WithinHost::CommonInfection *inf, double body_mass) const;
     virtual void updateConcentration (double body_mass);
     double getMetaboliteConcentration() const;

--- a/model/PkPd/Drug/LSTMDrugConversion.h
+++ b/model/PkPd/Drug/LSTMDrugConversion.h
@@ -50,7 +50,7 @@ public:
     virtual size_t getIndex() const;
     virtual double getConcentration(size_t index) const;
     
-    virtual void medicate (double time, double qty, double bodyMass);
+    virtual void medicate (double time, double qty);
     
     virtual double calculateDrugFactor(WithinHost::CommonInfection *inf, double body_mass) const;
     virtual void updateConcentration (double body_mass);

--- a/model/PkPd/Drug/LSTMDrugOneComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugOneComp.cpp
@@ -45,9 +45,9 @@ double LSTMDrugOneComp::getConcentration(size_t index) const {
     else return 0.0;
 }
 
-void LSTMDrugOneComp::medicate(double time, double qty, double bodyMass)
+void LSTMDrugOneComp::medicate(double time, double qty)
 {
-    medicate_vd(time, qty, vol_dist * bodyMass);
+    medicate_vd(time, qty);
 }
 
 // TODO: in high transmission, is this going to get called more often than updateConcentration?
@@ -77,7 +77,7 @@ double LSTMDrugOneComp::calculateDrugFactor(WithinHost::CommonInfection *inf, do
                 time = time_conc.first;
             }else{ assert( time == time_conc.first ); }
             // add dose (instantaneous absorption):
-            concentration_today += time_conc.second;
+            concentration_today += time_conc.second / (vol_dist * body_mass);
         }else/*i.e. tomorrow or later*/{
             break;
         }
@@ -103,7 +103,7 @@ void LSTMDrugOneComp::updateConcentration( double body_mass ){
         // we iteratate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             // calculate decayed dose and add:
-            concentration += time_conc.second * exp(neg_elim_rate * (1.0 - time_conc.first));
+            concentration += time_conc.second / (vol_dist * body_mass) * exp(neg_elim_rate * (1.0 - time_conc.first));
             doses_taken += 1;
         }else /*i.e. tomorrow or later*/{
             time_conc.first -= 1.0;

--- a/model/PkPd/Drug/LSTMDrugOneComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugOneComp.cpp
@@ -45,11 +45,6 @@ double LSTMDrugOneComp::getConcentration(size_t index) const {
     else return 0.0;
 }
 
-void LSTMDrugOneComp::medicate(double time, double qty)
-{
-    medicate_vd(time, qty);
-}
-
 // TODO: in high transmission, is this going to get called more often than updateConcentration?
 // When does it make sense to try to optimise (avoid doing decay calcuations here)?
 double LSTMDrugOneComp::calculateDrugFactor(WithinHost::CommonInfection *inf, double body_mass) const {

--- a/model/PkPd/Drug/LSTMDrugOneComp.h
+++ b/model/PkPd/Drug/LSTMDrugOneComp.h
@@ -48,8 +48,6 @@ public:
     virtual size_t getIndex() const;
     virtual double getConcentration(size_t index) const;
     
-    virtual void medicate (double time, double qty);
-    
     virtual double calculateDrugFactor(WithinHost::CommonInfection *inf, double body_mass) const;
     virtual void updateConcentration (double body_mass);
     

--- a/model/PkPd/Drug/LSTMDrugOneComp.h
+++ b/model/PkPd/Drug/LSTMDrugOneComp.h
@@ -48,7 +48,7 @@ public:
     virtual size_t getIndex() const;
     virtual double getConcentration(size_t index) const;
     
-    virtual void medicate (double time, double qty, double bodyMass);
+    virtual void medicate (double time, double qty);
     
     virtual double calculateDrugFactor(WithinHost::CommonInfection *inf, double body_mass) const;
     virtual void updateConcentration (double body_mass);

--- a/model/PkPd/Drug/LSTMDrugThreeComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.cpp
@@ -60,11 +60,6 @@ double LSTMDrugThreeComp::getConcentration(size_t index) const {
     else return 0.0;
 }
 
-void LSTMDrugThreeComp::medicate(double time, double qty)
-{
-    medicate_vd(time, qty);
-}
-
 void LSTMDrugThreeComp::updateCached(double body_mass) const{
     if( last_bm == body_mass ) return;
     

--- a/model/PkPd/Drug/LSTMDrugThreeComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.cpp
@@ -36,10 +36,10 @@ LSTMDrugThreeComp::LSTMDrugThreeComp(const LSTMDrugType& type) :
     typeData(type),
     concA(0.0), concB(0.0), concC(0.0), concABC(0.0),
     elim_sample(type.sample_elim_rate()),
-    a12(type.sample_a12()),
-    a21(type.sample_a21()),
-    a13(type.sample_a13()),
-    a31(type.sample_a31()),
+    k12(type.sample_k12()),
+    k21(type.sample_k21()),
+    k13(type.sample_k13()),
+    k31(type.sample_k31()),
     nka(-type.sample_ka()),
     last_bm(numeric_limits<double>::quiet_NaN()),
     na(numeric_limits<double>::quiet_NaN()),
@@ -69,8 +69,6 @@ void LSTMDrugThreeComp::updateCached(double body_mass) const{
     if( last_bm == body_mass ) return;
     
     double k = elim_sample * pow(body_mass, typeData.neg_m_exponent());
-    const double k12 = a12 / body_mass, k21 = a21 / body_mass;
-    const double k13 = a13 / body_mass, k31 = a31 / body_mass;
     
     const double a0 = k*k21*k31;
     const double a1 = k*k31 + k21*k31 + k21*k13 + k*k21 + k31*k12;
@@ -254,10 +252,10 @@ void LSTMDrugThreeComp::checkpoint(ostream& stream){
     concC & stream;
     concABC & stream;
     elim_sample & stream;
-    a12 & stream;
-    a21 & stream;
-    a13 & stream;
-    a31 & stream;
+    k12 & stream;
+    k21 & stream;
+    k13 & stream;
+    k31 & stream;
     nka & stream;
     last_bm & stream;
     na & stream;
@@ -273,10 +271,10 @@ void LSTMDrugThreeComp::checkpoint(istream& stream){
     concC & stream;
     concABC & stream;
     elim_sample & stream;
-    a12 & stream;
-    a21 & stream;
-    a13 & stream;
-    a31 & stream;
+    k12 & stream;
+    k21 & stream;
+    k13 & stream;
+    k31 & stream;
     nka & stream;
     last_bm & stream;
     na & stream;

--- a/model/PkPd/Drug/LSTMDrugThreeComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.cpp
@@ -60,9 +60,9 @@ double LSTMDrugThreeComp::getConcentration(size_t index) const {
     else return 0.0;
 }
 
-void LSTMDrugThreeComp::medicate(double time, double qty, double bodyMass)
+void LSTMDrugThreeComp::medicate(double time, double qty)
 {
-    medicate_vd(time, qty, vol_dist * bodyMass);
+    medicate_vd(time, qty);
 }
 
 void LSTMDrugThreeComp::updateCached(double bm) const{
@@ -190,10 +190,11 @@ double LSTMDrugThreeComp::calculateDrugFactor(WithinHost::CommonInfection *inf, 
                 time = time_conc.first;
             }else{ assert( time == time_conc.first ); }
             // add dose:
-            p.cA += AV * time_conc.second;
-            p.cB += BV * time_conc.second;
-            p.cC += CV * time_conc.second;
-            p.cABC += (AV + BV + CV) * time_conc.second;
+            const double conc = time_conc.second / (vol_dist * body_mass);
+            p.cA += AV * conc;
+            p.cB += BV * conc;
+            p.cC += CV * conc;
+            p.cABC += (AV + BV + CV) * conc;
         }else /*i.e. tomorrow or later*/{
             // ignore
         }
@@ -223,10 +224,11 @@ void LSTMDrugThreeComp::updateConcentration (double body_mass) {
         // we iteratate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             // add dose:
-            concA += AV * time_conc.second * exp(na * (1.0 - time_conc.first));
-            concB += BV * time_conc.second * exp(nb * (1.0 - time_conc.first));
-            concC += CV * time_conc.second * exp(ng * (1.0 - time_conc.first));
-            concABC += (AV + BV + CV) * time_conc.second * exp(nka * (1.0 - time_conc.first));
+            const double conc = time_conc.second / (vol_dist * body_mass);
+            concA += AV * conc * exp(na * (1.0 - time_conc.first));
+            concB += BV * conc * exp(nb * (1.0 - time_conc.first));
+            concC += CV * conc * exp(ng * (1.0 - time_conc.first));
+            concABC += (AV + BV + CV) * conc * exp(nka * (1.0 - time_conc.first));
             doses_taken += 1;
         }else /*i.e. tomorrow or later*/{
             time_conc.first -= 1.0;

--- a/model/PkPd/Drug/LSTMDrugThreeComp.h
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.h
@@ -85,7 +85,7 @@ protected:
     // (this is essentially a cache updated by updateCached())
     mutable double last_bm;     // body mass at time of last calculation
     mutable double na, nb, ng;      // -α, -β, -γ, -k_a
-    mutable double AV, BV, CV;     // A*V, B*V, C*V where V is total volume of distribution (litres)
+    mutable double A, B, C;     // A, B, C
     
 private:
     double calculateFactor(const Params_fC& p, double duration) const;

--- a/model/PkPd/Drug/LSTMDrugThreeComp.h
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.h
@@ -51,8 +51,6 @@ public:
     virtual size_t getIndex() const;
     virtual double getConcentration(size_t index) const;
     
-    virtual void medicate (double time, double qty);
-    
     virtual double calculateDrugFactor(WithinHost::CommonInfection *inf, double body_mass) const;
     virtual void updateConcentration (double body_mass);
     

--- a/model/PkPd/Drug/LSTMDrugThreeComp.h
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.h
@@ -51,7 +51,7 @@ public:
     virtual size_t getIndex() const;
     virtual double getConcentration(size_t index) const;
     
-    virtual void medicate (double time, double qty, double bodyMass);
+    virtual void medicate (double time, double qty);
     
     virtual double calculateDrugFactor(WithinHost::CommonInfection *inf, double body_mass) const;
     virtual void updateConcentration (double body_mass);

--- a/model/PkPd/Drug/LSTMDrugThreeComp.h
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.h
@@ -78,7 +78,7 @@ protected:
     
     // Sampled constants
     double elim_sample;
-    double a12, a21, a13, a31;
+    double k12, k21, k13, k31;
     double nka;    // -k_a
     
     // Computed parameters, constant except for dependence on body mass

--- a/model/PkPd/Drug/LSTMDrugType.cpp
+++ b/model/PkPd/Drug/LSTMDrugType.cpp
@@ -165,6 +165,9 @@ LSTMDrugType::LSTMDrugType (size_t index, const scnXml::PKPDDrug& drugData) :
     const scnXml::PK& pk = drugData.getPK();
     negligible_concentration = pk.getNegligible_concentration();
     if( pk.getHalf_life().present() ){
+        if( pk.getK().present() || pk.getM_exponent().present() ){
+            throw util::xml_scenario_error( "PK data must specify one of half_life or (k, m_exponent); it specifies both" );
+        }
         elimination_rate.setParams( log(2.0) / pk.getHalf_life().get(), 0.0 );
         neg_m_exp = 0.0; // no dependence on body mass
     }else{

--- a/model/PkPd/Drug/LSTMDrugType.cpp
+++ b/model/PkPd/Drug/LSTMDrugType.cpp
@@ -142,11 +142,11 @@ LSTMDrug* LSTMDrugType::createInstance(size_t index) {
     if( typeData.conversion_rate.isSet() ){
         LSTMDrugType& metaboliteData = drugTypes[typeData.metabolite];
         return new LSTMDrugConversion( typeData, metaboliteData );
-    }else if( typeData.a12.isSet() ){
-        // a21 is set when a12 is set; a13 and a31 may be set
+    }else if( typeData.k12.isSet() ){
+        // k21 is set when k12 is set; k13 and k31 may be set
         return new LSTMDrugThreeComp( typeData );
     }else{
-        // none of a12/a21/a13/a31 should be set in this case
+        // none of k12/k21/k13/k31 should be set in this case
         return new LSTMDrugOneComp( typeData );
     }
 }
@@ -180,22 +180,22 @@ LSTMDrugType::LSTMDrugType (size_t index, const scnXml::PKPDDrug& drugData) :
     vol_dist.setParams( pk.getVol_dist(),
                         pk.getVol_dist().getSigma() );
     if( pk.getCompartment2().present() ){
-        a12.setParams( pk.getCompartment2().get().getA12() );
-        a21.setParams( pk.getCompartment2().get().getA21() );
+        k12.setParams( pk.getCompartment2().get().getK12() );
+        k21.setParams( pk.getCompartment2().get().getK21() );
         if( pk.getCompartment3().present() ){
-            a13.setParams( pk.getCompartment3().get().getA13() );
-            a31.setParams( pk.getCompartment3().get().getA31() );
+            k13.setParams( pk.getCompartment3().get().getK13() );
+            k31.setParams( pk.getCompartment3().get().getK31() );
         }else{
             // 2-compartment model: use 3-compartment code with these parameters set to zero
-            a13.setParams(0.0, 0.0);
-            a31.setParams(0.0, 0.0);
+            k13.setParams(0.0, 0.0);
+            k31.setParams(0.0, 0.0);
         }
     }else if( pk.getCompartment3().present() ){
         throw util::xml_scenario_error( "PK model specifies parameters for "
                 "compartment3 without compartment2" );
     }
     if( pk.getConversion().present() ){
-        if( a12.isSet() ){
+        if( k12.isSet() ){
             throw util::xml_scenario_error( "PK conversion model is incompatible with 2/3-compartment model" );
         }
         const scnXml::Conversion& conv = pk.getConversion().get();
@@ -208,14 +208,14 @@ LSTMDrugType::LSTMDrugType (size_t index, const scnXml::PKPDDrug& drugData) :
         mwr = conv.getMolRatio();
     }
     if( pk.getK_a().present() ){
-        if( !a12.isSet() && !conversion_rate.isSet() ){
+        if( !k12.isSet() && !conversion_rate.isSet() ){
             throw util::xml_scenario_error( "PK models only allow an "
                 "absorption rate parameter (k_a) when compartment2 or "
                 " conversion parameters are present" );
         }
         absorption_rate.setParams(pk.getK_a().get());
     }else{
-        if( a12.isSet() ){
+        if( k12.isSet() ){
             throw util::xml_scenario_error( "PK models require an absorption "
                 "rate parameter (k_a) when compartment2 is present" );
         }

--- a/model/PkPd/Drug/LSTMDrugType.h
+++ b/model/PkPd/Drug/LSTMDrugType.h
@@ -152,10 +152,10 @@ public:
     inline double sample_conv_rate() const{
         return conversion_rate.sample();
     }
-    inline double sample_a12() const{ return a12.sample(); }
-    inline double sample_a21() const{ return a21.sample(); }
-    inline double sample_a13() const{ return a13.sample(); }
-    inline double sample_a31() const{ return a31.sample(); }
+    inline double sample_k12() const{ return k12.sample(); }
+    inline double sample_k21() const{ return k21.sample(); }
+    inline double sample_k13() const{ return k13.sample(); }
+    inline double sample_k31() const{ return k31.sample(); }
     inline double sample_ka() const{ return absorption_rate.sample(); }
     
     /** Return reference to correct drug-phenotype data. */
@@ -200,7 +200,7 @@ private:
     /// Convertion rate
     LognormalSampler conversion_rate;
     /// Parameters for absorption rates in two- and three-compartment models.
-    LognormalSampler a12, a21, a13, a31;
+    LognormalSampler k12, k21, k13, k31;
     
     // Allow LSTMDrug to access private members
     friend class LSTMDrugPD;

--- a/model/PkPd/LSTMModel.cpp
+++ b/model/PkPd/LSTMModel.cpp
@@ -80,7 +80,7 @@ void LSTMModel::prescribe(size_t schedule, size_t dosage, double age, double bod
     }
 }
 
-void LSTMModel::medicate(double body_mass){
+void LSTMModel::medicate(){
     if( medicateQueue.empty() ) return;
     
     // Process pending medications (in interal queue) and apply/update:
@@ -88,7 +88,7 @@ void LSTMModel::medicate(double body_mass){
     while( it != medicateQueue.end() ){
         if( it->time < 1.0 ){   // Medicate medications to be prescribed starting at the next time-step
             // This function could be inlined, except for uses in testing:
-            medicateDrug (it->drug, it->qty, it->time, body_mass);
+            medicateDrug (it->drug, it->qty, it->time);
             it = medicateQueue.erase (it);
         }else{  // and decrement treatment seeking delay for the rest
             it->time -= 1.0;
@@ -97,17 +97,17 @@ void LSTMModel::medicate(double body_mass){
     }
 }
 
-void LSTMModel::medicateDrug(size_t typeIndex, double qty, double time, double bodyMass) {
+void LSTMModel::medicateDrug(size_t typeIndex, double qty, double time) {
     //TODO: might be a little faster if m_drugs was pre-allocated with a slot for each drug type, using a null pointer
     foreach( LSTMDrug& drug, m_drugs ){
         if (drug.getIndex() == typeIndex){
-            drug.medicate (time, qty, bodyMass);
+            drug.medicate (time, qty);
             return;
         }
     }
     // No match, so insert one:
     m_drugs.push_back( LSTMDrugType::createInstance(typeIndex) );
-    m_drugs.back().medicate (time, qty, bodyMass);
+    m_drugs.back().medicate (time, qty);
 }
 
 double LSTMModel::getDrugConc (size_t drug_index) const{

--- a/model/PkPd/LSTMModel.h
+++ b/model/PkPd/LSTMModel.h
@@ -110,12 +110,10 @@ public:
     /** Medicate drugs: human takes prescribed drugs which are to be taken this
      * day.
      * 
-     * @param body_mass Mass of human in kg
-     * 
      * Note: poor adherence on the part of the patient is not modeled here; to
      * model, prescribe with a "poor adherence" schedule.
      */
-    void medicate(double body_mass);
+    void medicate();
     
     /** Get concentration of the drug at the beginning of the day.
      * 
@@ -145,7 +143,6 @@ private:
      * \param typeIndex The index of drug type data (what LSTMDrugType::findDrug() returns).
      * \param qty The quantity in mg
      * \param time Time in days since start of this time step to medicate at
-     * \param bodyMass Weight of human in kg
      * 
      * Due to the fact we're using a discrete time step model, the case-management
      * update (calling medicate) and within-host model update (calling
@@ -154,7 +151,7 @@ private:
      * new infection densities) happens first; hence medicate() will always be
      * called after getDrugFactor in a time step, and a time of zero means the
      * dose has effect from the start of the following time step. */
-    void medicateDrug(size_t typeIndex, double qty, double time, double bodyMass);
+    void medicateDrug(size_t typeIndex, double qty, double time);
   
     void checkpoint (istream& stream);
     void checkpoint (ostream& stream);

--- a/model/WithinHost/CommonWithinHost.cpp
+++ b/model/WithinHost/CommonWithinHost.cpp
@@ -182,7 +182,7 @@ void CommonWithinHost::update(int nNewInfs, vector<double>& genotype_weights,
     
     for( SimTime now = sim::ts0(), end = sim::ts0() + SimTime::oneTS(); now < end; now += SimTime::oneDay() ){
         // every day, medicate drugs, update each infection, then decay drugs
-        pkpdModel.medicate( body_mass );
+        pkpdModel.medicate();
         
         double sumLogDens = 0.0;
         

--- a/model/util/BoincWrapper.cpp
+++ b/model/util/BoincWrapper.cpp
@@ -48,10 +48,10 @@ namespace OM { namespace util {
 #ifdef WITHOUT_BOINC
 namespace BoincWrapper {
   void init () {
-    cout << "BoincWrapper: not using BOINC" << endl;
+    cerr << "BoincWrapper: not using BOINC" << endl;
   }
   void finish(int err) {
-      cout << '\r' << flush;	// clean last line of progress-output
+      cerr << '\r' << flush;	// clean last line of progress-output
     exit(err);	// doesn't return
   }
   
@@ -70,7 +70,7 @@ namespace BoincWrapper {
       if( percent != lastPercent ){	// avoid huge amounts of output for performance/log-file size reasons
 	  lastPercent = percent;
 	// \r cleans line. Then we print progress as a percentage.
-	cout << (boost::format("\r[%|3i|%%]\t") %percent) << flush;
+	cerr << (boost::format("\r[%|3i|%%]\t") %percent) << flush;
       }
   }
   int timeToCheckpoint() {
@@ -103,7 +103,7 @@ namespace BoincWrapper {
       exit (err);
     }
     // Probably we don't need to know this. Disable to compress stderr.txt:
-//     std::cout << "BoincWrapper: BOINC initialized" << std::endl;
+//     std::cerr << "BoincWrapper: BOINC initialized" << std::endl;
   }
   void finish(int err) {
     boinc_finish(err);	// doesn't return

--- a/schema/pharmacology.xsd
+++ b/schema/pharmacology.xsd
@@ -395,28 +395,26 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
               </xs:annotation>
               <xs:complexType>
                 <xs:all>
-                  <xs:element name="a12" type="om:SampledValue">
+                  <xs:element name="k12" type="om:SampledValue">
                     <xs:annotation>
                       <xs:documentation>
                           Absorption rate from the central compartment to the
-                          first periphery compartment (2). The parameter
-                          k12 = a12 / m where m is the body mass (kg).
+                          first periphery compartment (2).
                           
                           It is sampled per-patient when sigma &gt; 0.
                       </xs:documentation>
-                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate to compartment 2 (a12);</xs:appinfo>
+                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate to compartment 2 (k12);</xs:appinfo>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="a21" type="om:SampledValue">
+                  <xs:element name="k21" type="om:SampledValue">
                     <xs:annotation>
                       <xs:documentation>
                           Absorption rate from the first periphery compartment
-                          (2) to the central compartment. The parameter
-                          k21 = a21 / m where m is the body mass (kg).
+                          (2) to the central compartment.
                           
                           It is sampled per-patient when sigma &gt; 0.
                       </xs:documentation>
-                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate from compartment 2 (a21);</xs:appinfo>
+                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate from compartment 2 (k21);</xs:appinfo>
                     </xs:annotation>
                   </xs:element>
                 </xs:all>
@@ -432,28 +430,26 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
               </xs:annotation>
               <xs:complexType>
                 <xs:all>
-                  <xs:element name="a13" type="om:SampledValue">
+                  <xs:element name="k13" type="om:SampledValue">
                     <xs:annotation>
                       <xs:documentation>
                           Absorption rate from the central compartment to the
-                          second periphery compartment (3). The parameter
-                          k13 = a13 / m where m is the body mass (kg).
+                          second periphery compartment (3).
                           
                           It is sampled per-patient when sigma &gt; 0.
                       </xs:documentation>
-                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate to compartment 3 (a13);</xs:appinfo>
+                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate to compartment 3 (k13);</xs:appinfo>
                     </xs:annotation>
                   </xs:element>
-                  <xs:element name="a31" type="om:SampledValue">
+                  <xs:element name="k31" type="om:SampledValue">
                     <xs:annotation>
                       <xs:documentation>
                           Absorption rate from the second periphery compartment
-                          (3) to the central compartment. The parameter
-                          k31 = a31 / m where m is the body mass (kg).
+                          (3) to the central compartment.
                           
                           It is sampled per-patient when sigma &gt; 0.
                       </xs:documentation>
-                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate from compartment 3 (a31);</xs:appinfo>
+                      <xs:appinfo>units:day^-1;min:0;name:Absorption rate from compartment 3 (k31);</xs:appinfo>
                     </xs:annotation>
                   </xs:element>
                 </xs:all>

--- a/unittest/LSTMPkPdSuite.h
+++ b/unittest/LSTMPkPdSuite.h
@@ -63,32 +63,32 @@ public:
     }
     
     void testOral () {
-	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0, massAt21 );
+	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0 );
 	TS_ASSERT_APPROX (proxy->getDrugFactor (inf, massAt21), 0.03174563638523168);
     }
     
     void testOralHalves () {	// the point being: check it can handle two doses at the same time-point correctly
-	UnittestUtil::medicate( *proxy, MQ_index, 1500, 0, massAt21 );
-	UnittestUtil::medicate( *proxy, MQ_index, 1500, 0, massAt21 );
+	UnittestUtil::medicate( *proxy, MQ_index, 1500, 0 );
+	UnittestUtil::medicate( *proxy, MQ_index, 1500, 0 );
 	TS_ASSERT_APPROX (proxy->getDrugFactor (inf, massAt21), 0.03174563638523168);
     }
     
     void testOralSplit () {
-	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0, massAt21 );
-	UnittestUtil::medicate( *proxy, MQ_index, 0, 0.5, massAt21 );	// insert a second dose half way through the day: forces drug calculation to be split into half-days but shouldn't affect result
+	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0 );
+	UnittestUtil::medicate( *proxy, MQ_index, 0, 0.5 );	// insert a second dose half way through the day: forces drug calculation to be split into half-days but shouldn't affect result
 	TS_ASSERT_APPROX (proxy->getDrugFactor (inf, massAt21), 0.03174563639140275);
     }
     
     void testOralDecayed () {
-	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0, massAt21 );
+	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0 );
 	proxy->decayDrugs (massAt21);
 	TS_ASSERT_APPROX (proxy->getDrugFactor (inf, massAt21), 0.03174563639501896);
     }
     
     void testOral2Doses () {
-	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0, massAt21 );
+	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0 );
 	proxy->decayDrugs (massAt21);
-	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0, massAt21 );
+	UnittestUtil::medicate( *proxy, MQ_index, 3000, 0 );
 	TS_ASSERT_APPROX (proxy->getDrugFactor (inf, massAt21), 0.03174563637686205);
     }
     

--- a/unittest/PkPdComplianceSuite.h
+++ b/unittest/PkPdComplianceSuite.h
@@ -317,7 +317,7 @@ public:
     void testPPQ_Hodel2013 (){
         const double dose = 18 * bodymass;   // 18 mg/kg * 50 kg
         assembleTripleDosageSchedule( dose );
-        const double drug_conc[] = { 0, 0.0724459062, 0.1218019809, 0.1561173647, 0.1081632036, 0.0768569742 };
+        const double drug_conc[] = { 0, 0.08022449, 0.1416033, 0.18962337, 0.14792303, 0.11829172 };
         const double drug_factors[] = { 1, 0.03422595, 0.001086594, 3.449438e-05, 1.095144e-06, 3.479034e-08 };
         runDrugSimulations("PPQ2", drug_conc, drug_factors);
     }
@@ -326,7 +326,7 @@ public:
     void testPPQ_Tarning2012AAC (){
         const double dose = 18 * bodymass;   // 18 mg/kg * 50 kg
         assembleTripleDosageSchedule( dose );
-        const double drug_conc[] = { 0, 0.0768788483, 0.1201694285, 0.1526774077, 0.1016986483, 0.0798269206 };
+        const double drug_conc[] = { 0, 0.075305088, 0.118119866, 0.150210662, 0.100426437, 0.078729041 };
         const double drug_factors[] = { 1, 0.03421756, 0.001086307, 3.448539e-05, 1.094894e-06, 3.478302e-08 };
         runDrugSimulations("PPQ3", drug_conc, drug_factors);
     }

--- a/unittest/PkPdComplianceSuite.h
+++ b/unittest/PkPdComplianceSuite.h
@@ -233,7 +233,7 @@ public:
             pair<iter, iter> doses_tmp = schedule.equal_range(i);
             for( iter it = doses_tmp.first; it != doses_tmp.second; it++){
                 const double time = it->second.first, qty = it->second.second;
-                UnittestUtil::medicate( *proxy, drugIndex, qty, time, bodymass );
+                UnittestUtil::medicate( *proxy, drugIndex, qty, time );
             }
     }
     

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -476,8 +476,8 @@ public:
     }
     
     static void medicate(PkPd::LSTMModel& pkpd, size_t typeIndex, double qty,
-                         double time, double bodyMass){
-        pkpd.medicateDrug(typeIndex, qty, time, bodyMass);
+                         double time){
+        pkpd.medicateDrug(typeIndex, qty, time);
     }
     
     static void clearMedicateQueue( PkPd::LSTMModel& pkpd ){

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -93,13 +93,13 @@ namespace xml_helpers{
     ///@param k Elimination rate of drug (days^-1)
     ///@param m_exponent
     ///@param ka Absorbtion rate from gut
-    ///@param a12 Absorbtion rate parameter a12
-    ///@param a21 Absorbtion rate parameter a21
+    ///@param k12 Absorbtion rate parameter k12
+    ///@param k21 Absorbtion rate parameter k21
     struct PK2C{
         PK2C(double Vd, double negl_conc, double k, double m_exponent,
-             double ka, double a12, double a21):
-            Vd(Vd), negl_conc(negl_conc), k(k), me(m_exponent), ka(ka), a12(a12), a21(a21) {}
-        double Vd, negl_conc, k, me, ka, a12, a21;
+             double ka, double k12, double k21):
+            Vd(Vd), negl_conc(negl_conc), k(k), me(m_exponent), ka(ka), k12(k12), k21(k21) {}
+        double Vd, negl_conc, k, me, ka, k12, k21;
     };
     /// Construct a helper for setting PK parameters (2-compartment model)
     ///@param Vd Volume of distribution (l/kg)
@@ -107,16 +107,16 @@ namespace xml_helpers{
     ///@param k Elimination rate of drug (days^-1)
     ///@param m_exponent
     ///@param ka Absorbtion rate from gut
-    ///@param a12 Absorbtion rate parameter a12
-    ///@param a21 Absorbtion rate parameter a21
-    ///@param a13 Absorbtion rate parameter a13
-    ///@param a31 Absorbtion rate parameter a31
+    ///@param k12 Absorbtion rate parameter k12
+    ///@param k21 Absorbtion rate parameter k21
+    ///@param k13 Absorbtion rate parameter k13
+    ///@param k31 Absorbtion rate parameter k31
     struct PK3C{
         PK3C(double Vd, double negl_conc, double k, double m_exponent,
-             double ka, double a12, double a21, double a13, double a31):
+             double ka, double k12, double k21, double k13, double k31):
             Vd(Vd), negl_conc(negl_conc), k(k), me(m_exponent), ka(ka),
-            a12(a12), a21(a21), a13(a13), a31(a31) {}
-        double Vd, negl_conc, k, me, ka, a12, a21, a13, a31;
+            k12(k12), k21(k21), k13(k13), k31(k31) {}
+        double Vd, negl_conc, k, me, ka, k12, k21, k13, k31;
     };
     /// Construct a helper for setting PD parameters
     ///@param vmax Max killing rate
@@ -173,8 +173,8 @@ namespace xml_helpers{
         scnXml::PK xPK(pk.negl_conc, pk.Vd);
         xPK.setK(scnXml::SampledValue(pk.k, "const"));
         xPK.setCompartment2(scnXml::Compartment2(
-            scnXml::SampledValue(pk.a12, "const"),
-            scnXml::SampledValue(pk.a21, "const")));
+            scnXml::SampledValue(pk.k12, "const"),
+            scnXml::SampledValue(pk.k21, "const")));
         xPK.setM_exponent(pk.me);
         xPK.setK_a(scnXml::SampledValue(pk.ka, "const"));
         scnXml::PD xPD;
@@ -189,11 +189,11 @@ namespace xml_helpers{
         scnXml::PK xPK(pk.negl_conc, pk.Vd);
         xPK.setK(scnXml::SampledValue(pk.k, "const"));
         xPK.setCompartment2(scnXml::Compartment2(
-            scnXml::SampledValue(pk.a12, "const"),
-            scnXml::SampledValue(pk.a21, "const")));
+            scnXml::SampledValue(pk.k12, "const"),
+            scnXml::SampledValue(pk.k21, "const")));
         xPK.setCompartment3(scnXml::Compartment3(
-            scnXml::SampledValue(pk.a13, "const"),
-            scnXml::SampledValue(pk.a31, "const")));
+            scnXml::SampledValue(pk.k13, "const"),
+            scnXml::SampledValue(pk.k31, "const")));
         xPK.setM_exponent(pk.me);
         xPK.setK_a(scnXml::SampledValue(pk.ka, "const"));
         scnXml::PD xPD;
@@ -371,13 +371,13 @@ public:
                 PK1C(150 /*Vd*/, 0.005 /*negl_conc*/, 0.03 /*k*/, 0.0 /*m_exp*/),
                 PD(3.45 /* vmax */, 0.020831339 /* IC50 */, 6.0 /* slope */ )));
         drugs.getDrug().push_back(drug("PPQ2",   // Piperaquine, Hodel2013 model
-                PK2C(173 /*Vd*/, 0.005 /*negl_conc*/, 0.6242774566473989 /*k*/, 0.25 /*m_exp*/,
-                    11.16 /*k_a*/, 8.46242774566474 /*a12*/, 3.3058064516129035 /*a21*/),
+                PK2C(173 /*Vd*/, 0.005 /*negl_conc*/, 0.2452253 /*k*/, 0.25 /*m_exp*/,
+                    11.16 /*k_a*/, 0.2014864 /*k12*/, 0.07870968 /*k21*/),
                 PD(3.45 /* vmax */, 0.020831339 /* IC50 */, 6.0 /* slope */ )));
         drugs.getDrug().push_back(drug("PPQ3",  // Piperaquine, Tarning 2012 AAC
                 PK3C(57.5625 /*Vd*/, 0.005 /*negl_conc*/, 16.314788273615637 /*k*/, 1.0 /*m_exp*/,
-                    3.4825 /*k_a*/, 89.01628664495114 /*a12*/, 55.394594594594594 /*a21*/,
-                     43.36156351791531 /*a13*/, 3.8155414012738853 /*a31*/),
+                    3.4825 /*k_a*/, 1.854166666666667 /*k12*/, 1.1545945945945946 /*k21*/,
+                     0.9027777777777778 /*k13*/, 0.07948639559767655 /*k31*/),
                 PD(3.45 /* vmax */, 0.020831339 /* IC50 */, 6.0 /* slope */ )));
         
         PkPd::LSTMDrugType::init (drugs);


### PR DESCRIPTION
As discussed, these changes:

- store drug dose as a quantity in mg, not a concentration
- divide A/B/C constants by volume of distribution
- replace a12 etc params (where `a12 = k12 * bm`) with plain k12 etc
- include a few other small improvements to the code