### PR TITLE
add Docker files

### DIFF
--- a/docker/30.3
+++ b/docker/30.3
@@ -1,0 +1,29 @@
+FROM ubuntu:trusty as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g-dev cmake libgsl0-dev libboost-dev libxerces-c-dev xsdcxx python wget \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-30.3 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_43.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:trusty as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl0ldbl libxerces-c3.1 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* /om/
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/35.0
+++ b/docker/35.0
@@ -1,0 +1,29 @@
+FROM ubuntu:xenial as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g-dev cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev python \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-35.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_35.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:xenial as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl2 libxerces-c3.1 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/36.0
+++ b/docker/36.0
@@ -1,0 +1,29 @@
+FROM ubuntu:xenial as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g-dev cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev python \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-36.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_36.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:xenial as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl2 libxerces-c3.1 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/38.0
+++ b/docker/38.0
@@ -1,0 +1,29 @@
+FROM ubuntu:xenial as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g-dev cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev python \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-38.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_38.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:xenial as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl2 libxerces-c3.1 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/41.0
+++ b/docker/41.0
@@ -1,0 +1,29 @@
+FROM ubuntu:bionic as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-41.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_41.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:bionic as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl23 libxerces-c3.2 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/41.1
+++ b/docker/41.1
@@ -1,0 +1,29 @@
+FROM ubuntu:bionic as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-41.1 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_41.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:bionic as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl23 libxerces-c3.2 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/42.0
+++ b/docker/42.0
@@ -1,0 +1,29 @@
+FROM ubuntu:bionic as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-42.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_42.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:bionic as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl23 libxerces-c3.2 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/43.0
+++ b/docker/43.0
@@ -1,0 +1,29 @@
+FROM ubuntu:bionic as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git zlib1g cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-43.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_43.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:bionic as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl23 libxerces-c3.2 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml


### PR DESCRIPTION
Add Docker files for the following OpenMalaria versions:

- 30.3
- 35.0
- 36.0
- 38.0
- 40.0
- 41.0
- 41.1
- 42.0
- 43.0

Docker images are available on Docker-Hub: https://hub.docker.com/r/swisstph/openmalaria/tags?page=1&ordering=last_updated