### PR TITLE
cache packages installed via Cygwin with appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+cache:
+    - 'C:\cygwin64'
+    
 os: Visual Studio 2015
 
 configuration: Release


### PR DESCRIPTION
Save time and bandwidth when downloading dependencies for the Cygwin Windows build with appveyor.