### PR TITLE
Tweak integration parameters

### DIFF
--- a/model/PkPd/Drug/LSTMDrug.cpp
+++ b/model/PkPd/Drug/LSTMDrug.cpp
@@ -38,8 +38,8 @@ namespace PkPd {
 LSTMDrug::LSTMDrug(double Vd): vol_dist(Vd) {}
 LSTMDrug::~LSTMDrug() {}
 
-bool comp(pair<double,double> lhs, double rhs){
-    return lhs.first < rhs;
+bool comp(pair<double,double> lhs, pair<double,double> rhs){
+    return lhs.first < rhs.first;
 }
 
 // Create our list of doses. Optimise for the case where we only have 1 or less
@@ -48,8 +48,9 @@ bool comp(pair<double,double> lhs, double rhs){
 
 void LSTMDrug::medicate(double time, double qty){
     // Insert in the right position to maintain sorting:
-    auto pos = lower_bound(doses.begin(), doses.end(), time, comp);
-    doses.insert(pos, make_pair (time, qty));
+    auto elt = make_pair (time, qty);
+    auto pos = lower_bound(doses.begin(), doses.end(), elt, comp);
+    doses.insert(pos, move(elt));
     assert(is_sorted(doses.begin(), doses.end(), comp));
 }
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-schema-40.0
+schema-40.1


### PR DESCRIPTION
Fix #233 

As mentioned in the commit, the failing check was incorrect and not needed anyway.

This also increases absolute precision since this can have a significant effect on drug factor (e.g. `exp(-1e-3) ≅0.999`, `exp(-2e-3) ≅0.998`: 0.1% vs 0.2% survival) and appears to have very little run-time cost. I assume however that a relative difference of 1% in the drug factor makes little difference since parasite growth factors can be much larger. (Note: integration requires only that the weaker of the two bounds is met.)

This change has negligible effect on performance; using numerical integration like this is slow.