### PR TITLE
Add more OS versions to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
+os: linux     # set default
+dist: xenial  # set default
 language: cpp
+
 cache: 
   apt: true
   directories:
     - $HOME/Library/Caches/Homebrew
 
+before_cache:
+  - test "$TRAVIS_OS_NAME" == "osx" && brew cleanup
+
 install:
   - test "$TRAVIS_OS_NAME" == "linux" && sudo apt-get install build-essential git cmake libboost-dev libgsl-dev libxerces-c-dev xsdcxx || true
-  - test "$TRAVIS_OS_NAME" == "osx" && brew install git boost coreutils cmake gcc gsl xerces-c xsd || true
+  - test "$TRAVIS_OS_NAME" == "osx" && brew install -v git boost coreutils cmake gcc gsl xerces-c xsd || true
 
 # Build openMalaria and create the release folder openMalaria-$TRAVIS_OS_NAME
 script:
@@ -17,14 +23,14 @@ script:
 
 deploy:
   overwrite: true
-  skip_cleanup: true
+  cleanup: false
   provider: releases
-  api_key: $GH_TOKEN
+  token: $GH_TOKEN
   file: openMalaria-$OSNAME.tar.gz
   on:
     tags: true
 
-matrix:
+jobs:
   include:
     # Ubuntu Focal release
     - os: linux
@@ -49,12 +55,19 @@ matrix:
       dist: bionic
       compiler: clang
       env: OSNAME=Ubuntu-Bionic
+      deploy: # skip
+
+    # Max OSX release
+    - os: osx
+      osx_image: xcode12.2
+      compiler: gcc
+      env: OSNAME=macOS-10.15.7
 
     # Max OSX release
     - os: osx
       osx_image: xcode11.5
       compiler: gcc
-      env: OSNAME=macOS-10.15
+      env: OSNAME=macOS-10.15.4
 
     # Max OSX release
     - os: osx
@@ -79,11 +92,11 @@ matrix:
       after_success: true
       before_deploy: skip
       deploy:
-        skip_cleanup: true
+        cleanup: false
         provider: pages
-        github-token: $GH_TOKEN
-        local-dir: build/generated/book
-        keep-history: false
+        token: $GH_TOKEN
+        local_dir: build/generated/book
+        keep_history: false
         on:
           branch: master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,6 @@ jobs:
       compiler: gcc
       env: OSNAME=macOS-10.15.4
 
-    # See https://travis-ci.community/t/osx-homebrew-addons-module-not-as-reliable-as-claimed/4054/7
-    # Removed because most likely homebrew does not provide up-to-date
     # Max OSX release
     - os: osx
       osx_image: xcode9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ deploy:
 
 matrix:
   include:
+    # Ubuntu Focal release
+    - os: linux
+      dist: focal
+      compiler: gcc
+      env: OSNAME=Ubuntu-Focal
+
     # Ubuntu Xenial release
     - os: linux
       dist: xenial
@@ -38,6 +44,12 @@ matrix:
       compiler: gcc
       env: OSNAME=Ubuntu-Bionic
 
+    # Clang test, don't deploy
+    - os: linux
+      dist: bionic
+      compiler: clang
+      env: OSNAME=Ubuntu-Bionic
+
     # Max OSX release
     - os: osx
       osx_image: xcode11.5
@@ -45,19 +57,10 @@ matrix:
       env: OSNAME=macOS-10.15
 
     # Max OSX release
-    # - os: osx
-    #   osx_image: xcode9.4
-    #   compiler: gcc
-    #   env: OSNAME=macOS-10.13
-
-    # Clang test, don't deploy
-    - os: linux
-      dist: bionic
-      compiler: clang
-      env: OSNAME=Ubuntu-Bionic
-      deploy:
-        provider: script
-        script: echo "Skipping deployment!"
+    - os: osx
+      osx_image: xcode9.4
+      compiler: gcc
+      env: OSNAME=macOS-10.13
     
     - name: gh-pages build
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_cache:
 
 install:
   - test "$TRAVIS_OS_NAME" == "linux" && sudo apt-get install build-essential git cmake libboost-dev libgsl-dev libxerces-c-dev xsdcxx || true
-  - test "$TRAVIS_OS_NAME" == "osx" && brew install -v git boost coreutils cmake gcc gsl xerces-c xsd || true
+  - test "$TRAVIS_OS_NAME" == "osx" && HOMEBREW_NO_AUTO_UPDATE=1 brew install git boost coreutils cmake gcc gsl xerces-c xsd || true
 
 # Build openMalaria and create the release folder openMalaria-$TRAVIS_OS_NAME
 script:
@@ -69,6 +69,8 @@ jobs:
       compiler: gcc
       env: OSNAME=macOS-10.15.4
 
+    # See https://travis-ci.community/t/osx-homebrew-addons-module-not-as-reliable-as-claimed/4054/7
+    # Removed because most likely homebrew does not provide up-to-date
     # Max OSX release
     - os: osx
       osx_image: xcode9.4
@@ -93,6 +95,7 @@ jobs:
       before_deploy: skip
       deploy:
         cleanup: false
+        strategy: git
         provider: pages
         token: $GH_TOKEN
         local_dir: build/generated/book

--- a/build.sh
+++ b/build.sh
@@ -111,7 +111,8 @@ function build {
 
 function runtests {
     if [ $TESTS = "ON" ]; then
-        pushd build && ctest --output-on-failure -j$JOBS && popd
+        #pushd build && ctest --output-on-failure -j$JOBS && popd
+        pushd build && ctest -VV -j$JOBS && popd
     fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -111,8 +111,7 @@ function build {
 
 function runtests {
     if [ $TESTS = "ON" ]; then
-        #pushd build && ctest --output-on-failure -j$JOBS && popd
-        pushd build && ctest -VV -j$JOBS && popd
+        pushd build && ctest --output-on-failure -j$JOBS && popd
     fi
 }
 

--- a/model/mon/misc.cpp
+++ b/model/mon/misc.cpp
@@ -204,6 +204,12 @@ void writeSurveyData ()
         stream.flush();
         stream.close();
     }
+
+    ifstream stream(filename, mode);
+    if(stream.is_open() == false || !stream.good())
+    {
+        cerr << "STREAM BAD" << endl;
+    }
 }
 
 

--- a/model/mon/misc.cpp
+++ b/model/mon/misc.cpp
@@ -200,6 +200,9 @@ void writeSurveyData ()
     } else {
         ofstream stream(filename, mode);
         writeToStream(stream);
+        // Otherwise file may be written after OpenMalaria has returned (Mac OS Xcode 9.4)
+        stream.flush();
+        stream.close();
     }
 }
 

--- a/test/run.py
+++ b/test/run.py
@@ -165,8 +165,6 @@ def runScenario(options,omOptions,name):
             print("\033[0;32m  "+(" ".join(cmd))+"\033[0;00m")
         ret=subprocess.call (cmd, shell=False, cwd=simDir)
         
-        time.sleep(0.5)
-
         if ret != 0:
             print("\033[1;31mNon-zero exit status: " + str(ret))
             break
@@ -189,11 +187,15 @@ def runScenario(options,omOptions,name):
             f_in.close()
             os.remove(ctsoutGzFile)
         
+        os.system('ls -l '+simDir)
+
         # if the checkpoint file hasn't been updated, stop
         if not os.path.isfile(checkFile):
+            print('break because isfile(checkFile) is false')
             break
         checkTime=os.path.getmtime(checkFile)
         if not checkTime > lastTime:
+            print('break because checkTime > lastTime is false')
             break
         lastTime=checkTime
     
@@ -205,7 +207,11 @@ def runScenario(options,omOptions,name):
         for f in (glob.glob(os.path.join(simDir,"checkpoint*")) + glob.glob(os.path.join(simDir,"seed?")) + [os.path.join(simDir,"init_data.xml"),os.path.join(simDir,"scenario.sum")]):
             if os.path.isfile(f):
                 os.remove(f)
-    
+
+    #debug
+    print('Printing output:')
+    os.system('ls -l '+outputFile)
+
     origCtsout = os.path.join(testSrcDir,"expected/ctsout%s.txt"%tmpprefix)
     newCtsout = os.path.join(testBuildDir,"ctsout%s.txt"%tmpprefix)
     origOutput = os.path.join(testSrcDir,"expected/output%s.txt"%tmpprefix)

--- a/test/run.py
+++ b/test/run.py
@@ -113,6 +113,8 @@ def linkOrCopy (src, dest):
 
 # Run, with file "scenario"+name+".xml" (or just "name")
 def runScenario(options,omOptions,name):
+    print("Begin runScenario")
+    
     scenarioSrc=os.path.abspath(os.path.join(testSrcDir,"scenario%s.xml" % name))
     tmpprefix=name
     compare=options.compare

--- a/test/run.py
+++ b/test/run.py
@@ -188,6 +188,7 @@ def runScenario(options,omOptions,name):
             f_in.close()
             os.remove(ctsoutGzFile)
         
+        print('Folder:')
         os.system('ls -l '+simDir)
 
         # if the checkpoint file hasn't been updated, stop
@@ -211,7 +212,7 @@ def runScenario(options,omOptions,name):
                 os.remove(f)
 
     #debug
-    print('Printing output:')
+    print('Loop over, is outputFile here?')
     os.system('ls -l '+outputFile)
 
     origCtsout = os.path.join(testSrcDir,"expected/ctsout%s.txt"%tmpprefix)

--- a/test/run.py
+++ b/test/run.py
@@ -193,7 +193,6 @@ def runScenario(options,omOptions,name):
         if not os.path.isfile(checkFile):
             break
         checkTime=os.path.getmtime(checkFile)
-        print(checkTime, lastTime)
         if not checkTime > lastTime:
             break
         lastTime=checkTime

--- a/test/run.py
+++ b/test/run.py
@@ -158,7 +158,10 @@ def runScenario(options,omOptions,name):
     if options.logging:
         print(time.strftime("\033[0;33m%a, %d %b %Y %H:%M:%S")+"\t\033[1;33m%s" % scenarioSrc)
     
-    startTime=lastTime=time.time()
+    # -1 second for the first loop to make sure that 'last time' happened 'before' the loop
+    # on old Mac OS systems, lasttime seems to be rounded to the second.
+    # for processes < 1 second, the checkpoint file would be written 'before lastTime.
+    startTime=lastTime=time.time() - 1
     # While no output.txt file and cmd exits successfully:
     while (not os.path.isfile(outputFile)):
         if options.logging:

--- a/test/run.py
+++ b/test/run.py
@@ -158,10 +158,10 @@ def runScenario(options,omOptions,name):
     if options.logging:
         print(time.strftime("\033[0;33m%a, %d %b %Y %H:%M:%S")+"\t\033[1;33m%s" % scenarioSrc)
     
-    # -1 second for the first loop to make sure that 'last time' happened 'before' the loop
+    # -5.0 second for the first loop to make sure that 'last time' happened 'before' the loop
     # on old Mac OS systems, lasttime seems to be rounded to the second.
     # for processes < 1 second, the checkpoint file would be written 'before lastTime.
-    startTime=lastTime=time.time() - 1
+    startTime=lastTime=time.time() - 5.0
     # While no output.txt file and cmd exits successfully:
     while (not os.path.isfile(outputFile)):
         if options.logging:

--- a/test/run.py
+++ b/test/run.py
@@ -113,8 +113,6 @@ def linkOrCopy (src, dest):
 
 # Run, with file "scenario"+name+".xml" (or just "name")
 def runScenario(options,omOptions,name):
-    print("Begin runScenario")
-    
     scenarioSrc=os.path.abspath(os.path.join(testSrcDir,"scenario%s.xml" % name))
     tmpprefix=name
     compare=options.compare
@@ -163,11 +161,9 @@ def runScenario(options,omOptions,name):
     startTime=lastTime=time.time()
     # While no output.txt file and cmd exits successfully:
     while (not os.path.isfile(outputFile)):
-        print('Begin loop')
         if options.logging:
             print("\033[0;32m  "+(" ".join(cmd))+"\033[0;00m")
         ret=subprocess.call (cmd, shell=False, cwd=simDir)
-        
         if ret != 0:
             print("\033[1;31mNon-zero exit status: " + str(ret))
             break
@@ -190,19 +186,14 @@ def runScenario(options,omOptions,name):
             f_in.close()
             os.remove(ctsoutGzFile)
         
-        print('Folder:')
-        os.system('ls -l '+simDir)
-
         # if the checkpoint file hasn't been updated, stop
         if not os.path.isfile(checkFile):
-            print('break because isfile(checkFile) is false')
             break
         checkTime=os.path.getmtime(checkFile)
+        print(checkTime, lastTime)
         if not checkTime > lastTime:
-            print('break because checkTime > lastTime is false')
             break
         lastTime=checkTime
-        print('End loop')
     
     if ret == 0 and options.logging:
         print("\033[0;33mDone in " + str(time.time()-startTime) + " seconds")
@@ -212,11 +203,7 @@ def runScenario(options,omOptions,name):
         for f in (glob.glob(os.path.join(simDir,"checkpoint*")) + glob.glob(os.path.join(simDir,"seed?")) + [os.path.join(simDir,"init_data.xml"),os.path.join(simDir,"scenario.sum")]):
             if os.path.isfile(f):
                 os.remove(f)
-
-    #debug
-    print('Loop over, is outputFile here?')
-    os.system('ls -l '+outputFile)
-
+    
     origCtsout = os.path.join(testSrcDir,"expected/ctsout%s.txt"%tmpprefix)
     newCtsout = os.path.join(testBuildDir,"ctsout%s.txt"%tmpprefix)
     origOutput = os.path.join(testSrcDir,"expected/output%s.txt"%tmpprefix)

--- a/test/run.py
+++ b/test/run.py
@@ -161,6 +161,7 @@ def runScenario(options,omOptions,name):
     startTime=lastTime=time.time()
     # While no output.txt file and cmd exits successfully:
     while (not os.path.isfile(outputFile)):
+        print('Begin loop')
         if options.logging:
             print("\033[0;32m  "+(" ".join(cmd))+"\033[0;00m")
         ret=subprocess.call (cmd, shell=False, cwd=simDir)
@@ -198,6 +199,7 @@ def runScenario(options,omOptions,name):
             print('break because checkTime > lastTime is false')
             break
         lastTime=checkTime
+        print('End loop')
     
     if ret == 0 and options.logging:
         print("\033[0;33mDone in " + str(time.time()-startTime) + " seconds")

--- a/test/run.py
+++ b/test/run.py
@@ -164,6 +164,9 @@ def runScenario(options,omOptions,name):
         if options.logging:
             print("\033[0;32m  "+(" ".join(cmd))+"\033[0;00m")
         ret=subprocess.call (cmd, shell=False, cwd=simDir)
+        
+        time.sleep(0.5)
+
         if ret != 0:
             print("\033[1;31mNon-zero exit status: " + str(ret))
             break


### PR DESCRIPTION
- Fixes a bug where in older versions of Mac OS, sometimes Linux, where the output.txt file creation happened after OpenMalaria had returned, causing the tests to not detect the the file in time.