### PR TITLE
Update appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,23 @@
 cache:
-    - 'C:\cygwin64'
-    
-os: Visual Studio 2015
+    - 'C:\cygwin64\var\cache\setup'
+
+os: Visual Studio 2019
 
 configuration: Release
+
+clone_folder: c:\projects\openmalaria
 
 # Run install scripts
 install:
   - C:\cygwin64\bin\bash -lc "echo $HOME"
   - C:\cygwin64\bin\bash -lc "appveyor DownloadFile http://rawgit.com/transcode-open/apt-cyg/master/apt-cyg -FileName apt-cyg"
   - C:\cygwin64\bin\bash -lc "install apt-cyg /bin"
+  - C:\cygwin64\bin\bash -lc "apt-cyg update"
   - C:\cygwin64\bin\bash -lc "apt-cyg install wget grep"
   - C:\cygwin64\bin\bash -lc "apt-cyg install zlib-devel make python3 cmake libgsl-devel xsd libxerces-c-devel"
 
 build_script:
-  - C:\cygwin64\bin\bash -lc "cd /cygdrive/c/projects/openmalaria && ./build.sh --jobs=4 -r --artifact=openMalaria-windows"
+  - C:\cygwin64\bin\bash -lc "cd /cygdrive/c/projects/openmalaria && ./build.sh --jobs=4 -r --artifact=openMalaria-windows
 
 # Discover and run tests (or test_script)
 test_script:


### PR DESCRIPTION
Switch to Visual Studio 2019 for Windows builds because the 2015 is now too old for Cygwin.