### PR TITLE
fix: Numerical Result out of range for small exponent value

### DIFF
--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -168,7 +168,11 @@ public:
         return constOverLambda;
     }
     double eval(double effectiveAge) const{
-        return exp( -pow(effectiveAge, k) );
+        double p = -pow(effectiveAge, k);
+        if(p < -700.0)
+            return 0.0;
+        else
+            return exp(p);
     }
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const{


### PR DESCRIPTION
past about x < -700, the exp(x) function is not able to correctly represent the very small number (not enough digits). The errno variable is set with a "Numerical result out of range" and the stdexcept ERANGE exception is set. 

The code works fine since the exp function will return 0 anyway.

This commit removes the error.