### PR TITLE
Update header license

### DIFF
--- a/model/Clinical/CM5DayCommon.cpp
+++ b/model/Clinical/CM5DayCommon.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/CM5DayCommon.h
+++ b/model/Clinical/CM5DayCommon.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/CMDecisionTree.cpp
+++ b/model/Clinical/CMDecisionTree.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/CMDecisionTree.h
+++ b/model/Clinical/CMDecisionTree.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/ClinicalModel.cpp
+++ b/model/Clinical/ClinicalModel.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/ClinicalModel.h
+++ b/model/Clinical/ClinicalModel.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/DecisionTree5Day.cpp
+++ b/model/Clinical/DecisionTree5Day.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/DecisionTree5Day.h
+++ b/model/Clinical/DecisionTree5Day.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/ESCaseManagement.cpp
+++ b/model/Clinical/ESCaseManagement.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/ESCaseManagement.h
+++ b/model/Clinical/ESCaseManagement.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/Episode.cpp
+++ b/model/Clinical/Episode.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/Episode.h
+++ b/model/Clinical/Episode.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/EventScheduler.cpp
+++ b/model/Clinical/EventScheduler.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/EventScheduler.h
+++ b/model/Clinical/EventScheduler.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/ImmediateOutcomes.cpp
+++ b/model/Clinical/ImmediateOutcomes.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Clinical/ImmediateOutcomes.h
+++ b/model/Clinical/ImmediateOutcomes.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Global.h
+++ b/model/Global.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/Human.cpp
+++ b/model/Host/Human.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/Human.h
+++ b/model/Host/Human.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/ImportedInfections.cpp
+++ b/model/Host/ImportedInfections.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/ImportedInfections.h
+++ b/model/Host/ImportedInfections.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/InfectionIncidenceModel.cpp
+++ b/model/Host/InfectionIncidenceModel.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/InfectionIncidenceModel.h
+++ b/model/Host/InfectionIncidenceModel.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/NeonatalMortality.cpp
+++ b/model/Host/NeonatalMortality.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Host/NeonatalMortality.h
+++ b/model/Host/NeonatalMortality.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Parameters.h
+++ b/model/Parameters.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrug.cpp
+++ b/model/PkPd/Drug/LSTMDrug.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrug.h
+++ b/model/PkPd/Drug/LSTMDrug.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugConversion.cpp
+++ b/model/PkPd/Drug/LSTMDrugConversion.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugConversion.h
+++ b/model/PkPd/Drug/LSTMDrugConversion.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugOneComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugOneComp.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugOneComp.h
+++ b/model/PkPd/Drug/LSTMDrugOneComp.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugThreeComp.cpp
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugThreeComp.h
+++ b/model/PkPd/Drug/LSTMDrugThreeComp.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugType.cpp
+++ b/model/PkPd/Drug/LSTMDrugType.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/Drug/LSTMDrugType.h
+++ b/model/PkPd/Drug/LSTMDrugType.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/LSTMMedicate.h
+++ b/model/PkPd/LSTMMedicate.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/LSTMModel.cpp
+++ b/model/PkPd/LSTMModel.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/LSTMModel.h
+++ b/model/PkPd/LSTMModel.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/LSTMTreatments.cpp
+++ b/model/PkPd/LSTMTreatments.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PkPd/LSTMTreatments.h
+++ b/model/PkPd/LSTMTreatments.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Population.cpp
+++ b/model/Population.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Population.h
+++ b/model/Population.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PopulationAgeStructure.cpp
+++ b/model/PopulationAgeStructure.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/PopulationAgeStructure.h
+++ b/model/PopulationAgeStructure.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/Anopheles/PerHostAnoph.cpp
+++ b/model/Transmission/Anopheles/PerHostAnoph.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/Anopheles/PerHostAnoph.h
+++ b/model/Transmission/Anopheles/PerHostAnoph.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
+++ b/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/Anopheles/rotate.h
+++ b/model/Transmission/Anopheles/rotate.h
@@ -1,3 +1,24 @@
+/* This file is part of OpenMalaria.
+ * 
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
+ * 
+ * OpenMalaria is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #ifndef Hmod_rotate_H
 #define Hmod_rotate_H
 

--- a/model/Transmission/NonVectorModel.h
+++ b/model/Transmission/NonVectorModel.h
@@ -1,18 +1,19 @@
 /* This file is part of OpenMalaria.
- *
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * 
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
- *
+ * Copyright (C) 2020-2021 University of Basel
+ * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or (at
  * your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.

--- a/model/Transmission/PerHost.cpp
+++ b/model/Transmission/PerHost.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/PerHost.h
+++ b/model/Transmission/PerHost.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/TransmissionModel.h
+++ b/model/Transmission/TransmissionModel.h
@@ -1,22 +1,22 @@
 /* This file is part of OpenMalaria.
- *
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * 
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
- *
+ * Copyright (C) 2020-2021 University of Basel
+ * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or (at
  * your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
- * USA.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef Hmod_TransmissionModel

--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -73,18 +73,6 @@ void VectorModel::ctsCbP_Ah (ostream& stream) {
     for(size_t i = 0; i < speciesIndex.size(); ++i)
         stream << '\t' << species[i]->getLastVecStat(Anopheles::PAh);
 }
-void VectorModel::ctsCbP_Amu (ostream& stream) {
-    for(size_t i = 0; i < speciesIndex.size(); ++i)
-        stream << '\t' << species[i].getLastVecStat(Anopheles::PAmu);
-}
-void VectorModel::ctsCbP_A1 (ostream& stream) {
-    for(size_t i = 0; i < speciesIndex.size(); ++i)
-        stream << '\t' << species[i].getLastVecStat(Anopheles::PA1);
-}
-void VectorModel::ctsCbP_Ah (ostream& stream) {
-    for(size_t i = 0; i < speciesIndex.size(); ++i)
-        stream << '\t' << species[i].getLastVecStat(Anopheles::PAh);
-}
 void VectorModel::ctsCbP_df (ostream& stream) {
     for(size_t i = 0; i < speciesIndex.size(); ++i)
         stream << '\t' << species[i]->getLastVecStat(Anopheles::PDF);
@@ -659,23 +647,6 @@ void VectorModel::deployAddNonHumanHosts(string name, double popSize, SimTime li
     }
     for(size_t i = 0; i < speciesIndex.size(); ++i) {
         species[i]->deployAddNonHumanHosts( m_rng, i, name, popSize, lifespan);
-    }
-}
-void VectorModel::deployNonHumanHostsInterv( size_t instance, string name ){
-    if( interventionMode != dynamicEIR ){
-        throw xml_scenario_error(vec_mode_err);
-    }
-    for(size_t i = 0; i < speciesIndex.size(); ++i) {
-        species[i].deployNonHumanHostsInterv( m_rng, i, instance, name);
-    }
-}
-void VectorModel::deployAddNonHumanHosts(string name, double popSize, SimTime lifespan)
-{
-    if( interventionMode != dynamicEIR ){
-        throw xml_scenario_error(vec_mode_err);
-    }
-    for(size_t i = 0; i < speciesIndex.size(); ++i) {
-        species[i].deployAddNonHumanHosts( m_rng, i, name, popSize, lifespan);
     }
 }
 void VectorModel::uninfectVectors() {

--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -73,6 +73,18 @@ void VectorModel::ctsCbP_Ah (ostream& stream) {
     for(size_t i = 0; i < speciesIndex.size(); ++i)
         stream << '\t' << species[i]->getLastVecStat(Anopheles::PAh);
 }
+void VectorModel::ctsCbP_Amu (ostream& stream) {
+    for(size_t i = 0; i < speciesIndex.size(); ++i)
+        stream << '\t' << species[i].getLastVecStat(Anopheles::PAmu);
+}
+void VectorModel::ctsCbP_A1 (ostream& stream) {
+    for(size_t i = 0; i < speciesIndex.size(); ++i)
+        stream << '\t' << species[i].getLastVecStat(Anopheles::PA1);
+}
+void VectorModel::ctsCbP_Ah (ostream& stream) {
+    for(size_t i = 0; i < speciesIndex.size(); ++i)
+        stream << '\t' << species[i].getLastVecStat(Anopheles::PAh);
+}
 void VectorModel::ctsCbP_df (ostream& stream) {
     for(size_t i = 0; i < speciesIndex.size(); ++i)
         stream << '\t' << species[i]->getLastVecStat(Anopheles::PDF);
@@ -647,6 +659,23 @@ void VectorModel::deployAddNonHumanHosts(string name, double popSize, SimTime li
     }
     for(size_t i = 0; i < speciesIndex.size(); ++i) {
         species[i]->deployAddNonHumanHosts( m_rng, i, name, popSize, lifespan);
+    }
+}
+void VectorModel::deployNonHumanHostsInterv( size_t instance, string name ){
+    if( interventionMode != dynamicEIR ){
+        throw xml_scenario_error(vec_mode_err);
+    }
+    for(size_t i = 0; i < speciesIndex.size(); ++i) {
+        species[i].deployNonHumanHostsInterv( m_rng, i, instance, name);
+    }
+}
+void VectorModel::deployAddNonHumanHosts(string name, double popSize, SimTime lifespan)
+{
+    if( interventionMode != dynamicEIR ){
+        throw xml_scenario_error(vec_mode_err);
+    }
+    for(size_t i = 0; i < speciesIndex.size(); ++i) {
+        species[i].deployAddNonHumanHosts( m_rng, i, name, popSize, lifespan);
     }
 }
 void VectorModel::uninfectVectors() {

--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/VectorModel.h
+++ b/model/Transmission/VectorModel.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/Transmission/transmission.h
+++ b/model/Transmission/transmission.h
@@ -1,22 +1,22 @@
 /* This file is part of OpenMalaria.
- *
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * 
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
- *
+ * Copyright (C) 2020-2021 University of Basel
+ * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or (at
  * your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
- * USA.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
 #ifndef Hmod_Transmission

--- a/model/WithinHost/CommonWithinHost.cpp
+++ b/model/WithinHost/CommonWithinHost.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/CommonWithinHost.h
+++ b/model/WithinHost/CommonWithinHost.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/DescriptiveWithinHost.cpp
+++ b/model/WithinHost/DescriptiveWithinHost.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/DescriptiveWithinHost.h
+++ b/model/WithinHost/DescriptiveWithinHost.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Diagnostic.cpp
+++ b/model/WithinHost/Diagnostic.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Diagnostic.h
+++ b/model/WithinHost/Diagnostic.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Genotypes.cpp
+++ b/model/WithinHost/Genotypes.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Genotypes.h
+++ b/model/WithinHost/Genotypes.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/CommonInfection.cpp
+++ b/model/WithinHost/Infection/CommonInfection.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2019 Swiss Tropical and Public Health Institute
- * Copyright (C) 2005-2019 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/CommonInfection.h
+++ b/model/WithinHost/Infection/CommonInfection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/DescriptiveIPTInfection.cpp
+++ b/model/WithinHost/Infection/DescriptiveIPTInfection.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/DescriptiveIPTInfection.h
+++ b/model/WithinHost/Infection/DescriptiveIPTInfection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/DescriptiveInfection.cpp
+++ b/model/WithinHost/Infection/DescriptiveInfection.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/DescriptiveInfection.h
+++ b/model/WithinHost/Infection/DescriptiveInfection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/DummyInfection.cpp
+++ b/model/WithinHost/Infection/DummyInfection.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/DummyInfection.h
+++ b/model/WithinHost/Infection/DummyInfection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/EmpiricalInfection.cpp
+++ b/model/WithinHost/Infection/EmpiricalInfection.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/EmpiricalInfection.h
+++ b/model/WithinHost/Infection/EmpiricalInfection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/Infection.h
+++ b/model/WithinHost/Infection/Infection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/MolineauxInfection.cpp
+++ b/model/WithinHost/Infection/MolineauxInfection.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/MolineauxInfection.h
+++ b/model/WithinHost/Infection/MolineauxInfection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/PennyInfection.cpp
+++ b/model/WithinHost/Infection/PennyInfection.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Infection/PennyInfection.h
+++ b/model/WithinHost/Infection/PennyInfection.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Pathogenesis/PathogenesisModel.cpp
+++ b/model/WithinHost/Pathogenesis/PathogenesisModel.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Pathogenesis/PathogenesisModel.h
+++ b/model/WithinHost/Pathogenesis/PathogenesisModel.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Pathogenesis/State.h
+++ b/model/WithinHost/Pathogenesis/State.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Pathogenesis/Submodels.cpp
+++ b/model/WithinHost/Pathogenesis/Submodels.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Pathogenesis/Submodels.h
+++ b/model/WithinHost/Pathogenesis/Submodels.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Treatments.cpp
+++ b/model/WithinHost/Treatments.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/Treatments.h
+++ b/model/WithinHost/Treatments.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/WHFalciparum.h
+++ b/model/WithinHost/WHFalciparum.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/WHInterface.cpp
+++ b/model/WithinHost/WHInterface.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/WHInterface.h
+++ b/model/WithinHost/WHInterface.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/WHVivax.cpp
+++ b/model/WithinHost/WHVivax.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/WithinHost/WHVivax.h
+++ b/model/WithinHost/WHVivax.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/GVI.cpp
+++ b/model/interventions/GVI.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/GVI.h
+++ b/model/interventions/GVI.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/HumanComponents.h
+++ b/model/interventions/HumanComponents.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/IRS.cpp
+++ b/model/interventions/IRS.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/IRS.h
+++ b/model/interventions/IRS.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/ITN.cpp
+++ b/model/interventions/ITN.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/ITN.h
+++ b/model/interventions/ITN.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/InterventionManager.cpp
+++ b/model/interventions/InterventionManager.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/Vaccine.cpp
+++ b/model/interventions/Vaccine.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/interventions/Vaccine.h
+++ b/model/interventions/Vaccine.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/AgeGroup.h
+++ b/model/mon/AgeGroup.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/Continuous.cpp
+++ b/model/mon/Continuous.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/Continuous.h
+++ b/model/mon/Continuous.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/OutputMeasures.h
+++ b/model/mon/OutputMeasures.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2014 Swiss Tropical and Public Health Institute
- * Copyright (C) 2005-2014 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/info.h
+++ b/model/mon/info.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/management.h
+++ b/model/mon/management.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/misc.cpp
+++ b/model/mon/misc.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/mon.cpp
+++ b/model/mon/mon.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/mon/reporting.h
+++ b/model/mon/reporting.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/openMalaria.cpp
+++ b/model/openMalaria.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/sim.h
+++ b/model/sim.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/AgeGroupInterpolation.cpp
+++ b/model/util/AgeGroupInterpolation.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/AgeGroupInterpolation.h
+++ b/model/util/AgeGroupInterpolation.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/CommandLine.h
+++ b/model/util/CommandLine.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/DocumentLoader.cpp
+++ b/model/util/DocumentLoader.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/DocumentLoader.h
+++ b/model/util/DocumentLoader.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/ModelOptions.cpp
+++ b/model/util/ModelOptions.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/ModelOptions.h
+++ b/model/util/ModelOptions.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/MultidimSolver.h
+++ b/model/util/MultidimSolver.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/SimpleDecayingValue.h
+++ b/model/util/SimpleDecayingValue.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/SpeciesIndexChecker.cpp
+++ b/model/util/SpeciesIndexChecker.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/SpeciesIndexChecker.h
+++ b/model/util/SpeciesIndexChecker.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/StreamValidator.cpp
+++ b/model/util/StreamValidator.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/StreamValidator.h
+++ b/model/util/StreamValidator.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/Uninitialised.h
+++ b/model/util/Uninitialised.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/checkpoint.cpp
+++ b/model/util/checkpoint.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/checkpoint.h
+++ b/model/util/checkpoint.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/checkpoint_containers.h
+++ b/model/util/checkpoint_containers.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/errors.cpp
+++ b/model/util/errors.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/errors.h
+++ b/model/util/errors.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/misc.cpp
+++ b/model/util/misc.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/mod.h
+++ b/model/util/mod.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/random.cpp
+++ b/model/util/random.cpp
@@ -1,3 +1,24 @@
+/* This file is part of OpenMalaria.
+ * 
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
+ * 
+ * OpenMalaria is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
 #include "random.h"
 
 namespace OM{

--- a/model/util/random.h
+++ b/model/util/random.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/sampler.cpp
+++ b/model/util/sampler.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/sampler.h
+++ b/model/util/sampler.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/timeConversions.h
+++ b/model/util/timeConversions.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/timer.cpp
+++ b/model/util/timer.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/timer.h
+++ b/model/util/timer.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/vecDay.h
+++ b/model/util/vecDay.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/vectors.cpp
+++ b/model/util/vectors.cpp
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/model/util/vectors.h
+++ b/model/util/vectors.h
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/schema/scenario_43.xsd
+++ b/schema/scenario_43.xsd
@@ -5237,27 +5237,6 @@ restingKillingEffect: Reduction in the survival probability of the resting perio
           </xs:documentation>
           <xs:appinfo>name:Effect of need;</xs:appinfo>
         </xs:annotation>
-        <xs:complexType>
-          <xs:attribute name="onLocus" type="xs:string" use="required">
-            <xs:annotation>
-              <xs:documentation>
-                A locus under which only a restricted set of alleles map to
-                this phenotype.
-              </xs:documentation>
-              <xs:appinfo>name:Locus relevant to the mapping of alleles to this phenotype;</xs:appinfo>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="toAllele" type="xs:string" use="required">
-            <xs:annotation>
-              <xs:documentation>
-                One allele of a locus upon which phenotype choice depends.
-                If multiple alleles under this locus should map to the same
-                phenotype, repeat the whole &quot;restriction onLocus...&quot; element.
-              </xs:documentation>
-              <xs:appinfo>name:Alleles mapping to this phenotype;</xs:appinfo>
-            </xs:annotation>
-          </xs:attribute>
-        </xs:complexType>
       </xs:element>
       <xs:element name="effectInformal" type="xs:double">
         <xs:annotation>

--- a/schema/scenario_43.xsd
+++ b/schema/scenario_43.xsd
@@ -5237,6 +5237,27 @@ restingKillingEffect: Reduction in the survival probability of the resting perio
           </xs:documentation>
           <xs:appinfo>name:Effect of need;</xs:appinfo>
         </xs:annotation>
+        <xs:complexType>
+          <xs:attribute name="onLocus" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                A locus under which only a restricted set of alleles map to
+                this phenotype.
+              </xs:documentation>
+              <xs:appinfo>name:Locus relevant to the mapping of alleles to this phenotype;</xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="toAllele" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                One allele of a locus upon which phenotype choice depends.
+                If multiple alleles under this locus should map to the same
+                phenotype, repeat the whole &quot;restriction onLocus...&quot; element.
+              </xs:documentation>
+              <xs:appinfo>name:Alleles mapping to this phenotype;</xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
       </xs:element>
       <xs:element name="effectInformal" type="xs:double">
         <xs:annotation>

--- a/util/licence-template.txt
+++ b/util/licence-template.txt
@@ -1,7 +1,8 @@
 /* This file is part of OpenMalaria.
  * 
- * Copyright (C) 2005-2015 Swiss Tropical and Public Health Institute
+ * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
  * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
+ * Copyright (C) 2020-2021 University of Basel
  * 
  * OpenMalaria is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/util/update-header.py
+++ b/util/update-header.py
@@ -84,7 +84,7 @@ def update_source(filename, copyright):
         pass
     else:
         print(header)
-        r=eval(input("Remove above header? (y/N): "))
+        r=raw_input("Remove above header? (y/N): ")
         if r[0]=='y' or r[0]=='Y':
             oldheaders.add(header)
             fdata = fdata[len(header):]


### PR DESCRIPTION
- Update copyright dates for STPH
- Add University of Basel to the list of copyright holders

/* This file is part of OpenMalaria.
 * 
 * Copyright (C) 2005-2021 Swiss Tropical and Public Health Institute
 * Copyright (C) 2005-2015 Liverpool School Of Tropical Medicine
 * Copyright (C) 2020-2021 University of Basel
 * 
 * OpenMalaria is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or (at
 * your option) any later version.
 * 
 * This program is distributed in the hope that it will be useful, but
 * WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 * General Public License for more details.
 * 
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
 * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
