### PR TITLE
sim: Add SimDate type for improved type safety

### DIFF
--- a/model/Clinical/ClinicalModel.cpp
+++ b/model/Clinical/ClinicalModel.cpp
@@ -196,8 +196,8 @@ vector<int> infantIntervalsAtRisk;
 double nonMalariaMortality;
 
 void InfantMortality::init( const OM::Parameters& parameters ){
-    infantDeaths.resize(SimTime::stepsPerYear());
-    infantIntervalsAtRisk.resize(SimTime::stepsPerYear());
+    infantDeaths.resize(sim::stepsPerYear());
+    infantIntervalsAtRisk.resize(sim::stepsPerYear());
     nonMalariaMortality=parameters[Parameters::NON_MALARIA_INFANT_MORTALITY];
 }
 
@@ -223,7 +223,7 @@ void InfantMortality::reportRisk(size_t index, bool isDoomed) {
 
 double InfantMortality::allCause(){
     double infantPropSurviving=1.0;       // use to calculate proportion surviving
-    for( size_t i = 0; i < SimTime::stepsPerYear(); i += 1 ){
+    for( size_t i = 0; i < sim::stepsPerYear(); i += 1 ){
         // multiply by proportion of infants surviving at each interval
         infantPropSurviving *= double(infantIntervalsAtRisk[i] - infantDeaths[i])
             / double(infantIntervalsAtRisk[i]);

--- a/model/Host/Human.cpp
+++ b/model/Host/Human.cpp
@@ -94,7 +94,7 @@ bool Human::update(const Transmission::TransmissionModel& transmission, bool doU
         return true;
     
     if (doUpdate){
-        util::streamValidate( age0.raw() );
+        util::streamValidate( age0.inDays() );
         // Age at  the end of the update period. In most cases
         // the difference between this and age at the start is not especially
         // important in the model design, but since we parameterised with

--- a/model/Host/ImportedInfections.cpp
+++ b/model/Host/ImportedInfections.cpp
@@ -40,13 +40,10 @@ void ImportedInfections::init( const scnXml::ImportedInfections& iiElt ){
     rate.reserve( tElt.getRate().size() );
     try{
         for( auto it = tElt.getRate().begin(); it != tElt.getRate().end(); ++it ){
-            SimTime time = UnitParse::readDate( it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/ );
-            if( period != SimTime::zero() && time >= period ){
-                throw util::format_error( "cannot be greater than period when period is not zero" );
-            }
+            SimDate date = UnitParse::readDate( it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/ );
             // convert to per-time-step, per-person
-            double rateVal = it->getValue() * SimTime::yearsPerStep() * (1.0 / 1000.0);
-            rate.push_back( Rate( time, rateVal ) );
+            double rateVal = it->getValue() * sim::yearsPerStep() * (1.0 / 1000.0);
+            rate.push_back( Rate( date - sim::startDate(), rateVal ) );
         }
         sort( rate.begin(), rate.end() );
         if( rate.size() > 0 ){
@@ -71,7 +68,7 @@ void ImportedInfections::init( const scnXml::ImportedInfections& iiElt ){
 
 void ImportedInfections::import( Population& population ){
     if( rate.size() == 0 ) return;      // no imported infections
-    SimTime now = sim::intervNow();
+    SimTime now = sim::intervTime();
     assert( now >= SimTime::zero() );
     if( period > SimTime::zero() ){
         now = mod_nn(now, period);

--- a/model/Population.cpp
+++ b/model/Population.cpp
@@ -171,7 +171,7 @@ void Population::createInitialHumans()
 // -----  non-static methods: simulation loop  -----
 
 void Population::newHuman( SimTime dob ){
-    util::streamValidate( dob.raw() );
+    util::streamValidate( dob.inDays() );
     population.push_back( Host::Human (dob) );
     ++recentBirths;
 }

--- a/model/PopulationAgeStructure.cpp
+++ b/model/PopulationAgeStructure.cpp
@@ -160,7 +160,7 @@ double AgeStructure::setDemoParameters (double param1, double param2)
 {
     rho = initialRho;
 
-    rho = rho * (0.01 * SimTime::yearsPerStep());
+    rho = rho * (0.01 * sim::yearsPerStep());
     if (rho != 0.0)
 	// Issue: in this case the total population size differs from populationSize,
 	// however, some code currently uses this as the total population size.

--- a/model/Simulator.h
+++ b/model/Simulator.h
@@ -61,8 +61,8 @@ private:
     //@}
     
     // Data
-    SimTime simPeriodEnd;
-    SimTime totalSimDuration;
+    SimTime m_phaseEnd;
+    SimTime m_estimatedEnd;
     int phase;  // only need be a class member because value is checkpointed
     
     static bool startedFromCheckpoint;

--- a/model/Transmission/Anopheles/EmergenceModel.cpp
+++ b/model/Transmission/Anopheles/EmergenceModel.cpp
@@ -131,7 +131,7 @@ void EmergenceModel::initEIR(
     // Note: sum stays the same, units changes to per-time-step.
     for( SimTime i = SimTime::zero(); i < SimTime::oneYear(); i += SimTime::oneDay() ){
         // index 0 of initialisationEIR corresponds to first period of year
-        initialisationEIR[mod_nn(i.inSteps(), SimTime::stepsPerYear())] += speciesEIR[i];
+        initialisationEIR[mod_nn(i.inSteps(), sim::stepsPerYear())] += speciesEIR[i];
     }
     
     if ( util::CommandLine::option( util::CommandLine::PRINT_ANNUAL_EIR ) ) {

--- a/model/Transmission/Anopheles/FixedEmergence.cpp
+++ b/model/Transmission/Anopheles/FixedEmergence.cpp
@@ -117,7 +117,7 @@ bool FixedEmergence::initIterate (MosqTransmission& transmission) {
 
     const double LIMIT = 0.1;
     return (fabs(factor - 1.0) > LIMIT) ||
-           (rAngle > LIMIT * 2*M_PI / SimTime::stepsPerYear());
+           (rAngle > LIMIT * 2*M_PI / sim::stepsPerYear());
 }
 
 

--- a/model/Transmission/Anopheles/SimpleMPDEmergence.cpp
+++ b/model/Transmission/Anopheles/SimpleMPDEmergence.cpp
@@ -168,7 +168,7 @@ bool SimpleMPDEmergence::initIterate (MosqTransmission& transmission) {
     
     const double LIMIT = 0.1;
     return (fabs(factor - 1.0) > LIMIT) ||
-           (rAngle > LIMIT * 2*M_PI / SimTime::stepsPerYear());
+           (rAngle > LIMIT * 2*M_PI / sim::stepsPerYear());
     //NOTE: in theory, mosqEmergeRate and annualEggsLaid aren't needed after convergence.
 }
 

--- a/model/Transmission/NonVectorModel.h
+++ b/model/Transmission/NonVectorModel.h
@@ -106,9 +106,7 @@ private:
   //@}
   
   /** EIR per time interval during the intervention period. Value at index
-   * sim::intervNow().inSteps() used each time-step: first value should
-   * be used for update in the first interval, which has
-   * sim::intervNow().inSteps() = 0.
+   * sim::intervTime().inSteps() used each time-step.
    * 
    * Units: inoculations per adult per time step */
   vector<double> interventionEIR;

--- a/model/Transmission/TransmissionModel.cpp
+++ b/model/Transmission/TransmissionModel.cpp
@@ -82,7 +82,7 @@ TransmissionModel* TransmissionModel::createTransmissionModel (const scnXml::Ent
 void TransmissionModel::ctsCbInputEIR (ostream& stream){
     int prevStep = (sim::now() - SimTime::oneTS()) / SimTime::oneTS();
     //Note: prevStep may be negative, hence util::mod not mod_nn:
-    stream<<'\t'<<initialisationEIR[util::mod(prevStep, SimTime::stepsPerYear())];
+    stream<<'\t'<<initialisationEIR[util::mod(prevStep, sim::stepsPerYear())];
 }
 void TransmissionModel::ctsCbSimulatedEIR (ostream& stream){
     stream<<'\t'<<tsAdultEIR;
@@ -120,7 +120,7 @@ TransmissionModel::TransmissionModel(const scnXml::Entomology& entoData,
     adultAge(PerHost::adultAge()),
     numTransmittingHumans(0)
 {
-    initialisationEIR.assign (SimTime::stepsPerYear(), 0.0);
+    initialisationEIR.assign (sim::stepsPerYear(), 0.0);
     
   using mon::Continuous;
   Continuous.registerCallback( "input EIR", "\tinput EIR", MakeDelegate( this, &TransmissionModel::ctsCbInputEIR ) );
@@ -171,7 +171,7 @@ double TransmissionModel::updateKappa (const Population& population) {
     
     //Calculate time-weighted average of kappa
     _sumAnnualKappa += laggedKappa[lKMod] * initialisationEIR[tmod];
-    if (tmod == SimTime::stepsPerYear() - 1) {
+    if (tmod == sim::stepsPerYear() - 1) {
         _annualAverageKappa = _sumAnnualKappa / annualEIR;	// inf or NaN when annualEIR is 0
         _sumAnnualKappa = 0.0;
     }

--- a/model/WithinHost/Diagnostic.cpp
+++ b/model/WithinHost/Diagnostic.cpp
@@ -122,6 +122,8 @@ void diagnostics::clear(){
 }
 
 void diagnostics::init( const Parameters& parameters, const scnXml::Scenario& scenario ){
+    diagnostic_set.clear(); // compatibility with unit tests
+    
     if(scenario.getDiagnostics().present()){
         foreach( const scnXml::Diagnostic& diagnostic, scenario.getDiagnostics().get().getDiagnostic() ){
             string name = diagnostic.getName();     // conversion fails without this extra line

--- a/model/WithinHost/Pathogenesis/Submodels.cpp
+++ b/model/WithinHost/Pathogenesis/Submodels.cpp
@@ -37,7 +37,7 @@ double densityExponent_32;
 
 void MuellerPathogenesis::init( const Parameters& parameters ){
     rateMultiplier_31 = parameters[Parameters::MUELLER_RATE_MULTIPLIER]
-        * SimTime::yearsPerStep();
+        * sim::yearsPerStep();
     densityExponent_32 = parameters[Parameters::MUELLER_DENSITY_EXPONENT];
 }
 
@@ -67,7 +67,7 @@ void PyrogenPathogenesis::init( const Parameters& parameters ){
     
     double delt = 1.0 / n;
     double smuY = -log(0.5) /
-        (SimTime::stepsPerYear() * parameters[Parameters::Y_STAR_HALF_LIFE]);
+        (sim::stepsPerYear() * parameters[Parameters::Y_STAR_HALF_LIFE]);
     b = -smuY * delt;
     
     Ystar2_13 = parameters[Parameters::Y_STAR_SQ];

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -96,7 +96,7 @@ void WHFalciparum::init( const OM::Parameters& parameters, const scnXml::Model& 
     alpha_m = 1.0 - exp(-parameters[Parameters::NEG_LOG_ONE_MINUS_ALPHA_M]);
     decayM = parameters[Parameters::DECAY_M];
     
-    y_lag_len = SimTime::daysToSteps(20);
+    y_lag_len = SimTime::fromDays(20).inSteps();
     
     //NOTE: should also call cleanup() on the PathogenesisModel, but it only frees memory which the OS does anyway
     Pathogenesis::PathogenesisModel::init( parameters, model.getClinical(), false );
@@ -182,7 +182,7 @@ double WHFalciparum::probTransmissionToMosquito( double tbvFactor, double *sumX 
     // Take weighted sum of total asexual blood stage density 10, 15 and 20 days
     // before. Add y_lag_len to index to ensure positive.
     const int i10 = (sim::ts0() - SimTime::fromDays(10) + SimTime::oneTS()).inSteps() + y_lag_len;
-    const int i5d = SimTime::daysToSteps(5);
+    const int i5d = SimTime::fromDays(5).inSteps();
     const int i10d = 2 * i5d;
     // Sum lagged densities across genotypes:
     double y10 = 0.0, y15 = 0.0, y20 = 0.0;
@@ -221,7 +221,7 @@ double WHFalciparum::pTransGenotype(double pTrans, double sumX, size_t genotype)
     // Take weighted sum of total asexual blood stage density 10, 15 and 20 days
     // before. Add y_lag_len to index to ensure positive.
     const int i10 = (sim::ts0() - SimTime::fromDays(10) + SimTime::oneTS()).inSteps() + y_lag_len;
-    const int i5d = SimTime::daysToSteps(5);
+    const int i5d = SimTime::fromDays(5).inSteps();
     const int i10d = 2 * i5d;
     const double x =
         PTM_beta1 * m_y_lag.at(mod_nn(i10, y_lag_len), genotype) +

--- a/model/interventions/ITN.cpp
+++ b/model/interventions/ITN.cpp
@@ -502,9 +502,9 @@ ITNComponent::ITNComponent( ComponentId id, const scnXml::ITNDescription& elt,
     const double maxProp = 0.999;       //NOTE: this could be exposed in XML, but probably doesn't need to be
     maxInsecticide = R::qnorm5(maxProp, initialInsecticide.getMu(), initialInsecticide.getSigma(), true, false);
     holeRate.setParams( elt.getHoleRate() );    // per year
-    holeRate.scaleMean( SimTime::yearsPerStep() );  // convert to per step
+    holeRate.scaleMean( sim::yearsPerStep() );  // convert to per step
     ripRate.setParams( elt.getRipRate() );
-    ripRate.scaleMean( SimTime::yearsPerStep() );
+    ripRate.scaleMean( sim::yearsPerStep() );
     ripFactor = elt.getRipFactor().getValue();
     insecticideDecay = DecayFunction::makeObject( elt.getInsecticideDecay(), "ITNDescription.insecticideDecay" );
     attritionOfNets = DecayFunction::makeObject( elt.getAttritionOfNets(), "ITNDescription.attritionOfNets" );

--- a/model/interventions/InterventionManager.hpp
+++ b/model/interventions/InterventionManager.hpp
@@ -58,8 +58,7 @@ public:
      * interventions have been used. */
     static void loadFromCheckpoint(
                 Population& population,
-                Transmission::TransmissionModel& transmission,
-                SimTime interventionTime);
+                Transmission::TransmissionModel& transmission);
     
     /** @brief Deploy interventions
      *

--- a/model/mon/Continuous.cpp
+++ b/model/mon/Continuous.cpp
@@ -204,7 +204,8 @@ namespace OM { namespace mon {
         if( ctsPeriod == SimTime::zero() )
             return;	// output disabled
         if( !duringInit ){
-            if( sim::intervNow() < SimTime::zero() || mod_nn(sim::intervNow(), ctsPeriod) != SimTime::zero() )
+            if( sim::intervTime() < SimTime::zero()
+                || mod_nn(sim::intervTime(), ctsPeriod) != SimTime::zero() )
                 return;
         } else {
             if( mod_nn(sim::now(), ctsPeriod) != SimTime::zero() )
@@ -212,10 +213,12 @@ namespace OM { namespace mon {
             ctsOStream << sim::now().inSteps() << '\t';
         }
 	
-        if( duringInit && sim::intervNow() < SimTime::zero() ){
+        if( duringInit && sim::intervTime() < SimTime::zero() ){
             ctsOStream << "nan";
         }else{
-            ctsOStream << sim::intervNow().inSteps();
+            // NOTE: we could switch this to output dates, but (1) it would be
+            // breaking change and (2) it may be harder to use.
+            ctsOStream << sim::intervTime().inSteps();
         }
 	for( size_t i = 0; i < toReport.size(); ++i )
 	    toReport[i]->call( population, ctsOStream );

--- a/model/mon/info.h
+++ b/model/mon/info.h
@@ -37,7 +37,7 @@ namespace impl {
     // Variables (checkpointed):
     extern bool isInit; // set true after "initialisation" survey at intervention time 0
     extern size_t survNumEvent, survNumStat;
-    extern SimTime nextSurveyTime;
+    extern SimDate nextSurveyDate;
 }
 
 /// For surveys and measures to say something shouldn't be reported
@@ -56,17 +56,11 @@ inline size_t eventSurveyNumber(){ return impl::survNumEvent; }
 /// reported but acts like it is to set survey variables.
 inline bool isReported(){ return !impl::isInit || impl::survNumStat != NOT_USED; }
 
-/** Time the current (next) survey ends at, or SimTime::never() if no more
+/** Date the current (next) survey ends at, or SimTime::never() if no more
  * surveys take place. */
-SimTime nextSurveyTime();
-
-/** Return the time of the final survey.
- *
- * We use this to control when the simulation ends.
- * This isn't quite the same as before when the simulation end was
- * explicitly specified and has a small affect on
- * infantAllCauseMortality (survey 21) output. */
-SimTime finalSurveyTime();
+inline SimDate nextSurveyDate() {
+    return impl::nextSurveyDate;
+}
 
 /// The number of cohort sets
 inline size_t numCohortSets(){ return impl::nCohorts; }
@@ -79,7 +73,7 @@ inline size_t numCohortSets(){ return impl::nCohorts; }
 /// A key is returned; use this in future calls to checkCondition().
 /// 
 /// This should only be called before the simulation is started but after
-/// initSurveyTimes() is called.
+/// initReporting() is called.
 size_t setupCondition( const std::string& measureName, double minValue,
                      double maxValue, bool initialState );
 

--- a/model/mon/management.h
+++ b/model/mon/management.h
@@ -35,10 +35,11 @@ namespace OM {
     class Parameters;
 namespace mon {
 
-/// Read survey times from XML.
-void initSurveyTimes( const Parameters& parameters,
-        const scnXml::Scenario& scenario,
-        const scnXml::Monitoring& monitoring );
+/// Read survey times from XML. Return the date of the final survey.
+SimDate readSurveyDates( const scnXml::Monitoring& monitoring );
+
+/// Call before start of simulation to set up outputs. Call readSurveyDates first.
+void initReporting( const scnXml::Scenario& scenario );
 
 /// Call after initialising interventions
 void initCohorts( const scnXml::Monitoring& monitoring );
@@ -58,9 +59,6 @@ void checkpoint( std::istream& stream );
 
 // Functions for internal use (within mon package)
 namespace internal{
-    /// Call before start of simulation to set up outputs. Call initSurveyTimes first.
-    void initReporting( const scnXml::Scenario& scenario );
-    
     // Write results to stream
     void write( std::ostream& stream );
     

--- a/model/mon/mon.cpp
+++ b/model/mon/mon.cpp
@@ -53,7 +53,7 @@ namespace impl {
     bool isInit = false;
     size_t surveyIndex = 0;     // index in surveyTimes of next survey
     size_t survNumEvent = NOT_USED, survNumStat = NOT_USED;
-    SimTime nextSurveyTime = SimTime::future();
+    SimDate nextSurveyDate = SimDate::future();
     
     vector<Condition> conditions;
 }
@@ -417,7 +417,7 @@ struct MeasureByOutId{
     }
 } measureByOutId;
 
-void internal::initReporting( const scnXml::Scenario& scenario ){
+void initReporting( const scnXml::Scenario& scenario ){
     defineOutMeasures();        // set up namedOutMeasures
     assert(reportedMeasures.empty());
     
@@ -690,7 +690,7 @@ void checkpoint( ostream& stream ){
     impl::surveyIndex & stream;
     impl::survNumEvent & stream;
     impl::survNumStat & stream;
-    impl::nextSurveyTime & stream;
+    impl::nextSurveyDate & stream;
     
     storeI.checkpoint(stream);
     storeF.checkpoint(stream);
@@ -700,7 +700,7 @@ void checkpoint( istream& stream ){
     impl::surveyIndex & stream;
     impl::survNumEvent & stream;
     impl::survNumStat & stream;
-    impl::nextSurveyTime & stream;
+    impl::nextSurveyDate & stream;
     
     storeI.checkpoint(stream);
     storeF.checkpoint(stream);

--- a/model/util/checkpoint.cpp
+++ b/model/util/checkpoint.cpp
@@ -283,7 +283,8 @@ namespace OM { namespace util { namespace checkpoint {
         x.size() & stream;
         for(auto pos = x.begin (); pos != x.end() ; ++pos) {
             pos->first & stream;
-            pos->second.raw() & stream;
+            SimTime t = pos->second;    // use a copy: avoid const restriction
+            t & stream;
         }
     }
     void operator& (map<interventions::ComponentId,SimTime>& x, istream& stream) {

--- a/model/util/timeConversions.h
+++ b/model/util/timeConversions.h
@@ -68,16 +68,12 @@ namespace UnitParse {
      * 
      * Supports dates (e.g. 2015-10-08) as well as times relative to the start
      * of the intervention period (as readDuration will parse). Returns a time
-     * to be compared against sim::intervNow(). Again, the result is rounded to
+     * to be compared against sim::intervDate(). Again, the result is rounded to
      * the nearest time step. */
-    SimTime readDate( const std::string& str, DefaultUnit defUnit );
-    
-    /** Return true if we have a starting date (and thus can convert to and
-     * from dates), false if not. */
-    bool haveDate();
+    SimDate readDate( const std::string& str, DefaultUnit defUnit );
     
     /// Write a time to a stream as a date. Throws if !haveDate().
-    void formatDate( ostream& stream, SimTime time );
+    void formatDate( ostream& stream, SimDate date );
 }
 
 }

--- a/schema/interventions.xsd
+++ b/schema/interventions.xsd
@@ -161,10 +161,12 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
                   <xs:annotation>
                     <xs:documentation>
                       If period is 0 (or effectively infinite), the last specified
-                      value remains indefinitely in effect, otherwise the times of
-                      all values specified must be less than the period, and values
-                      are repeated modulo period (the step at time 'period+2t'
-                      has same value as the step at '2t', etc.).
+                      value remains indefinitely in effect.
+                      
+                      If period is less than the length of the simulation's intervention phase,
+                      then all "rate" deployments are repeated with this periodicity.
+                      In this case, the first "rate" deployment must coincide with the start of
+                      the intervention phase (monitoring/startDate).
                       
                       Can be specified in steps (e.g. 1t) or days (e.g. 365d).
                     </xs:documentation>

--- a/unittest/CMDecisionTreeSuite.h
+++ b/unittest/CMDecisionTreeSuite.h
@@ -47,7 +47,6 @@ public:
         // generator which is initialized after constructor runs.
         util::random::seed (83);	// seed is unimportant, but must be fixed
         UnittestUtil::initTime(5);
-        UnittestUtil::initSurveys();
         UnittestUtil::setDiagnostics();
 
         UnittestUtil::EmpiricalWHM_setup();

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -258,19 +258,23 @@ public:
         dummyXML::modelParams.setInterval( daysPerStep );
         dummyXML::model.setParameters(dummyXML::modelParams);
         dummyXML::scenario.setModel(dummyXML::model);
+        dummyXML::surveys.setDetectionLimit( numeric_limits<double>::quiet_NaN() );
+        dummyXML::surveys.getSurveyTime().push_back( scnXml::SurveyTime ( "1t" ) );
+        dummyXML::monitoring.setSurveys( dummyXML::surveys );
+        dummyXML::scenario.setMonitoring( dummyXML::monitoring );
         sim::init( dummyXML::scenario );
         
         // we could just use zero, but we may spot more errors by using some weird number
-        sim::time0 = SimTime::fromYearsN(83.2591);
-        sim::time1 = sim::time0;
+        sim::s_t0 = SimTime::fromYearsN(83.2591);
+        sim::s_t1 = sim::s_t0;
 #ifndef NDEBUG
         sim::in_update = true;  // may not always be correct but we're more interested in getting around this check than using it in unit tests
 #endif
     }
     static void incrTime(SimTime incr){
-        //NOTE: for unit tests, we do not differentiate between time0 and time1
-        sim::time0 += incr;
-        sim::time1 = sim::time0;
+        //NOTE: for unit tests, we do not differentiate between s_t0 and s_t1
+        sim::s_t0 += incr;
+        sim::s_t1 = sim::s_t0;
     }
     
     static const scnXml::Parameters& prepareParameters(){
@@ -284,14 +288,6 @@ public:
         return dummyXML::modelParams;
     }
     
-    // Initialise surveys, to the minimum required not to crash
-    static void initSurveys(){
-        diagnostics::clear();
-        Parameters parameters( prepareParameters() );
-        dummyXML::surveys.setDetectionLimit( numeric_limits<double>::quiet_NaN() );
-        dummyXML::monitoring.setSurveys( dummyXML::surveys );
-        mon::initSurveyTimes( parameters, dummyXML::scenario, dummyXML::monitoring );
-    }
     // Parameterise standard diagnostics
     static void setDiagnostics(){
         // note that this is only ever called after initSurveys(), thus we


### PR DESCRIPTION
This also sets the startDate internally even if
monitoring/startDate is not specified (in this case to 0).
This allows formatting of dates regardless of this parameter.