### PR TITLE
fix log(0) for false positives while reporting totalDensity

### DIFF
--- a/model/WithinHost/DescriptiveWithinHost.cpp
+++ b/model/WithinHost/DescriptiveWithinHost.cpp
@@ -215,7 +215,8 @@ bool DescriptiveWithinHostModel::summarize( Host::Human& human )const{
     // totalDensity > 0. Here we report the last calculated density.
     if( diagnostics::monitoringDiagnostic().isPositive(human.rng(), totalDensity, std::numeric_limits<double>::quiet_NaN()) ){
         mon::reportStatMHI( mon::MHR_PATENT_HOSTS, human, 1 );
-        mon::reportStatMHF( mon::MHF_LOG_DENSITY, human, log(totalDensity) );
+        if(totalDensity > 1e-10)
+            mon::reportStatMHF( mon::MHF_LOG_DENSITY, human, log(totalDensity) );
         return true;    // patent
     }
     return false;       // not patent


### PR DESCRIPTION
If the diagnostic specificity is less than 1, false positives (humans without infections) will be reported.

When this happens, openMalaria will try to report the log(totalDensity) for the given human. Since this is a false positive, the human has totalDensity = 0, and log(0) sets the errno variable with a "Numerical result out of range".

This change will only report densities if they are higher than 0. 