### PR TITLE
Add docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic as builder
+WORKDIR /root/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g cmake libgsl-dev libxerces-c-dev xsdcxx \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch refactor https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  && ./build.sh -c -b=master -r -a=openmalariaRelease
+
+FROM ubuntu:bionic as openmalaria
+WORKDIR /root/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl23 libxerces-c3.2 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /root/openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/root/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/build.sh
+++ b/build.sh
@@ -100,18 +100,18 @@ function build {
     mkdir -p build
 
     if [ $CLEAN -eq 1 ]; then
-        pushd build && rm -rf * && popd
+        cd build && rm -rf * && cd ..
     fi
 
     # Compile OpenMalaria
-    pushd build
+    cd build
     cmake -DCMAKE_BUILD_TYPE=Release -DOM_BOXTEST_ENABLE=$TESTS -DOM_CXXTEST_ENABLE=$TESTS .. && make -j$JOBS
-    popd
+    cd ..
 }
 
 function runtests {
     if [ $TESTS = "ON" ]; then
-        pushd build && ctest --output-on-failure -j$JOBS && popd
+        cd build && ctest --output-on-failure -j$JOBS && cd ..
     fi
 }
 
@@ -135,7 +135,7 @@ function package {
 
     # if Cygwin, copy dll files
     if [ $CYGWIN -eq 1 ]; then
-        pushd $ARTIFACT/
+        cd $ARTIFACT/
         rm -f dlls
         for i in $(ldd openMalaria); do
             echo $i | grep "/usr" >> dlls || true
@@ -145,7 +145,7 @@ function package {
             echo "cp $i ."
         done
         rm -f dlls
-        popd
+        cd ..
     fi
 
     # Compress

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # Assuming you have installed:
 # gsl, git, cmake, xsd, xerces-c, boost
@@ -28,7 +28,7 @@ CYGWIN=0
 # For Windows - Cygwin (MobaXTerm)
 export PATH=/usr/bin:$PATH
 
-function printHelp {
+printHelp () {
     echo "HELP: make sure dependencies are installed (adapt to your distribution)"
     echo "======================================================================="
     echo "Ubuntu/Debian: sudo apt-get install build-essential git cmake libboost-dev libgsl-dev libxerces-c-dev xsdcxx"
@@ -48,7 +48,7 @@ function printHelp {
     echo "  -h, --help"             "print this message"
 }
 
-function parseArguments {
+parseArguments () {
     for i in "$@"; do
         case $i in
             -b=*|--branch=*)    BRANCH="${i#*=}"; SWITCHBRANCH=1 && shift ;;
@@ -63,7 +63,7 @@ function parseArguments {
     done
 }
 
-function isWindows {
+isWindows () {
     unameOut="$(uname -s)"
     case "${unameOut}" in
         CYGWIN*)    CYGWIN=1;;
@@ -72,7 +72,7 @@ function isWindows {
     esac
 }
 
-function clone {
+clone () {
     # Already in openmalaria?
     if [ -d .git ]; then
         if [ $(basename -s .git `git remote get-url origin`) = "openmalaria" ]; then
@@ -96,7 +96,7 @@ function clone {
     git branch
 }
 
-function build {
+build () {
     mkdir -p build
 
     if [ $CLEAN -eq 1 ]; then
@@ -109,13 +109,13 @@ function build {
     cd ..
 }
 
-function runtests {
+runtests () {
     if [ $TESTS = "ON" ]; then
         cd build && ctest --output-on-failure -j$JOBS && cd ..
     fi
 }
 
-function package {
+package () {
     # Get version number
     VERSION=$(cat version.txt | cut -d'-' -f2)
     MAJOR=$(cat version.txt | cut -d'-' -f2 | cut -d'.' -f1)


### PR DESCRIPTION
Add a DockerFile for building an OpenMalaria image using a multi-stage build to minimize the size.

Update build.sh to make it POSIX compliant so that it can be run using both sh (used by docker/ubunutu) and bash.