### PR TITLE
Remove boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,15 +65,9 @@ jobs:
 
     # Max OSX release
     - os: osx
-<<<<<<< HEAD
       osx_image: xcode11.5
       compiler: gcc
       env: OSNAME=macOS-10.15.4
-=======
-      osx_image: xcode9.4
-      compiler: gcc
-      env: OSNAME=macOS-10.13
->>>>>>> b6c5c9a1 (remove boost from install deps)
 
     # Max OSX release
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_cache:
   - test "$TRAVIS_OS_NAME" == "osx" && brew cleanup
 
 install:
-  - test "$TRAVIS_OS_NAME" == "linux" && sudo apt-get install build-essential git cmake libboost-dev libgsl-dev libxerces-c-dev xsdcxx || true
-  - test "$TRAVIS_OS_NAME" == "osx" && HOMEBREW_NO_AUTO_UPDATE=1 brew install git boost coreutils cmake gcc gsl xerces-c xsd || true
+  - test "$TRAVIS_OS_NAME" == "linux" && sudo apt-get install build-essential git cmake libgsl-dev libxerces-c-dev xsdcxx || true
+  - test "$TRAVIS_OS_NAME" == "osx" && HOMEBREW_NO_AUTO_UPDATE=1 brew install git coreutils cmake gcc gsl xerces-c xsd || true
 
 # Build openMalaria and create the release folder openMalaria-$TRAVIS_OS_NAME
 script:
@@ -65,9 +65,15 @@ jobs:
 
     # Max OSX release
     - os: osx
+<<<<<<< HEAD
       osx_image: xcode11.5
       compiler: gcc
       env: OSNAME=macOS-10.15.4
+=======
+      osx_image: xcode9.4
+      compiler: gcc
+      env: OSNAME=macOS-10.13
+>>>>>>> b6c5c9a1 (remove boost from install deps)
 
     # Max OSX release
     - os: osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 if (NOT MSVC)
   # Enable builds on Raspberry pi (although without optimizations)
   if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
   else (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -msse2 -mfpmath=sse")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -msse2 -mfpmath=sse")
   endif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
   # We almost always want optimisations enabled:
   set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
@@ -102,22 +102,6 @@ if (NOT PYTHON_EXECUTABLE)
     message (SEND_ERROR "Unable to find a Python interpreter (required).")
 endif (NOT PYTHON_EXECUTABLE)
 
-
-# Find Boost:
-
-# suggested on windows: install boost such that paths are:
-# C:\Program Files\boost\boost_VER\boost\config.hpp
-# VER looks like 1_38_0 NOT 1.38.0
-# Add additional versions here when needed:
-# set (Boost_ADDITIONAL_VERSIONS "1.54.0" "1.55.0" "1.56.0" "1.57.0" "1.58.0")
-#set (Boost_DEBUG)
-# We require 1.54: first version including nonfinite_num_facets.hpp
-find_package( Boost 1.54.0 )
-if(NOT Boost_FOUND)
-    message (FATAL_ERROR "Unable to find boost headers! Please install libboost-dev or boost from boost.org (preferably at least version 1.41)")
-endif(NOT Boost_FOUND)
-
-
 # -----  Compile-time optional features  -----
 # (must come before add_subdirectory (model))
 
@@ -132,7 +116,7 @@ endif (OM_STREAM_VALIDATOR)
 add_subdirectory (contrib)
 add_subdirectory (schema)
 add_subdirectory (model)
-add_subdirectory (util/SchemaTranslator)
+# add_subdirectory (util/SchemaTranslator)
 add_dependencies (model schema)
 
 # -----  generate openMalaria  -----
@@ -150,7 +134,6 @@ include_directories (SYSTEM
   ${XERCESC_INCLUDE_DIRS}
   ${GSL_INCLUDE_DIRS}
   ${Z_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
   ${CMAKE_SOURCE_DIR}/contrib
   ${CMAKE_SOURCE_DIR}/contrib/FastDelegate_src
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 endif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 
 # Statically link libgcc; isn't going to work when other C++ libraries are dynamically linked
-if( ${CMAKE_COMPILER_IS_GNUCXX} )
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # This doesn't show up in the cache, but it is passed to gcc:
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations")
 
@@ -48,7 +48,7 @@ if( ${CMAKE_COMPILER_IS_GNUCXX} )
     add_definitions(-static-libgcc -static-libstdc++)
     set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE} -static-libgcc -static-libstdc++")
   endif (OM_STATICALLY_LINK)
-endif( ${CMAKE_COMPILER_IS_GNUCXX} )
+endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
 option (BUILD_SHARED_LIBS "Link xsdcxx, model, etc. libraries dynamically instead of statically (almost certainly not wanted)." OFF)
 mark_as_advanced (BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,12 @@ endif (NOT MSVC)
 
 set (OM_STD_LIBS )
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fp-model source")
-endif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+endif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 
 # Statically link libgcc; isn't going to work when other C++ libraries are dynamically linked
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   # This doesn't show up in the cache, but it is passed to gcc:
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations")
 
@@ -48,7 +48,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_definitions(-static-libgcc -static-libstdc++)
     set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE} -static-libgcc -static-libstdc++")
   endif (OM_STATICALLY_LINK)
-endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
 option (BUILD_SHARED_LIBS "Link xsdcxx, model, etc. libraries dynamically instead of statically (almost certainly not wanted)." OFF)
 mark_as_advanced (BUILD_SHARED_LIBS)
@@ -81,12 +81,12 @@ if (MSVC)
   set (OM_COMPILE_FLAGS "${OM_COMPILE_FLAGS} /D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS")
 endif (MSVC)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -Wno-deprecated-declarations")
   # These are actually only needed when using "clang" not "clang++" (same with
   # "gcc"), but adding here saves a user error:
   set (OM_STD_LIBS m stdc++)
-endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 # -----  Find dependencies  -----
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,14 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set (OM_STD_LIBS m stdc++)
 endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -Wno-deprecated-declarations")
+  # These are actually only needed when using "clang" not "clang++" (same with
+  # "gcc"), but adding here saves a user error:
+  set (OM_STD_LIBS m stdc++)
+endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
+
+
 # -----  Find dependencies  -----
 
 set (CMAKE_LIBRARY_PATH /usr/lib64)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 # -----  Compile options  -----
 
+# -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR
+# auto_ptr has been removed from c++17
+# This extension is needed because XSD still use auto_ptr in its headers
+# Note that is doe snot use auto_ptr in the generated code, only in the library headers
+
 if (NOT MSVC)
   # Enable builds on Raspberry pi (although without optimizations)
   if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
@@ -32,7 +37,7 @@ endif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 # Statically link libgcc; isn't going to work when other C++ libraries are dynamically linked
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   # This doesn't show up in the cache, but it is passed to gcc:
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR")
 
   option (OM_COVERAGE "Produce coverage into binary.")
   if (OM_COVERAGE)
@@ -82,14 +87,14 @@ if (MSVC)
 endif (MSVC)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -Wno-deprecated-declarations")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR")
   # These are actually only needed when using "clang" not "clang++" (same with
   # "gcc"), but adding here saves a user error:
   set (OM_STD_LIBS m stdc++)
 endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -Wno-deprecated-declarations")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR")
   # These are actually only needed when using "clang" not "clang++" (same with
   # "gcc"), but adding here saves a user error:
   set (OM_STD_LIBS m stdc++)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 # Statically link libgcc; isn't going to work when other C++ libraries are dynamically linked
 if( ${CMAKE_COMPILER_IS_GNUCXX} )
   # This doesn't show up in the cache, but it is passed to gcc:
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations")
 
   option (OM_COVERAGE "Produce coverage into binary.")
   if (OM_COVERAGE)
@@ -82,7 +82,7 @@ if (MSVC)
 endif (MSVC)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -Wno-deprecated-declarations")
   # These are actually only needed when using "clang" not "clang++" (same with
   # "gcc"), but adding here saves a user error:
   set (OM_STD_LIBS m stdc++)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - C:\cygwin64\bin\bash -lc "appveyor DownloadFile http://rawgit.com/transcode-open/apt-cyg/master/apt-cyg -FileName apt-cyg"
   - C:\cygwin64\bin\bash -lc "install apt-cyg /bin"
   - C:\cygwin64\bin\bash -lc "apt-cyg install wget grep"
-  - C:\cygwin64\bin\bash -lc "apt-cyg install zlib-devel make python3 cmake libboost-devel libgsl-devel xsd libxerces-c-devel"
+  - C:\cygwin64\bin\bash -lc "apt-cyg install zlib-devel make python3 cmake libgsl-devel xsd libxerces-c-devel"
 
 build_script:
   - C:\cygwin64\bin\bash -lc "cd /cygdrive/c/projects/openmalaria && ./build.sh --jobs=4 -r --artifact=openMalaria-windows"

--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,7 @@ function build {
 
     # Compile OpenMalaria
     pushd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DOM_BOXTEST_ENABLE=$TESTS -DOM_CXXTEST_ENABLE=$TESTS .. && make -j$JOBS VERBOSE=1
+    cmake -DCMAKE_BUILD_TYPE=Release -DOM_BOXTEST_ENABLE=$TESTS -DOM_CXXTEST_ENABLE=$TESTS .. && make -j$JOBS
     popd
 }
 

--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,7 @@ function build {
 
     # Compile OpenMalaria
     pushd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DOM_BOXTEST_ENABLE=$TESTS -DOM_CXXTEST_ENABLE=$TESTS .. && make -j$JOBS --trace
+    cmake -DCMAKE_BUILD_TYPE=Release -DOM_BOXTEST_ENABLE=$TESTS -DOM_CXXTEST_ENABLE=$TESTS .. && make -j$JOBS VERBOSE=1
     popd
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #/bin/bash
 
 # Assuming you have installed:
-# gsl, git, cmake, xsd, xerces-c, boost
+# gsl, git, cmake, xsd, xerces-c
 
 # stop on error
 set -e
@@ -31,11 +31,11 @@ export PATH=/usr/bin:$PATH
 function printHelp {
     echo "HELP: make sure dependencies are installed (adapt to your distribution)"
     echo "======================================================================="
-    echo "Ubuntu/Debian: sudo apt-get install build-essential git cmake libboost-dev libgsl-dev libxerces-c-dev xsdcxx"
+    echo "Ubuntu/Debian: sudo apt-get install build-essential git cmake libgsl-dev libxerces-c-dev xsdcxx"
     echo "--------------"
-    echo "Mac OS: brew install git boost coreutils cmake gcc gsl xerces-c xsd"
+    echo "Mac OS: brew install git coreutils cmake gcc gsl xerces-c xsd"
     echo "--------------"
-    echo "Windows - Cygwin (MobaXTerm): apt-get install p7zip gcc-g++ git cmake make zlib-devel libboost-devel libgsl-devel xsd libxerces-c-devel"
+    echo "Windows - Cygwin (MobaXTerm): apt-get install p7zip gcc-g++ git cmake make zlib-devel libgsl-devel xsd libxerces-c-devel"
 
     echo ""
     echo "Options:"

--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,7 @@ function build {
 
     # Compile OpenMalaria
     pushd build
-    cmake -DCMAKE_BUILD_TYPE=Release -DOM_BOXTEST_ENABLE=$TESTS -DOM_CXXTEST_ENABLE=$TESTS .. && make -j$JOBS
+    cmake -DCMAKE_BUILD_TYPE=Release -DOM_BOXTEST_ENABLE=$TESTS -DOM_CXXTEST_ENABLE=$TESTS .. && make -j$JOBS --trace
     popd
 }
 

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -9,7 +9,6 @@ set (Contrib_CPP
 
 include_directories (SYSTEM
   ${Z_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
 )
 include_directories (
   ${CMAKE_SOURCE_DIR}/contrib/gzstream

--- a/contrib/R_nmath/qnorm.cpp
+++ b/contrib/R_nmath/qnorm.cpp
@@ -47,13 +47,11 @@
  */
 
 
-#include <math.h>
+#include <cmath>
 
 #include <limits>
-#include <boost/math/special_functions/expm1.hpp>
 
-#include <boost/math/special_functions/fpclassify.hpp>
-#define ISNAN(x) (boost::math::isnan)(x)
+#define ISNAN(x) (std::isnan)(x)
 
 #define ML_NAN          std::numeric_limits<double>::quiet_NaN()
 #define ML_POSINF       std::numeric_limits<double>::infinity()
@@ -77,14 +75,14 @@ namespace R {
     template<typename T>
     inline T R_DT_qIv(T p, bool log_p, bool lower_tail) {
         if (log_p)
-            return lower_tail ? exp(p) : - boost::math::expm1(p);
+            return lower_tail ? exp(p) : - std::expm1(p);
         return R_D_Lval(p, lower_tail);
     }
     /*#define R_DT_CIv(p)   R_D_Cval(R_D_qIv(p))             *  1 - p in qF */
     template<typename T>
     inline T R_DT_CIv(T p, bool log_p, bool lower_tail) {
         if (log_p)
-            return lower_tail ? -boost::math::expm1(p) : exp(p);
+            return lower_tail ? -std::expm1(p) : exp(p);
         return R_D_Cval(p, lower_tail);
     }
 

--- a/contrib/chacha.h
+++ b/contrib/chacha.h
@@ -32,6 +32,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <cstring>
 
 template<size_t R>
 class ChaCha {

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -110,13 +110,12 @@ include_directories (SYSTEM
   ${XERCESC_INCLUDE_DIRS}
   ${GSL_INCLUDE_DIRS}
   ${Z_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
-  ${SPIRIT_INCLUDE_DIRS}
+  # ${SPIRIT_INCLUDE_DIRS}
   
   ${CMAKE_BINARY_DIR}/model
   ${CMAKE_SOURCE_DIR}/contrib
   ${CMAKE_SOURCE_DIR}/contrib/FastDelegate_src
-  ${CMAKE_SOURCE_DIR}/contrib/floating_point_utilities_v3
+  # ${CMAKE_SOURCE_DIR}/contrib/floating_point_utilities_v3
 )
 include_directories (
   ${CMAKE_SOURCE_DIR}/model ${CMAKE_BINARY_DIR}

--- a/model/Clinical/ESCaseManagement.cpp
+++ b/model/Clinical/ESCaseManagement.cpp
@@ -26,14 +26,9 @@
 
 #include <set>
 #include <sstream>
-#include <boost/format.hpp>
-#include <boost/assign/std/vector.hpp> // for 'operator+=()'
 
 namespace OM { namespace Clinical {
     using namespace OM::util;
-    using namespace boost::assign;
-    using boost::format;
-
 
 // -----  ESCaseManagement  -----
 

--- a/model/Global.h
+++ b/model/Global.h
@@ -31,13 +31,9 @@
 #endif
 
 // unit32_t and similar, mostly for compatibility with MSVC:
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
-#include <boost/math/special_functions/fpclassify.hpp>
-// this provides: isfinite, isinf, isnan, isnormal
-// use these functions like this: (boost::math::isnan)(x)
-// extra brackets are necessary since isnan etc. may be defined as macros!
-// explicit namespace usage avoids confusion with std versions available sometimes
+#include <cmath>
 
 // Checkpointing and time-step operations are used _everywhere_:
 #include "sim.h"    // includes util/checkpoint.h and util/mod.h
@@ -47,16 +43,7 @@
 #define foreach BOOST_FOREACH
 
 namespace OM {
-
-using boost::uint8_t;
-using boost::uint16_t;
-using boost::uint32_t;
-using boost::uint64_t;
-using boost::int8_t;
-using boost::int16_t;
-using boost::int32_t;
-using boost::int64_t;
-
+	
 using namespace util::checkpoint;
 using util::mod;
 using util::mod_nn;

--- a/model/Global.h
+++ b/model/Global.h
@@ -38,9 +38,7 @@
 // Checkpointing and time-step operations are used _everywhere_:
 #include "sim.h"    // includes util/checkpoint.h and util/mod.h
 
-// foreach "keyword"
-#include <boost/foreach.hpp>
-#define foreach BOOST_FOREACH
+#define PI 3.14159265358979323846
 
 namespace OM {
 	

--- a/model/Global.h
+++ b/model/Global.h
@@ -32,7 +32,7 @@
 
 // unit32_t and similar, mostly for compatibility with MSVC:
 #include <cstdint>
-
+#include <algorithm>
 #include <cmath>
 
 // Checkpointing and time-step operations are used _everywhere_:

--- a/model/Host/InfectionIncidenceModel.cpp
+++ b/model/Host/InfectionIncidenceModel.cpp
@@ -105,7 +105,7 @@ void InfectionIncidenceModel::init ( const Parameters& parameters ) {
         inf_rate_shape_param = sqrt(r_square_LogNormal - 1.86 * pow(baseline_avail_shape_param, 2));
         inf_rate_shape_param=std::max(inf_rate_shape_param, 0.0);
         inf_rate_offset = 0.5 * pow(inf_rate_shape_param, 2);
-        if( (boost::math::isnan)(inf_rate_shape_param) ){
+        if( (std::isnan)(inf_rate_shape_param) ){
             throw util::xml_scenario_error( "bad parameter 16 (BASELINE_AVAILABILITY_SHAPE)" );
         }
     }else{
@@ -214,7 +214,7 @@ double InfectionIncidenceModel::susceptibility () {
 int InfectionIncidenceModel::numNewInfections (Human& human, double effectiveEIR) {
   double expectedNumInfections = getModelExpectedInfections (human.rng(), effectiveEIR, human.perHostTransmission);
   // error check (should be OK if kappa is checked, for nonVector model):
-  if( !(boost::math::isfinite)(effectiveEIR) ){
+  if( !(std::isfinite)(effectiveEIR) ){
     ostringstream out;
     out << "effectiveEIR is not finite: " << effectiveEIR << endl;
     throw TRACED_EXCEPTION (out.str(), util::Error::EffectiveEIR);
@@ -241,7 +241,7 @@ int InfectionIncidenceModel::numNewInfections (Human& human, double effectiveEIR
     ctsNewInfections += n;
     return n;
   }
-  if ( (boost::math::isnan)(expectedNumInfections) ){	// check for not-a-number
+  if ( (std::isnan)(expectedNumInfections) ){	// check for not-a-number
       // bad Params::BASELINE_AVAILABILITY_SHAPE ?
       throw TRACED_EXCEPTION( "numNewInfections: NaN", util::Error::NumNewInfections );
   }

--- a/model/PkPd/Drug/LSTMDrugConversion.cpp
+++ b/model/PkPd/Drug/LSTMDrugConversion.cpp
@@ -224,7 +224,7 @@ double LSTMDrugConversion::calculateDrugFactor(LocalRng& rng, WithinHost::Common
     double totalFactor = 1.0;   // survival factor for whole day
     
     typedef pair<double,double> TimeConc;
-    foreach( const TimeConc& time_conc, doses ){
+    for( const TimeConc& time_conc : doses ){
         // we iterate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             if( time < time_conc.first ){
@@ -261,7 +261,7 @@ void LSTMDrugConversion::updateConcentration( double body_mass ){
     double time = 0.0, duration;
     size_t doses_taken = 0;
     typedef pair<double,double> TimeConc;
-    foreach( TimeConc& time_conc, doses ){
+    for( TimeConc& time_conc : doses ){
         // we iteratate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             if( (duration = time_conc.first - time) > 0.0 ){

--- a/model/PkPd/Drug/LSTMDrugOneComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugOneComp.cpp
@@ -64,7 +64,7 @@ double LSTMDrugOneComp::calculateDrugFactor(LocalRng& rng, WithinHost::CommonInf
     
     double time = 0.0;
     typedef pair<double,double> TimeConc;
-    foreach( TimeConc time_conc, doses ){
+    for( TimeConc time_conc : doses ){
         // we iteratate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             if( time < time_conc.first ){
@@ -94,7 +94,7 @@ void LSTMDrugOneComp::updateConcentration( double body_mass ){
     concentration *= exp(neg_elim_rate);
     size_t doses_taken = 0;
     typedef pair<double,double> TimeConc;
-    foreach( TimeConc& time_conc, doses ){
+    for( TimeConc& time_conc : doses ){
         // we iteratate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             // calculate decayed dose and add:

--- a/model/PkPd/Drug/LSTMDrugThreeComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.cpp
@@ -23,7 +23,6 @@
 #include "util/errors.h"
 #include "util/StreamValidator.h"
 
-#include <boost/math/constants/constants.hpp>
 #include <gsl/gsl_integration.h>
 #include <limits>
 
@@ -78,7 +77,7 @@ void LSTMDrugThreeComp::updateCached(double body_mass) const{
     const double r2 = 2.0 * sqrt(rt);
     
     const double phi = acos(-q / (rt * r2)) * third;
-    const double pi23 = (2.0 / 3.0) * boost::math::constants::pi<double>();
+    const double pi23 = (2.0 / 3.0) * PI;
     
     // negative alpha, beta, gamma:
     na = r2 * cos(phi) - at;
@@ -171,7 +170,7 @@ double LSTMDrugThreeComp::calculateDrugFactor(LocalRng& rng, WithinHost::CommonI
     double totalFactor = 1.0;   // survival factor for whole day
     
     typedef pair<double,double> TimeConc;
-    foreach( const TimeConc& time_conc, doses ){
+    for( const TimeConc& time_conc : doses ){
         // we iteratate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             if( time < time_conc.first ){
@@ -213,7 +212,7 @@ void LSTMDrugThreeComp::updateConcentration (double body_mass) {
     
     size_t doses_taken = 0;
     typedef pair<double,double> TimeConc;
-    foreach( TimeConc& time_conc, doses ){
+    for( TimeConc& time_conc : doses ){
         // we iteratate through doses in time order (since doses are sorted)
         if( time_conc.first < 1.0 /*i.e. today*/ ){
             // add dose:

--- a/model/PkPd/LSTMModel.cpp
+++ b/model/PkPd/LSTMModel.cpp
@@ -63,7 +63,7 @@ void LSTMModel::checkpoint (istream& stream) {
 
 void LSTMModel::checkpoint (ostream& stream) {
     m_drugs.size() & stream;
-    foreach( auto& drug, m_drugs ){
+    for( auto& drug : m_drugs ){
         drug->getIndex() & stream;
         drug & stream;
     }
@@ -77,7 +77,7 @@ void LSTMModel::prescribe(size_t schedule, size_t dosage, double age, double bod
     DosageTable& table = dosages[dosage];
     double key = table.useMass ? body_mass : age;
     double doseMult = table.getMultiplier( key );
-    foreach( MedicateData& medicateData, schedules[schedule].medications ){
+    for( MedicateData& medicateData : schedules[schedule].medications ){
         MedicateData data = medicateData.multiplied(doseMult);
         data.time += delay_d;
         medicateQueue.push_back( std::move(data) );
@@ -103,7 +103,7 @@ void LSTMModel::medicate(LocalRng& rng){
 
 void LSTMModel::medicateDrug(LocalRng& rng, size_t typeIndex, double qty, double time) {
     //TODO: might be a little faster if m_drugs was pre-allocated with a slot for each drug type, using a null pointer
-    foreach( auto& drug, m_drugs ){
+    for( auto& drug : m_drugs ){
         if (drug->getIndex() == typeIndex){
             drug->medicate (time, qty);
             return;
@@ -117,7 +117,7 @@ void LSTMModel::medicateDrug(LocalRng& rng, size_t typeIndex, double qty, double
 double LSTMModel::getDrugConc (size_t drug_index) const{
     double c = 0.0;
     double d = 0.0;
-    foreach( auto& drug, m_drugs ){
+    for( auto& drug : m_drugs ){
         d = drug->getConcentration(drug_index);
         if(d < 0.0){
             // FIXME: @tph-thuering, 2015-08-11:
@@ -134,8 +134,7 @@ double LSTMModel::getDrugConc (size_t drug_index) const{
 double LSTMModel::getDrugFactor (LocalRng& rng, WithinHost::CommonInfection *inf, double body_mass) const{
     double factor = 1.0; //no effect
     
-    for( auto drug = m_drugs.begin(), end = m_drugs.end();
-            drug != end; ++drug ){
+    for( auto drug = m_drugs.begin(), end = m_drugs.end(); drug != end; ++drug ){
         double drugFactor = (*drug)->calculateDrugFactor(rng, inf, body_mass);
         factor *= drugFactor;
     }
@@ -145,15 +144,15 @@ double LSTMModel::getDrugFactor (LocalRng& rng, WithinHost::CommonInfection *inf
 void LSTMModel::decayDrugs (double body_mass) {
     // Update concentrations for each drug.
     // TODO: previously we removed drugs with negligible concentration here. What now, just set concentration to 0?
-    foreach( auto& drug, m_drugs ){
+    for( auto& drug : m_drugs ){
         drug->updateConcentration(body_mass);
     }
 }
 
 void LSTMModel::summarize(const Host::Human& human) const{
     const vector<size_t> &drugsInUse( LSTMDrugType::getDrugsInUse() );
-    foreach( size_t index, drugsInUse ){
-        foreach( auto& drug, m_drugs ){
+    for( size_t index : drugsInUse ){
+        for( auto& drug : m_drugs ){
             double conc = drug->getConcentration(index);
             if( conc > 0.0 ){
                 mon::reportStatMHPI( mon::MHR_HOSTS_POS_DRUG_CONC, human, index, 1 );

--- a/model/PkPd/LSTMTreatments.cpp
+++ b/model/PkPd/LSTMTreatments.cpp
@@ -23,8 +23,6 @@
 #include "PkPd/Drug/LSTMDrugType.h"
 #include "PkPd/LSTMModel.h"
 
-#include <boost/foreach.hpp>
-
 namespace OM {
 namespace PkPd {
 
@@ -37,7 +35,7 @@ void MedicateData::load( const scnXml::PKPDMedication& med ){
 void Schedule::load( const scnXml::PKPDSchedule::MedicateSequence& seq ){
     medications.resize( seq.size() );
     size_t i = 0;
-    foreach( const scnXml::PKPDMedication& med, seq ){
+    for( const scnXml::PKPDMedication& med : seq ){
         medications[i].load( med );
         i += 1;
     }
@@ -50,7 +48,7 @@ void DosageTable::load( const xsd::cxx::tree::sequence<scnXml::PKPDDosageRange>&
     useMass = isBodyMass;
     multMassKg = false;
     double lastMult = 0.0, lastAge = numeric_limits<double>::quiet_NaN();
-    foreach( const scnXml::PKPDDosageRange& age, seq ){
+    for( const scnXml::PKPDDosageRange& age : seq ){
         if( lastAge != lastAge ){
             if( age.getLowerbound() != 0.0 )
                 throw util::xml_scenario_error( "dosage table must have first lower bound equal 0" );
@@ -72,7 +70,7 @@ map<string,size_t> dosagesNames;
 void LSTMTreatments::init(const scnXml::Treatments& data){
     schedules.resize( data.getSchedule().size() );
     size_t i = 0;
-    foreach( const scnXml::PKPDSchedule& schedule, data.getSchedule() ){
+    for( const scnXml::PKPDSchedule& schedule : data.getSchedule() ){
         schedules[i].load( schedule.getMedicate() );
         scheduleNames[schedule.getName()] = i;
         i += 1;
@@ -80,7 +78,7 @@ void LSTMTreatments::init(const scnXml::Treatments& data){
     
     dosages.resize( data.getDosages().size() );
     i = 0;
-    foreach( const scnXml::PKPDDosages& elt, data.getDosages() ){
+    for( const scnXml::PKPDDosages& elt : data.getDosages() ){
         if( elt.getAge().size() ) dosages[i].load( elt.getAge(), false );
         else if( elt.getBodymass().size() ) dosages[i].load( elt.getBodymass(), true );
         else{

--- a/model/Population.cpp
+++ b/model/Population.cpp
@@ -36,13 +36,10 @@
 #include <schema/scenario.h>
 
 #include <cmath>
-#include <boost/format.hpp>
-#include <boost/assign.hpp>
 
 namespace OM
 {
     using namespace OM::util;
-    using namespace boost::assign;
     using Transmission::TransmissionModel;
 
 // -----  Population: static data / methods  -----
@@ -79,9 +76,9 @@ Population::Population(size_t populationSize)
     using mon::Continuous;
     Continuous.registerCallback( "hosts", "\thosts", MakeDelegate( this, &Population::ctsHosts ) );
     // Age groups are currently hard-coded.
-    ctsDemogAgeGroups += 1.0, 5.0, 10.0, 15.0, 25.0;
+    ctsDemogAgeGroups.insert(ctsDemogAgeGroups.end(), { 1.0, 5.0, 10.0, 15.0, 25.0 });
     ostringstream ctsDemogTitle;
-    foreach( double ubound, ctsDemogAgeGroups ){
+    for( double ubound : ctsDemogAgeGroups ){
         ctsDemogTitle << "\thost % ≤ " << ubound;
     }
     Continuous.registerCallback( "host demography", ctsDemogTitle.str(),
@@ -124,8 +121,7 @@ void Population::checkpoint (istream& stream)
         population.back() & stream;
     }
     if (population.size() != populationSize)
-        throw util::checkpoint_error(
-            (boost::format("Population: out of data (read %1% humans)") %population.size() ).str() );
+        throw util::checkpoint_error("Population: out of data (read " + to_string(population.size()) + " humans)");
 }
 void Population::checkpoint (ostream& stream)
 {
@@ -232,7 +228,7 @@ void Population::ctsHosts (ostream& stream){
 void Population::ctsHostDemography (ostream& stream){
     auto iter = population.crbegin();
     int cumCount = 0;
-    foreach( double ubound, ctsDemogAgeGroups ){
+    for( double ubound : ctsDemogAgeGroups ){
         while( iter != population.crend() && iter->age(sim::now()).inYears() < ubound ){
             ++cumCount;
             ++iter;

--- a/model/Population.h
+++ b/model/Population.h
@@ -101,6 +101,12 @@ public:
     inline size_t size() const {
         return populationSize;
     }
+    inline HumanPop &getHumans() {
+        return population;
+    }
+    inline const HumanPop &getHumans() const {
+        return population;
+    }
     //@}
 
 private:

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -31,7 +31,6 @@
 #include "util/StreamValidator.h"
 
 #include <cmath>
-#include <boost/format.hpp>
 
 namespace OM {
 namespace Transmission {
@@ -173,7 +172,7 @@ void AnophelesModel::initAvailability(
         double sum_u = 0.0;     // sum u across NNHs where u = xi * P_B * P_C
         double sum_uvw = 0.0;   // sum u*(v+w) across NNHs where w = (1-χ)*P_D*P_E
         
-        foreach( const scnXml::NonHumanHosts& xmlNNH, xmlSeqNNHs ){
+        for( const scnXml::NonHumanHosts& xmlNNH : xmlSeqNNHs ){
             // availability population of hosts of this type relative to other non-human hosts:
             const double xi_i = xmlNNH.getMosqRelativeEntoAvailability().getValue();
             // cycle probabilities, when biting this type of host:
@@ -207,16 +206,7 @@ void AnophelesModel::initAvailability(
     nhh_avail = 0.0;
     nhh_sigma_df = 0.0;
     nhh_sigma_dff = 0.0;
-    foreach( const scnXml::NonHumanHosts& xmlNNH, xmlSeqNNHs ){
-//         auto pop = nonHumanHostPopulations.find(xmlNNH.getName());
-//         if (pop == nonHumanHostPopulations.end()){
-//             throw xml_scenario_error ((boost::format("There is no population size defined for "
-//             "non-human host type \"%1%\"") %xmlNNH.getName()).str());
-//         }
-        
-        // population size for non-human host category:
-//         const double N_i = pop->second;
-        // per-NNH parameters, as above:
+    for( const scnXml::NonHumanHosts& xmlNNH : xmlSeqNNHs ){
         const double xi_i = xmlNNH.getMosqRelativeEntoAvailability().getValue();
         const double P_B_i = xmlNNH.getMosqProbBiting().getValue();
         const double P_C_i = xmlNNH.getMosqProbFindRestSite().getValue();
@@ -689,7 +679,7 @@ void AnophelesModel::advancePeriod (
     
     // ν_A: rate at which mosquitoes find hosts or die (i.e. leave host-seeking state
     double leaveRate = mosqSeekingDeathRate;
-    foreach( const util::SimpleDecayingValue& increase, seekingDeathRateIntervs ){
+    for( const util::SimpleDecayingValue& increase : seekingDeathRateIntervs ){
         leaveRate *= 1.0 + increase.current_value( sim::ts0() );
     }
     leaveRate += sum_avail;
@@ -780,7 +770,7 @@ void AnophelesModel::advancePeriod (
     
     // alphaE (α_E) is α_d * P_E, where P_E may be adjusted by interventions
     double alphaE = availDivisor * probMosqSurvivalOvipositing;
-    foreach( const util::SimpleDecayingValue& pDeath, probDeathOvipositingIntervs ){
+    for( const util::SimpleDecayingValue& pDeath : probDeathOvipositingIntervs ){
         alphaE *= 1.0 - pDeath.current_value( sim::ts0() );
     }
     double tsP_df  = sigma_df * alphaE;

--- a/model/Transmission/NonVectorModel.cpp
+++ b/model/Transmission/NonVectorModel.cpp
@@ -252,7 +252,7 @@ void NonVectorModel::calculateEIR(Host::Human& human, double ageYears, vector<do
         throw util::xml_scenario_error ("Invalid simulation mode");
     }
     #ifndef NDEBUG
-    if (!(boost::math::isfinite)(EIR[0])) {
+    if (!(std::isfinite)(EIR[0])) {
         size_t t = (sim::ts1()-nSpore).inSteps();
         ostringstream msg;
         msg << "Error: non-vect eir is: " << EIR[0]

--- a/model/Transmission/TransmissionModel.cpp
+++ b/model/Transmission/TransmissionModel.cpp
@@ -141,7 +141,7 @@ double TransmissionModel::updateKappa (const Population& population) {
     double sumWeight  = 0.0;
     numTransmittingHumans = 0;
 
-    foreach(const Host::Human& human, population.crange()) {
+    for(const Host::Human& human : population.getHumans()) {
         //NOTE: calculate availability relative to age at end of time step;
         // not my preference but consistent with TransmissionModel::getEIR().
         const double avail = human.perHostTransmission.relativeAvailabilityHetAge(

--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -494,7 +494,7 @@ void VectorModel::calculateEIR(Host::Human& human, double ageYears,
             const vector<double>& partialEIR = species[i].getPartialEIR();
             
             assert( EIR.size() == partialEIR.size() );
-            if ( (boost::math::isnan)(vectors::sum(partialEIR)) ) {
+            if ( (std::isnan)(vectors::sum(partialEIR)) ) {
                 cerr<<"partialEIR is not a number; "<<i<<endl;
             }
             
@@ -533,7 +533,7 @@ void VectorModel::vectorUpdate (const Population& population) {
         if( nGenotypes == 1 ) probTransmission[0] = pTrans;
         else for( size_t g = 0; g < nGenotypes; ++g ){
             const double k = whm.probTransGenotype( pTrans, sumX, g );
-            assert( (boost::math::isfinite)(k) );
+            assert( (std::isfinite)(k) );
             probTransmission[g] = k;
         }
         

--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -301,7 +301,7 @@ void VectorModel::init2 (const Population& population) {
     saved_sigma_dff.assign( speciesIndex.size(), 0.0 );
     
     double sumRelativeAvailability = 0.0;
-    foreach(const Host::Human& human, population.crange()) {
+    for(const Host::Human& human : population.getHumans()) {
         sumRelativeAvailability +=
                 human.perHostTransmission.relativeAvailabilityAge (human.age(sim::now()).inYears());
     }
@@ -318,7 +318,7 @@ void VectorModel::init2 (const Population& population) {
         double sigma_df = 0.0;
         double sigma_dff = 0.0;
         
-        foreach(const Host::Human& human, population.crange()) {
+        for(const Host::Human& human : population.getHumans()) {
             const OM::Transmission::PerHost& host = human.perHostTransmission;
             double prod = host.entoAvailabilityFull (i, human.age(sim::now()).inYears());
             sum_avail += prod;
@@ -337,7 +337,7 @@ void VectorModel::initVectorInterv( const scnXml::Description::AnophelesSequence
         size_t instance, const string& name )
 {
     SpeciesIndexChecker checker( name, speciesIndex );
-    foreach( const scnXml::VectorSpeciesIntervention& anoph, list ){
+    for( const scnXml::VectorSpeciesIntervention& anoph : list ){
         const string& mosq = anoph.getMosquito();
         species[checker.getIndex(mosq)].initVectorInterv( anoph, instance );
     }
@@ -351,7 +351,7 @@ void VectorModel::initVectorTrap( const scnXml::VectorTrap::DescriptionSequence 
     else name_ss << "vector trap intervention " << (instance+1);
     string name = name_ss.str();
     SpeciesIndexChecker checker( name, speciesIndex );
-    foreach( const scnXml::Description1& anoph, list ){
+    for( const scnXml::Description1& anoph : list ){
         const string& mosq = anoph.getMosquito();
         species[checker.getIndex(mosq)].initVectorTrap( anoph, instance );
     }
@@ -361,7 +361,7 @@ void VectorModel::initNonHumanHostsInterv( const scnXml::Description2::Anopheles
         const scnXml::DecayFunction& decay, size_t instance, const string& name )
 {
     SpeciesIndexChecker checker( name, speciesIndex );
-    foreach( const scnXml::NonHumanHostsSpeciesIntervention& anoph, list ){
+    for( const scnXml::NonHumanHostsSpeciesIntervention& anoph : list ){
         const string& mosq = anoph.getMosquito();
         species[checker.getIndex(mosq)].initNonHumanHostsInterv( anoph, decay, instance, name );
     }
@@ -370,7 +370,7 @@ void VectorModel::initNonHumanHostsInterv( const scnXml::Description2::Anopheles
 void VectorModel::initAddNonHumanHostsInterv( const scnXml::Description3::AnophelesSequence list, const string& name )
 {
     SpeciesIndexChecker checker( name, speciesIndex );
-    foreach( const scnXml::NonHumanHostsVectorSpecies& anoph, list ){
+    for( const scnXml::NonHumanHostsVectorSpecies& anoph : list ){
         const string& mosq = anoph.getMosquito();
         species[checker.getIndex(mosq)].initAddNonHumanHostsInterv( anoph, name );
     }
@@ -522,7 +522,7 @@ void VectorModel::vectorUpdate (const Population& population) {
     saved_sigma_dif.assign_at1(popDataInd, 0.0);
     saved_sigma_dff.assign( saved_sigma_dff.size(), 0.0 );
     
-    foreach(const Host::Human& human, population.crange()) {
+    for(const Host::Human& human : population.getHumans()) {
         const OM::Transmission::PerHost& host = human.perHostTransmission;
         WithinHost::WHInterface& whm = *human.withinHostModel;
         const double tbvFac = human.getVaccine().getFactor( interventions::Vaccine::TBV );

--- a/model/WithinHost/CommonWithinHost.cpp
+++ b/model/WithinHost/CommonWithinHost.cpp
@@ -29,8 +29,6 @@
 #include "util/StreamValidator.h"
 #include "schema/scenario.h"
 
-#include <boost/algorithm/string.hpp>
-
 using namespace std;
 
 namespace OM {
@@ -210,7 +208,7 @@ void CommonWithinHost::update(LocalRng& rng,
     
     util::streamValidate(totalDensity);
     util::streamValidate(hrp2Density);
-    assert( (boost::math::isfinite)(totalDensity) );        // inf probably wouldn't be a problem but NaN would be
+    assert( (std::isfinite)(totalDensity) );        // inf probably wouldn't be a problem but NaN would be
     
     // Cache total density for infectiousness calculations
     int y_lag_i = sim::ts1().moduloSteps(y_lag_len);

--- a/model/WithinHost/DescriptiveWithinHost.cpp
+++ b/model/WithinHost/DescriptiveWithinHost.cpp
@@ -233,7 +233,7 @@ void DescriptiveWithinHostModel::checkpoint (istream& stream) {
 }
 void DescriptiveWithinHostModel::checkpoint (ostream& stream) {
     WHFalciparum::checkpoint (stream);
-    foreach (DescriptiveInfection& inf, infections) {
+    for(DescriptiveInfection& inf : infections) {
         inf & stream;
     }
 }

--- a/model/WithinHost/DescriptiveWithinHost.cpp
+++ b/model/WithinHost/DescriptiveWithinHost.cpp
@@ -163,7 +163,7 @@ void DescriptiveWithinHostModel::update(LocalRng& rng,
     
     util::streamValidate( totalDensity );
     util::streamValidate( hrp2Density );
-    assert( (boost::math::isfinite)(totalDensity) );        // inf probably wouldn't be a problem but NaN would be
+    assert( (std::isfinite)(totalDensity) );        // inf probably wouldn't be a problem but NaN would be
     
     // Cache total density for infectiousness calculations
     int y_lag_i = sim::ts1().moduloSteps(y_lag_len);

--- a/model/WithinHost/Diagnostic.cpp
+++ b/model/WithinHost/Diagnostic.cpp
@@ -102,7 +102,7 @@ bool Diagnostic::isPositive( LocalRng& rng, double dens, double densHRP2 ) const
         assert( densHRP2 == densHRP2 ); // monitoring diagnostic passes NaN; use of HRP2 is not supported
         dens = densHRP2;
     }
-    if( (boost::math::isnan)(specificity) ){
+    if( (std::isnan)(specificity) ){
         // use deterministic test
         return dens >= dens_lim;
     }else{
@@ -114,7 +114,7 @@ bool Diagnostic::isPositive( LocalRng& rng, double dens, double densHRP2 ) const
 }
 
 bool Diagnostic::allowsFalsePositives() const{
-    if( (boost::math::isnan)(specificity) ) return dens_lim <= 0.0;
+    if( (std::isnan)(specificity) ) return dens_lim <= 0.0;
     return specificity < 1.0;
 }
 

--- a/model/WithinHost/Diagnostic.cpp
+++ b/model/WithinHost/Diagnostic.cpp
@@ -132,7 +132,7 @@ void diagnostics::init( const Parameters& parameters, const scnXml::Scenario& sc
     diagnostic_set.clear(); // compatibility with unit tests
     
     if(scenario.getDiagnostics().present()){
-        foreach( const scnXml::Diagnostic& diagnostic, scenario.getDiagnostics().get().getDiagnostic() ){
+        for( const scnXml::Diagnostic& diagnostic : scenario.getDiagnostics().get().getDiagnostic() ){
             string name = diagnostic.getName();     // conversion fails without this extra line
             bool inserted = diagnostic_set.insert( make_pair(move(name), Diagnostic(parameters, diagnostic)) ).second;
             if( !inserted ){

--- a/model/WithinHost/Infection/MolineauxInfection.cpp
+++ b/model/WithinHost/Infection/MolineauxInfection.cpp
@@ -30,8 +30,6 @@
 #include <sstream>
 #include <fstream>
 #include <cmath>
-#include <boost/static_assert.hpp>
-
 
 namespace OM {
 namespace WithinHost {

--- a/model/WithinHost/Infection/MolineauxInfection.cpp
+++ b/model/WithinHost/Infection/MolineauxInfection.cpp
@@ -306,7 +306,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     // S[i] (                      "                      acquired and variant-specific immune response)
     
     // ———  2. innate immunity (equation 5)  ———
-    static_assert( kappa_c == 3 );        // allows us to optimise pow(..., kappa_c) to multiplication
+    static_assert( kappa_c == 3, "kappa_c == 3" );        // allows us to optimise pow(..., kappa_c) to multiplication
     const double base = m_density/Pc_star;
     const double Sc = 1.0 / (1.0 + base*base*base);
     
@@ -322,7 +322,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     lagged_Pc[tau] = static_cast<float>(m_density < C ? m_density : C);
     
     // 3.c) calculate S_m(t) (equation 7)
-    static_assert( kappa_m == 1 );        // allows us to optimise out pow(..., kappa_m):
+    static_assert( kappa_m == 1, "kappa_m == 1" );        // allows us to optimise out pow(..., kappa_m):
     //double Sm = (1.0 - beta) / (1.0 + pow(Sm_summation / Pm_star, kappa_m)) + beta
     const double Sm = (1.0 - beta) / (1.0 + Sm_summation / Pm_star) + beta;
     
@@ -340,7 +340,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
             variants[i].lagged_Pi[tau] = static_cast<float>(Pi[i]);
             
             // 4.c) calculate S_i(t) (equation 6)
-            static_assert( kappa_v == 3 );        // again, optimise pow to multiplication
+            static_assert( kappa_v == 3, "kappa_v == 3" );        // again, optimise pow to multiplication
             const double base = variants[i].Si_summation * inv_Pv_star;
             Si[i] = 1.0 / (1.0 + base*base*base);        // eqn 6, given κ_v = 3
         }else{

--- a/model/WithinHost/Infection/MolineauxInfection.cpp
+++ b/model/WithinHost/Infection/MolineauxInfection.cpp
@@ -308,7 +308,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     // S[i] (                      "                      acquired and variant-specific immune response)
     
     // ———  2. innate immunity (equation 5)  ———
-    BOOST_STATIC_ASSERT( kappa_c == 3 );        // allows us to optimise pow(..., kappa_c) to multiplication
+    static_assert( kappa_c == 3 );        // allows us to optimise pow(..., kappa_c) to multiplication
     const double base = m_density/Pc_star;
     const double Sc = 1.0 / (1.0 + base*base*base);
     
@@ -324,7 +324,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     lagged_Pc[tau] = static_cast<float>(m_density < C ? m_density : C);
     
     // 3.c) calculate S_m(t) (equation 7)
-    BOOST_STATIC_ASSERT( kappa_m == 1 );        // allows us to optimise out pow(..., kappa_m):
+    static_assert( kappa_m == 1 );        // allows us to optimise out pow(..., kappa_m):
     //double Sm = (1.0 - beta) / (1.0 + pow(Sm_summation / Pm_star, kappa_m)) + beta
     const double Sm = (1.0 - beta) / (1.0 + Sm_summation / Pm_star) + beta;
     
@@ -342,7 +342,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
             variants[i].lagged_Pi[tau] = static_cast<float>(Pi[i]);
             
             // 4.c) calculate S_i(t) (equation 6)
-            BOOST_STATIC_ASSERT( kappa_v == 3 );        // again, optimise pow to multiplication
+            static_assert( kappa_v == 3 );        // again, optimise pow to multiplication
             const double base = variants[i].Si_summation * inv_Pv_star;
             Si[i] = 1.0 / (1.0 + base*base*base);        // eqn 6, given κ_v = 3
         }else{

--- a/model/WithinHost/Infection/PennyInfection.cpp
+++ b/model/WithinHost/Infection/PennyInfection.cpp
@@ -29,8 +29,6 @@
 #include <sstream>
 #include <fstream>
 #include <cmath>
-#include <boost/static_assert.hpp>
-
 
 namespace OM {
 namespace WithinHost {

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -212,7 +212,7 @@ double WHFalciparum::probTransmissionToMosquito( double tbvFactor, double *sumX 
 double WHFalciparum::pTransGenotype(double pTrans, double sumX, size_t genotype)
 {
     assert( pTrans > 0.0 );
-    assert( (boost::math::isfinite)(sumX) );
+    assert( (std::isfinite)(sumX) );
     
     // This is an extension of the original model.
     //NOTE: it is an approximation since it ignores the possibility of

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -39,7 +39,6 @@
 #include "schema/scenario.h"
 
 #include <cmath>
-#include <boost/format.hpp>
 #include <gsl/gsl_cdf.h>
 
 

--- a/model/WithinHost/WHInterface.cpp
+++ b/model/WithinHost/WHInterface.cpp
@@ -33,8 +33,6 @@
 //using namespace std;
 
 #include <cmath>
-#include <boost/format.hpp>
-
 
 namespace OM {
 namespace WithinHost {
@@ -109,7 +107,7 @@ void WHInterface::checkpoint (istream& stream) {
     numInfs & stream;
 
     if (numInfs > MAX_INFECTIONS)
-        throw util::checkpoint_error( (boost::format("numInfs: %1%") %numInfs).str() );
+        throw util::checkpoint_error("numInfs: " + to_string(numInfs));
 }
 void WHInterface::checkpoint (ostream& stream) {
     numInfs & stream;

--- a/model/interventions/GVI.cpp
+++ b/model/interventions/GVI.cpp
@@ -81,7 +81,7 @@ unique_ptr<PerHostInterventionData> GVIComponent::makeHumanPart( istream& stream
 void GVIComponent::GVIAnopheles::init(const scnXml::GVIDescription::AnophelesParamsType& elt,
                                           double proportionUse)
 {
-    assert( (boost::math::isnan)(deterrency) ); // double init
+    assert( (std::isnan)(deterrency) ); // double init
     deterrency = elt.getDeterrency().present() ? elt.getDeterrency().get().getValue() : 0.0;
     preprandialKilling = elt.getPreprandialKillingEffect().present() ? elt.getPreprandialKillingEffect().get().getValue() : 0.0;
     postprandialKilling = elt.getPostprandialKillingEffect().present() ? elt.getPostprandialKillingEffect().get().getValue() : 0.0;

--- a/model/interventions/HumanInterventionComponents.hpp
+++ b/model/interventions/HumanInterventionComponents.hpp
@@ -121,7 +121,7 @@ HumanIntervention::HumanIntervention( const xsd::cxx::tree::sequence<scnXml::DTD
 void HumanIntervention::deploy( Human& human, mon::Deploy::Method method,
     VaccineLimits vaccLimits ) const
 {
-    foreach( size_t cond, conditions ){
+    for( size_t cond : conditions ){
         // Abort deployment if any condition is false.
         if( !mon::checkCondition(cond) ) return;
     }

--- a/model/interventions/IRS.cpp
+++ b/model/interventions/IRS.cpp
@@ -138,7 +138,7 @@ void IRSComponent::IRSAnopheles::RelativeAttractiveness::init(const scnXml::IRSD
         // Potentially warn about this... but not necessary since making humans
         // more attractive isn't really an issue.
 //     }
-    assert( (boost::math::isnan)(lPF) ); // double init
+    assert( (std::isnan)(lPF) ); // double init
     lPF = log( PF );
 }
 IRSComponent::IRSAnopheles::SurvivalFactor::SurvivalFactor() :

--- a/model/interventions/ITN.cpp
+++ b/model/interventions/ITN.cpp
@@ -384,7 +384,7 @@ void factors::RelativeAttractiveness::initSingleStage(
 
 void factors::RelativeAttractiveness::initTwoStage (
         const scnXml::TwoStageDeterrency& elt, double maxInsecticide,
-        std::optional<double> holeIndexMax)
+        double holeIndexMax, bool holeIndexMaxPresent)
 {
     b.lPFEntering = numeric_limits<double>::quiet_NaN();
     if (elt.getEntering().present()) {
@@ -444,7 +444,7 @@ void factors::RelativeAttractiveness::initTwoStage (
         if (!holeIndexMax) {
             throw util::xml_scenario_error("ITN.description.anophelesParams: holeIndexMax required when using logit attacking deterrency");
         }
-        b.pAttacking.initLogit(elt.getAttackingLogit().get(), *holeIndexMax, true);
+        b.pAttacking.initLogit(elt.getAttackingLogit().get(), holeIndexMax, true);
     }
 }
 
@@ -558,17 +558,19 @@ void ITNComponent::ITNAnopheles::init(
     const scnXml::ITNDescription::AnophelesParamsType& elt,
     double proportionUse,
     double maxInsecticide)
-{
-    std::optional<double> holeIndexMax;
+{   bool holeIndexMaxPresent = false;
+
+    double holeIndexMax = 0.0;
     if (elt.getHoleIndexMax().present()) {
         holeIndexMax = elt.getHoleIndexMax().get().getValue();
+        holeIndexMaxPresent = true;
     }
     
     if (elt.getDeterrency().present()) {
         relAttractiveness.initSingleStage(elt.getDeterrency().get(), maxInsecticide);
     } else {
         assert (elt.getTwoStageDeterrency().present());
-        relAttractiveness.initTwoStage(elt.getTwoStageDeterrency().get(), maxInsecticide, holeIndexMax);
+        relAttractiveness.initTwoStage(elt.getTwoStageDeterrency().get(), maxInsecticide, holeIndexMax, holeIndexMaxPresent);
     }
     if (elt.getPreprandialKillingEffect().present()) {
         preprandialKillingEffect.init(elt.getPreprandialKillingEffect().get(),
@@ -581,7 +583,7 @@ void ITNComponent::ITNAnopheles::init(
             throw util::xml_scenario_error("ITN.description.anophelesParams: holeIndexMax required when using logit killing effect");
         }
         preprandialKillingEffect.initLogit(elt.getPreprandialKillingEffectLogit().get(),
-                                           *holeIndexMax,
+                                           holeIndexMax,
                                            false);
     }
     if (elt.getPostprandialKillingEffect().present()) {
@@ -595,7 +597,7 @@ void ITNComponent::ITNAnopheles::init(
             throw util::xml_scenario_error("ITN.description.anophelesParams: holeIndexMax required when using logit killing effect");
         }
         postprandialKillingEffect.initLogit(elt.getPostprandialKillingEffectLogit().get(),
-                                            *holeIndexMax,
+                                            holeIndexMax,
                                             false);
     }
     if (elt.getFecundityReduction().present()) {
@@ -608,7 +610,7 @@ void ITNComponent::ITNAnopheles::init(
             throw util::xml_scenario_error("ITN.description.anophelesParams: holeIndexMax required when using logit fecundity effect");
         }
         relFecundityEffect.initLogit(elt.getFecundityReductionLogit().get(),
-                                     *holeIndexMax,
+                                     holeIndexMax,
                                      false);
     } else {
         relFecundityEffect.init1();

--- a/model/interventions/ITN.cpp
+++ b/model/interventions/ITN.cpp
@@ -384,7 +384,7 @@ void factors::RelativeAttractiveness::initSingleStage(
 
 void factors::RelativeAttractiveness::initTwoStage (
         const scnXml::TwoStageDeterrency& elt, double maxInsecticide,
-        boost::optional<double> holeIndexMax)
+        std::optional<double> holeIndexMax)
 {
     b.lPFEntering = numeric_limits<double>::quiet_NaN();
     if (elt.getEntering().present()) {
@@ -559,7 +559,7 @@ void ITNComponent::ITNAnopheles::init(
     double proportionUse,
     double maxInsecticide)
 {
-    boost::optional<double> holeIndexMax;
+    std::optional<double> holeIndexMax;
     if (elt.getHoleIndexMax().present()) {
         holeIndexMax = elt.getHoleIndexMax().get().getValue();
     }

--- a/model/interventions/ITN.h
+++ b/model/interventions/ITN.h
@@ -25,7 +25,6 @@
 #include "Transmission/PerHost.h"
 #include "util/sampler.h"
 #include "schema/interventions.h"
-#include <optional>
 
 namespace OM {
 namespace interventions {
@@ -112,7 +111,7 @@ namespace factors {
          * the deterrent can never be perfect, but can have zero effect. */
         void initTwoStage(const scnXml::TwoStageDeterrency& elt,
                           double maxInsecticide,
-                          std::optional<double> holeIndexMax);
+                          double holeIndexMax, bool holeIndexMaxPresent = false);
         
         /** Calculate effect. Range of output is any value ≥ 0.
          * 

--- a/model/interventions/ITN.h
+++ b/model/interventions/ITN.h
@@ -25,7 +25,7 @@
 #include "Transmission/PerHost.h"
 #include "util/sampler.h"
 #include "schema/interventions.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace OM {
 namespace interventions {
@@ -112,7 +112,7 @@ namespace factors {
          * the deterrent can never be perfect, but can have zero effect. */
         void initTwoStage(const scnXml::TwoStageDeterrency& elt,
                           double maxInsecticide,
-                          boost::optional<double> holeIndexMax);
+                          std::optional<double> holeIndexMax);
         
         /** Calculate effect. Range of output is any value ≥ 0.
          * 

--- a/model/interventions/Interfaces.hpp
+++ b/model/interventions/Interfaces.hpp
@@ -23,7 +23,7 @@
 #include "Global.h"
 #include "mon/reporting.h"
 #include <schema/interventions.h>
-#include <boost/integer_traits.hpp>
+#include <limits>
 
 namespace scnXml{ class DeploymentBase; }
 
@@ -54,7 +54,7 @@ namespace Component { enum Type {
 /** Specifies limits on the number of existing doses when deciding whether to
  * vaccinate a human. */
 struct VaccineLimits{
-    VaccineLimits() : minPrevDoses( 0 ), maxCumDoses( boost::integer_traits<uint32_t>::const_max ) {}
+    VaccineLimits() : minPrevDoses( 0 ), maxCumDoses( numeric_limits<uint32_t>::max() ) {}
     void set( const scnXml::DeploymentBase& );
     uint32_t minPrevDoses, maxCumDoses;
 };
@@ -73,7 +73,7 @@ struct ComponentId{
     
     /// Special value indicating the whole population
     static ComponentId wholePop() {
-        return ComponentId{ boost::integer_traits<size_t>::const_max };
+        return ComponentId{ numeric_limits<uint32_t>::max() };
     }
     
     size_t id;

--- a/model/interventions/InterventionManager.cpp
+++ b/model/interventions/InterventionManager.cpp
@@ -315,7 +315,7 @@ void InterventionManager::init (const scnXml::Interventions& intervElt, Transmis
             const scnXml::NonHumanHosts2& elt = *it;
             if (elt.getTimed().present() ) {
                 transmission.initAddNonHumanHostsInterv( elt.getDescription().getAnopheles(), elt.getName() );
-                foreach( const scnXml::Deploy2 deploy, elt.getTimed().get().getDeploy() ){
+                for( const scnXml::Deploy2 deploy : elt.getTimed().get().getDeploy() ){
                     SimDate date = UnitParse::readDate(deploy.getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                     SimTime lifespan = UnitParse::readDuration(deploy.getLifespan(), UnitParse::NONE);
                     timed.push_back( unique_ptr<TimedDeployment>(new TimedAddNonHumanHostsDeployment( date, elt.getName(), lifespan )) );
@@ -344,10 +344,10 @@ void InterventionManager::init (const scnXml::Interventions& intervElt, Transmis
     }
     if( intervElt.getVectorTrap().present() ){
         size_t instance = 0;
-        foreach( const scnXml::VectorTrap& trap, intervElt.getVectorTrap().get().getIntervention() ){
+        for( const scnXml::VectorTrap& trap : intervElt.getVectorTrap().get().getIntervention() ){
             transmission.initVectorTrap(trap.getDescription(), instance, trap.getName());
             if( trap.getTimed().present() ) {
-                foreach( const scnXml::Deploy1 deploy, trap.getTimed().get().getDeploy() ){
+                for( const scnXml::Deploy1 deploy : trap.getTimed().get().getDeploy() ){
                     SimDate date = UnitParse::readDate(deploy.getTime(), UnitParse::STEPS);
                     double ratio = deploy.getRatioToHumans();
                     SimTime lifespan = UnitParse::readDuration(deploy.getLifespan(), UnitParse::NONE);
@@ -376,12 +376,12 @@ void InterventionManager::init (const scnXml::Interventions& intervElt, Transmis
         }
         cout << "Timed deployments:" << endl
             << "time\tmin age\tmax age\tsub pop\tcompl\tcoverag\tcomponents" << endl;
-        foreach( auto& deploy, timed ){
+        for( auto& deploy : timed ){
             deploy->print_details( std::cout );
             cout << endl;
         }
         cout << "Human components:" << endl;
-        foreach( auto& component, humanComponents ){
+        for( auto& component : humanComponents ){
             component->print_details( cout );
             cout << endl;
         }

--- a/model/mon/Continuous.cpp
+++ b/model/mon/Continuous.cpp
@@ -18,9 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-// must be included first to avoid compiler error (incompatible with fpclassify which is included from Global.h?)
-#include <boost/math/special_functions/nonfinite_num_facets.hpp>
-
 #include "mon/Continuous.h"
 #include "mon/info.h"   // lineEnd
 #include "util/errors.h"
@@ -31,7 +28,6 @@
 #include <vector>
 #include <map>
 #include <fstream>
-#include <boost/format.hpp>
 #include <gzstream/gzstream.h>
 
 namespace OM { namespace mon {
@@ -117,10 +113,6 @@ namespace OM { namespace mon {
         
         cts_filename = util::CommandLine::getCtsoutName();
         
-	// This locale ensures uniform formatting of nans and infs on all platforms.
-	locale old_locale;
-	locale nfn_put_locale(old_locale, new boost::math::nonfinite_num_put<char>);
-	ctsOStream.imbue( nfn_put_locale );
 	ctsOStream.width (0);
 	
 	if( isCheckpoint ){
@@ -128,7 +120,7 @@ namespace OM { namespace mon {
 	    for(scnXml::OptionSet::OptionConstIterator it = sOSeq.begin(); it != sOSeq.end(); ++it) {
 		auto reg_it = registered.find( it->getName() );
 		if( reg_it == registered.end() )
-		    throw xml_scenario_error( (boost::format("monitoring.continuous: no output \"%1%\"") %it->getName() ).str() );
+		    throw xml_scenario_error("monitoring.continuous: no output " + string(it->getName()));
 		if( it->getValue() ){
 		    toReport.push_back( reg_it->second );
 		}
@@ -154,7 +146,7 @@ namespace OM { namespace mon {
 	    for(scnXml::OptionSet::OptionConstIterator it = sOSeq.begin(); it != sOSeq.end(); ++it) {
 		auto reg_it = registered.find( it->getName() );
 		if( reg_it == registered.end() )
-		    throw xml_scenario_error( (boost::format("monitoring.continuous: no output \"%1%\"") %it->getName() ).str() );
+		    throw xml_scenario_error("monitoring.continuous: no output " + string(it->getName()));
 		if( it->getValue() ){
 		    ctsOStream << reg_it->second->titles;
 		    toReport.push_back( reg_it->second );

--- a/model/mon/OutputMeasures.h
+++ b/model/mon/OutputMeasures.h
@@ -456,7 +456,7 @@ void defineOutMeasures(){
         OutMeasure::species( 79, MVF_INOCS, false );
     
     // Now initialise valid condition measures:
-    foreach( const NamedMeasureMapT::value_type& v, namedOutMeasures ){
+    for( const NamedMeasureMapT::value_type& v : namedOutMeasures ){
         Measure m = v.second.m;
         // Not the following:
         if( m == mon::MHE_SEVERE_EPISODES ||

--- a/model/mon/info.h
+++ b/model/mon/info.h
@@ -24,7 +24,7 @@
 #include "Global.h"     // SimTime
 
 #include <string>
-#include <boost/integer_traits.hpp>
+#include <limits>
 
 /** This header provides information from the reporting system. */
 namespace OM {
@@ -41,7 +41,7 @@ namespace impl {
 }
 
 /// For surveys and measures to say something shouldn't be reported
-const size_t NOT_USED = boost::integer_traits<size_t>::const_max;
+const size_t NOT_USED = std::numeric_limits<size_t>::max();
 
 /** Line end character. Use Unix line endings to save a little size. */
 const char lineEnd = '\n';

--- a/model/openMalaria.cpp
+++ b/model/openMalaria.cpp
@@ -41,7 +41,6 @@
 
 #include <fstream>
 #include <gzstream/gzstream.h>
-#include <boost/format.hpp>
 
 #include <cstdio>
 #include <cerrno>
@@ -240,7 +239,7 @@ void loop(const SimTime humanWarmupLength, Population &population, TransmissionM
         if( percent != lastPercent ){   // avoid huge amounts of output for performance/log-file size reasons
             lastPercent = percent;
             // \r cleans line. Then we print progress as a percentage.
-            cerr << (boost::format("\r[%|3i|%%]\t") %percent) << flush;
+            cerr << "\r" << percent << "%\t" << flush;
         }
     }
 }

--- a/model/util/AgeGroupInterpolation.cpp
+++ b/model/util/AgeGroupInterpolation.cpp
@@ -18,13 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+#include <fstream>
+
 #include "util/AgeGroupInterpolation.h"
 #include "util/CommandLine.h"
 #include "util/errors.h"
 #include "schema/healthSystem.h"
-
-#include <fstream>
-#include <boost/format.hpp>
 
 /* Required by AgeGroupSplineInterpolation
 #include <gsl_interp.h>
@@ -77,35 +76,25 @@ namespace OM { namespace util {
                                     const char* eltName )
         {
             if( ageGroups.getGroup().size() == 0 ){
-                throw util::xml_scenario_error( (
-                    boost::format( "%1%: at least one age group required" ) %eltName
-                ).str() );
+                throw util::xml_scenario_error(string(eltName) + ": at least one age group required" );
             }
 
             auto pos = dataGroups.begin();
             assert(pos == dataGroups.end());
 
             double greatestLbound = -1.0;
-            foreach( const scnXml::Group& group, ageGroups.getGroup() ){
+            for( const scnXml::Group& group : ageGroups.getGroup() ){
                 double lbound = group.getLowerbound();
                 if( lbound >= greatestLbound ){
                     greatestLbound = lbound;
                     pos = dataGroups.insert( pos, make_pair( lbound, group.getValue() ) );
-                } else {
-                    throw util::xml_scenario_error( (
-                        boost::format("%3%: lower bound %1% not greater than previous %2%")
-                        %lbound %greatestLbound %eltName
-                    ).str() );
-                }
+                } else
+                    throw util::xml_scenario_error(string(eltName) + ": lower bound " + to_string(lbound) + " not greater than previous " + to_string(greatestLbound));
             }
 
             // first lower-bound must be 0
-            if( dataGroups.begin()->first != 0.0 ){
-                throw util::xml_scenario_error( (
-                    boost::format("%1%: first lower-bound must be 0")
-                    %eltName
-                ).str() );
-            }
+            if( dataGroups.begin()->first != 0.0 )
+                throw util::xml_scenario_error(string(eltName) + ": first lower-bound must be 0");
 
             outputSamples( eltName );
         }
@@ -152,18 +141,12 @@ namespace OM { namespace util {
             // Our read iterator
             auto it = ageGroups.getGroup().begin();
 
-            if( it == ageGroups.getGroup().end() ){
-                throw util::xml_scenario_error( (
-                    boost::format( "%1%: at least one age group required" ) %eltName
-                ).str() );
-            }
+            if( it == ageGroups.getGroup().end() )
+                throw util::xml_scenario_error(string(eltName) + ": at least one age group required");
+
             // first lower-bound must be 0
-            if( it->getLowerbound() != 0.0 ){
-                throw util::xml_scenario_error( (
-                    boost::format("%1%: first lower-bound must be 0")
-                    %eltName
-                ).str() );
-            }
+            if( it->getLowerbound() != 0.0 )
+                throw util::xml_scenario_error(string(eltName) + ": first lower-bound must be 0");
 
             // Our insert iterator (used for performance)
             auto pos = dataPoints.begin();
@@ -178,12 +161,8 @@ namespace OM { namespace util {
                     pos = dataPoints.insert( pos, make_pair( insBound, lastValue ) );
                     greatestLbound = lbound;
                     lastValue = it->getValue();     // always insert previous value
-                } else {
-                    throw util::xml_scenario_error( (
-                        boost::format("%3%: lower bound %1% less than previous %2%")
-                        %lbound %greatestLbound %eltName
-                    ).str() );
-                }
+                } else
+                    throw util::xml_scenario_error(string(eltName) + ": lower bound " + to_string(lbound) + " less than previous " + to_string(greatestLbound));
             }
 
             // add a point in middle of last age group (taking upper bound as max-age-years:
@@ -307,9 +286,8 @@ namespace OM { namespace util {
             obj = new AgeGroupPiecewiseLinear( ageGroups, eltName );
         }else if( interp.get() == "none" ){
             obj = new AgeGroupPiecewiseConstant( ageGroups, eltName );
-        }else{
-            throw util::xml_scenario_error( (boost::format( "age group interpolation %1% not implemented" ) %interp).str() );
-        }
+        }else
+            throw util::xml_scenario_error(string("age group interpolation ") + interp.get() + " not implemented" );
     }
     void AgeGroupInterpolator::reset(){
         assert( obj != nullptr );  // should not do that

--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -29,11 +29,8 @@
 #include <sstream>
 #include <iostream>
 #include <cassert>
-#include <boost/lexical_cast.hpp>
 
 namespace OM { namespace util {
-    using boost::lexical_cast;
-    
     bitset<CommandLine::NUM_OPTIONS> CommandLine::options;
     string CommandLine::resourcePath;
     string CommandLine::outputName;

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -26,7 +26,6 @@
 
 #include <cmath>
 #include <stdexcept>
-#include <boost/format.hpp>
 
 namespace OM {
 namespace util {
@@ -254,7 +253,7 @@ unique_ptr<DecayFunction> DecayFunction::makeObject(
     }else if( func == "smooth-compact" ){
         return unique_ptr<DecayFunction>(new SmoothCompactDecayFunction( elt ));
     }else{
-        throw util::xml_scenario_error( (boost::format( "decay function type %1% of %2% unrecognized" ) %func %eltName).str() );
+        throw util::xml_scenario_error("decay function type " + string(func) + " of " + string(eltName) + " unrecognized");
     }
 }
 unique_ptr<DecayFunction> DecayFunction::makeConstantObject(){

--- a/model/util/DocumentLoader.cpp
+++ b/model/util/DocumentLoader.cpp
@@ -25,7 +25,6 @@
 #include <sstream>
 #include <fstream>
 #include <map>
-#include <boost/format.hpp>
 
 namespace OM { namespace util {
 

--- a/model/util/StreamValidator.cpp
+++ b/model/util/StreamValidator.cpp
@@ -139,11 +139,11 @@ StreamValidatorType StreamValidator;
 // ———  Our cross-platform consistent-result hasing functions  ——
 namespace CPCH {
     SVType toSVType(uint32_t x){
-        BOOST_STATIC_ASSERT( sizeof(x) == sizeof(SVType) );
+        static_assert( sizeof(x) == sizeof(SVType) );
         return x;
     }
     SVType toSVType(int32_t x){
-        BOOST_STATIC_ASSERT( sizeof(x) == sizeof(SVType) );
+        static_assert( sizeof(x) == sizeof(SVType) );
         union {
             int32_t asS32;
             uint32_t asU32;
@@ -152,7 +152,7 @@ namespace CPCH {
         return asU32;
     }
     SVType toSVType(uint64_t x){
-        BOOST_STATIC_ASSERT( sizeof(x) == 2*sizeof(SVType) );
+        static_assert( sizeof(x) == 2*sizeof(SVType) );
         union {
             uint64_t asU64;
             uint32_t asU32[2];
@@ -161,7 +161,7 @@ namespace CPCH {
         return asU32[0] ^ asU32[1];     // XOR two parts together
     }
     SVType toSVType(int64_t x){
-        BOOST_STATIC_ASSERT( sizeof(x) == 2*sizeof(SVType) );
+        static_assert( sizeof(x) == 2*sizeof(SVType) );
         union {
             int64_t asS64;
             uint32_t asU32[2];
@@ -173,7 +173,7 @@ namespace CPCH {
     //Also not guaranteed to produce the same result on all platforms (but will
     //it?).
     SVType toSVType(float x){
-        BOOST_STATIC_ASSERT( sizeof(x) == sizeof(SVType) );
+        static_assert( sizeof(x) == sizeof(SVType) );
         union {
             float asFloat;
             uint32_t asU32;
@@ -182,7 +182,7 @@ namespace CPCH {
         return asU32;
     }
     SVType toSVType(double x){
-        BOOST_STATIC_ASSERT( sizeof(x) == 2*sizeof(SVType) );
+        static_assert( sizeof(x) == 2*sizeof(SVType) );
         union {
             double asDouble;
             uint32_t asU32[2];

--- a/model/util/StreamValidator.cpp
+++ b/model/util/StreamValidator.cpp
@@ -25,8 +25,6 @@
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
-#include <boost/format.hpp>
-#include <boost/static_assert.hpp>
 
 // Compile-time optional
 #ifdef OM_STREAM_VALIDATOR
@@ -87,11 +85,11 @@ void StreamValidatorType::loadStream( const string& path ){
     storeMode = false;
     ifstream f_str( file.c_str(), ios::in | ios::binary );
     if( !f_str.is_open() )
-	throw util::base_exception( (boost::format("unable to read %1%") %file).str(), Error::FileIO );
+	throw util::base_exception("unable to read " + string(file), Error::FileIO);
     char head[4];
     f_str.read( reinterpret_cast<char*>(&head), sizeof(char)*4 );
     if( memcmp( &OM_SV_HEAD, &head, sizeof(char)*4 ) != 0 )
-	throw util::base_exception( (boost::format("%1% is not a valid StreamValidator file") %file).str(), Error::FileIO );
+	throw util::base_exception(string(file) + " is not a valid StreamValidator file", Error::FileIO);
     
     stream & f_str;
     

--- a/model/util/StreamValidator.cpp
+++ b/model/util/StreamValidator.cpp
@@ -137,11 +137,11 @@ StreamValidatorType StreamValidator;
 // ———  Our cross-platform consistent-result hasing functions  ——
 namespace CPCH {
     SVType toSVType(uint32_t x){
-        static_assert( sizeof(x) == sizeof(SVType) );
+        static_assert( sizeof(x) == sizeof(SVType), "sizeof(x) == sizeof(SVType)" );
         return x;
     }
     SVType toSVType(int32_t x){
-        static_assert( sizeof(x) == sizeof(SVType) );
+        static_assert( sizeof(x) == sizeof(SVType), "sizeof(x) == sizeof(SVType)" );
         union {
             int32_t asS32;
             uint32_t asU32;
@@ -150,7 +150,7 @@ namespace CPCH {
         return asU32;
     }
     SVType toSVType(uint64_t x){
-        static_assert( sizeof(x) == 2*sizeof(SVType) );
+        static_assert( sizeof(x) == 2*sizeof(SVType), "sizeof(x) == 2*sizeof(SVType)" );
         union {
             uint64_t asU64;
             uint32_t asU32[2];
@@ -159,7 +159,7 @@ namespace CPCH {
         return asU32[0] ^ asU32[1];     // XOR two parts together
     }
     SVType toSVType(int64_t x){
-        static_assert( sizeof(x) == 2*sizeof(SVType) );
+        static_assert( sizeof(x) == 2*sizeof(SVType), "sizeof(x) == 2*sizeof(SVType)" );
         union {
             int64_t asS64;
             uint32_t asU32[2];
@@ -171,7 +171,7 @@ namespace CPCH {
     //Also not guaranteed to produce the same result on all platforms (but will
     //it?).
     SVType toSVType(float x){
-        static_assert( sizeof(x) == sizeof(SVType) );
+        static_assert( sizeof(x) == sizeof(SVType), "sizeof(x) == sizeof(SVType)" );
         union {
             float asFloat;
             uint32_t asU32;
@@ -180,7 +180,7 @@ namespace CPCH {
         return asU32;
     }
     SVType toSVType(double x){
-        static_assert( sizeof(x) == 2*sizeof(SVType) );
+        static_assert( sizeof(x) == 2*sizeof(SVType), "sizeof(x) == 2*sizeof(SVType)" );
         union {
             double asDouble;
             uint32_t asU32[2];

--- a/model/util/StreamValidator.h
+++ b/model/util/StreamValidator.h
@@ -21,8 +21,6 @@
 #ifndef Hmod_StreamValidator
 #define Hmod_StreamValidator
 
-#include <boost/cstdint.hpp>
-
 // Compile-time optional
 #ifdef OM_STREAM_VALIDATOR
 #include "Global.h"

--- a/model/util/StreamValidator.h
+++ b/model/util/StreamValidator.h
@@ -84,10 +84,7 @@ namespace OM { namespace util {
 	/// Load a reference stream from file and switch to validation mode.
 	void loadStream( const string& path );
 	
-	/** Templated function to take a value, hash it, and call handle.
-         * 
-         * We can't just use something like boost::hash because we want the
-         * result to be the same across platforms, builds, etc. */
+	/** Templated function to take a value, hash it, and call handle. */
 	template<class T>
 	void operator() (T value){
             handle( CPCH::toSVType( value ) );

--- a/model/util/Uninitialised.h
+++ b/model/util/Uninitialised.h
@@ -41,12 +41,12 @@ public:
     Uninitialised () : initialised(false) {}
     Uninitialised (T var) : variable(var) {
         // don't consider setting to NaN initialisation
-        initialised = !(boost::math::isnan)(var);
+        initialised = !(std::isnan)(var);
     }
     
     inline void operator= (T var) {
         variable = var;
-        initialised = !(boost::math::isnan)(var);
+        initialised = !(std::isnan)(var);
     }
     
     // Implicit cast-to-T (should be invoked automatically on use): throw if uninitialised

--- a/model/util/checkpoint.cpp
+++ b/model/util/checkpoint.cpp
@@ -64,11 +64,11 @@ namespace OM { namespace util { namespace checkpoint {
     //@}
     
     void staticChecks () {
-        static_assert (sizeof(char) == 1);
-        static_assert (sizeof(short int) == 2);
-        static_assert (sizeof(int) == 4);
-        static_assert (sizeof(float) == 4);
-        static_assert (sizeof(double) == 8);
+        static_assert (sizeof(char) == 1, "sizeof(char) == 1");
+        static_assert (sizeof(short int) == 2, "sizeof(short int) == 2");
+        static_assert (sizeof(int) == 4, "sizeof(int) == 4");
+        static_assert (sizeof(float) == 4, "sizeof(float) == 4");
+        static_assert (sizeof(double) == 8, "sizeof(double) == 8");
     }
     
     void header (ostream& stream) {

--- a/model/util/checkpoint.cpp
+++ b/model/util/checkpoint.cpp
@@ -64,11 +64,11 @@ namespace OM { namespace util { namespace checkpoint {
     //@}
     
     void staticChecks () {
-        BOOST_STATIC_ASSERT (sizeof(char) == 1);
-        BOOST_STATIC_ASSERT (sizeof(short int) == 2);
-        BOOST_STATIC_ASSERT (sizeof(int) == 4);
-        BOOST_STATIC_ASSERT (sizeof(float) == 4);
-        BOOST_STATIC_ASSERT (sizeof(double) == 8);
+        static_assert (sizeof(char) == 1);
+        static_assert (sizeof(short int) == 2);
+        static_assert (sizeof(int) == 4);
+        static_assert (sizeof(float) == 4);
+        static_assert (sizeof(double) == 8);
     }
     
     void header (ostream& stream) {

--- a/model/util/checkpoint.h
+++ b/model/util/checkpoint.h
@@ -27,48 +27,12 @@
 #endif
 
 #include <iostream>
-#include <boost/foreach.hpp>
 #include <vector>
 #include <list>
 #include <map>
 #include <set>
 using namespace std;
 
-/** @brief Checkpointing utility functions
- *
- * These functions are intended to facilitate checkpointing. They were inspired
- * by the boost::serialization library (which proved to be easier not to use,
- * due to the additional library dependency).
- * 
- * My current rule-of-thumb is to checkpoint all non-static data but not static data in general.
- * 
- * Data should be checkpointed with the & operator. Non-derived classes should implement a
- * checkpointing function like the following:
- * 
- * \code
-/// Checkpointing
-template<class S>
-void operator& (S& stream) {
-    var1 & stream;
-    var2 & stream;
-}
- * \endcode
- * 
- * (This template will be implemented for istream and ostream types.)
- * Derived classes should implement the same templated function, but calling a virtual checkpoint
- * function defined as the following:
- * 
- * \code
-virtual checkpoint (istream& stream);
-virtual checkpoint (ostream& stream);
- * \endcode
- *
- * Although this needs to be implemented twice, in most cases one implementation will just be a copy
- * of the other with istream replaced with ostream as the argument type.
- * 
- * Checkpointing should be set up by including Global.h. Some more
- * checkpointing functions (for handling containers) are available by including
- * checkpoint_containers.h. */
 namespace OM {
 namespace interventions{
     struct ComponentId;

--- a/model/util/checkpoint_containers.h
+++ b/model/util/checkpoint_containers.h
@@ -53,7 +53,7 @@ namespace checkpoint {
     template<class T>
     void operator& (vector<T>& x, ostream& stream) {
         x.size() & stream;
-        foreach (T& y, x) {
+        for (T& y : x) {
             y & stream;
         }
     }
@@ -63,7 +63,7 @@ namespace checkpoint {
         l & stream;
         validateListSize (l);
         x.resize (l);
-        foreach (T& y, x) {
+        for (T& y : x) {
             y & stream;
         }
     }
@@ -74,7 +74,7 @@ namespace checkpoint {
         l & stream;
         validateListSize (l);
         x.resize (l, templateInstance);
-        foreach (T& y, x) {
+        for (T& y : x) {
             y & stream;
         }
     }
@@ -82,7 +82,7 @@ namespace checkpoint {
     template<class T>
     void operator& (list<T> x, ostream& stream) {
         x.size() & stream;
-        foreach (T& y, x) {
+        for (T& y : x) {
             y & stream;
         }
     }
@@ -92,7 +92,7 @@ namespace checkpoint {
         l & stream;
         validateListSize (l);
         x.resize (l);
-        foreach (T& y, x) {
+        for (T& y : x) {
             y & stream;
         }
     }

--- a/model/util/errors.h
+++ b/model/util/errors.h
@@ -99,7 +99,7 @@ namespace OM { namespace util {
     
     // As in the "Advanced Bash-Scripting Guide"; not directly relevant to C++
     // but gives some idea what codes make sense to use.
-    static_assert( Error::Max <= 113 );
+    static_assert( Error::Max <= 113, "Error::Max <= 113" );
     
     /** Base OpenMalaria exception class.
      * 

--- a/model/util/errors.h
+++ b/model/util/errors.h
@@ -25,7 +25,6 @@
 #include <vector>
 #include <iostream>
 #include <sstream>
-#include <boost/static_assert.hpp>
 
 using namespace std;
 

--- a/model/util/errors.h
+++ b/model/util/errors.h
@@ -100,7 +100,7 @@ namespace OM { namespace util {
     
     // As in the "Advanced Bash-Scripting Guide"; not directly relevant to C++
     // but gives some idea what codes make sense to use.
-    BOOST_STATIC_ASSERT( Error::Max <= 113 );
+    static_assert( Error::Max <= 113 );
     
     /** Base OpenMalaria exception class.
      * 

--- a/model/util/misc.cpp
+++ b/model/util/misc.cpp
@@ -27,10 +27,8 @@
 #include "mon/management.h"
 
 #include <cstdlib>
-#include <boost/xpressive/xpressive.hpp>
 #include <iomanip>
-
-using namespace boost::xpressive;
+#include <regex>
 
 namespace OM {
 
@@ -167,8 +165,9 @@ double durationToDays( const std::string& str, DefaultUnit unit ){
 /** Returns SimDate::never() when it doesn't recognise a date. Throws when it does
  * but encounters definite format errors. */
 SimDate parseDate( const std::string& str ){
-    static sregex dateRx = sregex::compile ( "(\\d{4})-(\\d{1,2})-(\\d{1,2})" );
-    smatch rx_what;
+    std::regex dateRx("(\\d{4})-(\\d{1,2})-(\\d{1,2})");
+    std::smatch rx_what;
+
     if( regex_match(str, rx_what, dateRx) ){
         int year = std::atoi(rx_what[1].str().c_str()),
             month = std::atoi(rx_what[2].str().c_str()),

--- a/model/util/random.h
+++ b/model/util/random.h
@@ -35,10 +35,6 @@
  * are stable across platforms and releases, allowing reproducibility.
  */
 
-// Experimental support for boost random number distributions.
-// Unfortunately the authors do not support reproducibility of results.
-// #define OM_RANDOM_USE_BOOST_DIST
-
 #include "Global.h"
 #include "util/errors.h"
 #include <set>
@@ -46,20 +42,8 @@
 #include <chacha.h>
 #include "util/xoshiro.hpp"
 
-#ifdef OM_RANDOM_USE_BOOST_DIST
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/lognormal_distribution.hpp>
-#include <boost/random/gamma_distribution.hpp>
-#include <boost/random/beta_distribution.hpp>
-#include <boost/random/poisson_distribution.hpp>
-#include <boost/random/bernoulli_distribution.hpp>
-#include <boost/random/weibull_distribution.hpp>
-#endif
-
-#if !defined OM_RANDOM_USE_BOOST_DIST
 #include <gsl/gsl_cdf.h>
 #include <gsl/gsl_randist.h>
-#endif
 
 #include <cmath>
 
@@ -166,22 +150,12 @@ struct RNG {
     /** This function returns a Gaussian random variate, with mean mean and
      * standard deviation std. The sampled value x ~ N(mean, std^2) . */
     double gauss (double mean, double std){
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        boost::random::normal_distribution<> dist (mean, std);
-        return dist(m_rng);
-# else
         return gsl_ran_gaussian(&m_gsl_gen,std)+mean;
-# endif
     }
     
     /** This function returns a random variate from the gamma distribution. */
     double gamma (double a, double b){
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        boost::random::gamma_distribution<> dist (a, b);
-        return dist(m_rng);
-# else
         return gsl_ran_gamma(&m_gsl_gen, a, b);
-# endif
     }
     
     /** This function returns a random variate from the lognormal distribution.
@@ -193,12 +167,7 @@ struct RNG {
      * @param sigma sigma-log
      */
     double log_normal (double meanlog, double stdlog){
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        boost::random::lognormal_distribution<> dist (meanlog, stdlog);
-        return dist (m_rng);
-# else
         return gsl_ran_lognormal (&m_gsl_gen, meanlog, stdlog);
-# endif
     }
     
     /** Return the maximum over multiple log-normal samples.
@@ -210,15 +179,6 @@ struct RNG {
      * @param stdlog standard deviation of underlying Gaussian
      */
     double max_multi_log_normal (double start, int n, double meanlog, double stdlog){
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        // We don't have a CDF available, so take log-normal samples
-        double result = start;
-        for (int i = 0; i < n; ++i) {
-            double sample = log_normal(meanlog, stdlog);
-            if (sample > result) result = sample;
-        }
-        return result;
-# else
         // Used for performance reasons. Calling GSL's log_normal 5 times is 50% slower.
         // For random variables X1, .., Xn with identical distribution X and
         // Mn = max(X1, .., Xn), the CDF:
@@ -230,17 +190,11 @@ struct RNG {
         double zval = gsl_cdf_ugaussian_Pinv (normp);
         double multi_sample = exp(meanlog + stdlog * zval);
         return std::max(start, multi_sample);
-# endif
     }
     
     /** This function returns a random variate from the beta distribution. */
     double beta(double a, double b){
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        boost::random::beta_distribution<> dist (a, b);
-        return dist(m_rng);
-# else
         return gsl_ran_beta (&m_gsl_gen,a,b);
-# endif
     }
     
     /** This function wraps beta(), setting b=b and a such that m is the mean
@@ -253,35 +207,25 @@ struct RNG {
     
     /** This function returns a random integer from the Poisson distribution with mean lambda. */
     int poisson(double lambda){
-        if( !(boost::math::isfinite)(lambda) ){
+        if( !(std::isfinite)(lambda) ){
             //This would lead to an inifinite loop
             throw TRACED_EXCEPTION( "lambda is inf", Error::InfLambda );
         }
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        boost::random::poisson_distribution<> dist (lambda);
-        return dist(m_rng);
-# else
         return gsl_ran_poisson (&m_gsl_gen, lambda);
-# endif
     }
 
     /** This function returns true with probability prob or 0 with probability
      * 1-prob (Bernoulli distribution). */
     bool bernoulli(double prob){
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        boost::random::bernoulli_distribution<> dist (prob);
-        return dist(m_rng);
-# else
-        assert( (boost::math::isfinite)(prob) );
+        assert( (std::isfinite)(prob) );
         // return true iff our variate is less than the probability
         return uniform_01() < prob;
-# endif
     }
     
     /** This function returns an integer from 0 to 1-n, where every value has
      * equal probability of being sampled. */
     inline int uniform (int n) {
-        assert( (boost::math::isfinite)(n) );
+        assert( (std::isfinite)(n) );
         return static_cast<int>( uniform_01() * n );
     }
     
@@ -294,12 +238,7 @@ struct RNG {
      * @param k is the shape parameter
      */
     double weibull( double lambda, double k ){
-# ifdef OM_RANDOM_USE_BOOST_DIST
-        boost::random::weibull_distribution<> dist (k, lambda);
-        return dist(m_rng);
-# else
         return gsl_ran_weibull( &m_gsl_gen, lambda, k );
-# endif
     }
     //@}
     

--- a/model/util/vecDay.h
+++ b/model/util/vecDay.h
@@ -24,10 +24,10 @@
 #include "Global.h"
 #include <vector>
 
-#if __cplusplus >= 201402L
-// Update classes to mimic std::vector members
-#error "vecDay should be updated if switching to a later C++ version"
-#endif
+// #if __cplusplus >= 201402L
+// // Update classes to mimic std::vector members
+// #error "vecDay should be updated if switching to a later C++ version"
+// #endif
 
 namespace OM {
 namespace util {

--- a/unittest/CMDecisionTreeSuite.h
+++ b/unittest/CMDecisionTreeSuite.h
@@ -29,11 +29,9 @@
 #include "UnittestUtil.h"
 #include "WHMock.h"
 #include <limits>
-#include <boost/assign/std/vector.hpp> // for 'operator+=()'
 
 using namespace OM::Clinical;
 using namespace OM::WithinHost;
-using namespace boost::assign; // bring 'operator+=()' into scope
 using UnitTest::WHMock;
 
 class CMDecisionTreeSuite : public CxxTest::TestSuite

--- a/unittest/ESCaseManagementSuite.h
+++ b/unittest/ESCaseManagementSuite.h
@@ -28,10 +28,8 @@
 #include "UnittestUtil.h"
 #include "ExtraAsserts.h"
 #include <list>
-#include <boost/assign/std/vector.hpp> // for 'operator+=()'
 
 using namespace OM::Clinical;
-using namespace boost::assign;
 
 #if 0
 TODO: replace this test suite

--- a/unittest/PkPdComplianceSuite.h
+++ b/unittest/PkPdComplianceSuite.h
@@ -129,11 +129,11 @@ public:
         fm += white + "\n";
         // head row
         const char * type = hasSecondDrug ? "type" : "";
-        printf(fm.c_str(), "day", "conc", yellow, "rel err %", yellow, "abs err", "factor", yellow, "rel err %", yellow, "abs err", type);
+        printf(fm.c_str(), "day", "conc", yellow.c_str(), "rel err %", yellow.c_str(), "abs err", "factor", yellow.c_str(), "rel err %", yellow.c_str(), "abs err", type);
         // cout << format(fm) % "day" % "conc" % yellow % "rel err %" % yellow % "abs err" % "factor" % yellow % "rel err %" % yellow % "abs err" % type;
         // head row separator
         string sfill = "------------";
-        printf(fm.c_str(), "---", "------------", white, "---------", white, sfill, sfill, white, "---------", white, sfill, "----");
+        printf(fm.c_str(), "---", "------------", white.c_str(), "---------", white.c_str(), sfill.c_str(), sfill.c_str(), white.c_str(), "---------", white.c_str(), sfill.c_str(), "----");
         // cout << format(fm) % "---" % "------------" % white % "---------" % white % sfill % sfill % white % "---------" % white % sfill % "----";
         return fm;
     }

--- a/unittest/PkPdComplianceSuite.h
+++ b/unittest/PkPdComplianceSuite.h
@@ -150,7 +150,7 @@ public:
         const char* col_CA = abs(c_abs_error) > conc_abs_tol ? red : green;
         const char* col_FR = abs(f_rel_error) > PKPD_FACT_REL_TOL * 100 ? red : green;
         const char* col_FA = abs(f_abs_error) > PKPD_FACT_ABS_TOL ? red : green;
-        printf(fm.c_str(), day, concentration, col_CR, c_rel_error, col_CA, c_abs_error, factor, col_FR, f_rel_error, col_FA, f_abs_error, type);
+        printf(fm.c_str(), day, concentration, col_CR, c_rel_error, col_CA, c_abs_error, factor, col_FR, f_rel_error, col_FA, f_abs_error, type.c_str());
         // cout << format(fm) % day % concentration % col_CR % c_rel_error % col_CA % c_abs_error
         //         % factor % col_FR % f_rel_error % col_FA % f_abs_error % type;
     }

--- a/unittest/PkPdComplianceSuite.h
+++ b/unittest/PkPdComplianceSuite.h
@@ -128,8 +128,8 @@ public:
             + white + "%12$=4s|";
         fm += white + "\n";
         // head row
-        const char * type = hasSecondDrug ? "type" : "";
-        printf(fm.c_str(), "day", "conc", yellow.c_str(), "rel err %", yellow.c_str(), "abs err", "factor", yellow.c_str(), "rel err %", yellow.c_str(), "abs err", type);
+        string type = hasSecondDrug ? "type" : "";
+        printf(fm.c_str(), "day", "conc", yellow.c_str(), "rel err %", yellow.c_str(), "abs err", "factor", yellow.c_str(), "rel err %", yellow.c_str(), "abs err", type.c_str());
         // cout << format(fm) % "day" % "conc" % yellow % "rel err %" % yellow % "abs err" % "factor" % yellow % "rel err %" % yellow % "abs err" % type;
         // head row separator
         string sfill = "------------";

--- a/unittest/PkPdComplianceSuite.h
+++ b/unittest/PkPdComplianceSuite.h
@@ -24,16 +24,15 @@
 #define Hmod_PkPdComplianceSuite
 
 #include <cxxtest/TestSuite.h>
-#include <boost/format.hpp>
 #include "PkPd/LSTMModel.h"
 #include "WithinHost/Infection/DummyInfection.h"
 #include "UnittestUtil.h"
 #include "ExtraAsserts.h"
 #include <limits>
+#include <cstdio>
 
 using std::pair;
 using std::multimap;
-using boost::format;
 using namespace OM;
 using namespace OM::PkPd;
 
@@ -130,10 +129,12 @@ public:
         fm += white + "\n";
         // head row
         const char * type = hasSecondDrug ? "type" : "";
-        cout << format(fm) % "day" % "conc" % yellow % "rel err %" % yellow % "abs err" % "factor" % yellow % "rel err %" % yellow % "abs err" % type;
+        printf(fm.c_str(), "day", "conc", yellow, "rel err %", yellow, "abs err", "factor", yellow, "rel err %", yellow, "abs err", type);
+        // cout << format(fm) % "day" % "conc" % yellow % "rel err %" % yellow % "abs err" % "factor" % yellow % "rel err %" % yellow % "abs err" % type;
         // head row separator
         string sfill = "------------";
-        cout << format(fm) % "---" % "------------" % white % "---------" % white % sfill % sfill % white % "---------" % white % sfill % "----";
+        printf(fm.c_str(), "---", "------------", white, "---------", white, sfill, sfill, white, "---------", white, sfill, "----");
+        // cout << format(fm) % "---" % "------------" % white % "---------" % white % sfill % sfill % white % "---------" % white % sfill % "----";
         return fm;
     }
     
@@ -149,8 +150,9 @@ public:
         const char* col_CA = abs(c_abs_error) > conc_abs_tol ? red : green;
         const char* col_FR = abs(f_rel_error) > PKPD_FACT_REL_TOL * 100 ? red : green;
         const char* col_FA = abs(f_abs_error) > PKPD_FACT_ABS_TOL ? red : green;
-        cout << format(fm) % day % concentration % col_CR % c_rel_error % col_CA % c_abs_error
-                % factor % col_FR % f_rel_error % col_FA % f_abs_error % type;
+        printf(fm.c_str(), day, concentration, col_CR, c_rel_error, col_CA, c_abs_error, factor, col_FR, f_rel_error, col_FA, f_abs_error, type);
+        // cout << format(fm) % day % concentration % col_CR % c_rel_error % col_CA % c_abs_error
+        //         % factor % col_FR % f_rel_error % col_FA % f_abs_error % type;
     }
     
     void runDrugSimulations (string drugName, string drug2Name,

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -457,7 +457,7 @@ public:
     
     static double getPrescribedMg( const PkPd::LSTMModel& pkpd ){
         double r = 0.0;
-        foreach( const PkPd::MedicateData& md, pkpd.medicateQueue ){
+        for( const PkPd::MedicateData& md : pkpd.medicateQueue ){
             r += md.qty;
         }
         return r;


### PR DESCRIPTION
Fully remove Boost from OpenMalaria. It is not needed as a dependency anymore.

- switch to C++17, even though Ubuntu Xenial LTS 16.04 is old, it has enough support for C++17
- get rid of std::optional for compatibility with old versions of gcc
- add <algorithm> to Global.h (previously included via boost) to fix SSE compiler errors in chacha.h
- add -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR to CXX to the flags because C++17 standard got rid of auto_ptr but XSD/Xercec libs still use it
- update static_assert calls for compatibility with older versions of gcc