### PR TITLE
update travis and appveyor to overwrite release artifacts on deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - util/build-info.sh | tee openMalaria-$OSNAME/travis-build.json
 
 deploy:
+  overwrite: true
   skip_cleanup: true
   provider: releases
   api_key: $GH_TOKEN

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ artifacts:
 
 # Deployment
 deploy:
+  force_update: true
   provider: GitHub
   description: "OpenMalaria build for Windows"
   auth_token:


### PR DESCRIPTION
Allow travis and appveyor to overwrite release artifacts on deployments.