### PR TITLE
Remove SimTime

### DIFF
--- a/model/Clinical/CM5DayCommon.cpp
+++ b/model/Clinical/CM5DayCommon.cpp
@@ -53,7 +53,7 @@ void CM5DayCommon::init(){
 // ———  per-human, construction and destruction  ———
 
 CM5DayCommon::CM5DayCommon (double tSF) :
-        m_tLastTreatment (SimTime::never()),
+        m_tLastTreatment (sim::never()),
         m_treatmentSeekingFactor (tSF)
 {}
 
@@ -79,7 +79,7 @@ void CM5DayCommon::doClinicalUpdate (Human& human, double ageYears) {
     }
     
     if (pg.indirectMortality && doomed == NOT_DOOMED)
-        doomed = -SimTime::oneTS().inDays();
+        doomed = -sim::oneTS().inDays();
     
     if( m_tLastTreatment == sim::ts0() ){
         human.removeFirstEvent( interventions::SubPopRemove::ON_FIRST_TREATMENT );

--- a/model/Clinical/CM5DayCommon.cpp
+++ b/model/Clinical/CM5DayCommon.cpp
@@ -79,7 +79,7 @@ void CM5DayCommon::doClinicalUpdate (Human& human, double ageYears) {
     }
     
     if (pg.indirectMortality && doomed == NOT_DOOMED)
-        doomed = -sim::oneTS().inDays();
+        doomed = -sim::oneTS();
     
     if( m_tLastTreatment == sim::ts0() ){
         human.removeFirstEvent( interventions::SubPopRemove::ON_FIRST_TREATMENT );

--- a/model/Clinical/CM5DayCommon.h
+++ b/model/Clinical/CM5DayCommon.h
@@ -67,7 +67,7 @@ protected:
     /** Called when a non-severe/complicated malaria sickness occurs. */
     virtual void uncomplicatedEvent(Human& human, Episode::State pgState) =0;
     
-    /** Time of the last treatment (SimTime::never() if never treated). */
+    /** Time of the last treatment (sim::never() if never treated). */
     SimTime m_tLastTreatment;
 
     //! treatment seeking for heterogeneity

--- a/model/Clinical/CM5DayCommon.h
+++ b/model/Clinical/CM5DayCommon.h
@@ -68,7 +68,7 @@ protected:
     virtual void uncomplicatedEvent(Human& human, Episode::State pgState) =0;
     
     /** Time of the last treatment (sim::never() if never treated). */
-    SimTime m_tLastTreatment;
+    SimTime m_tLastTreatment = sim::never();
 
     //! treatment seeking for heterogeneity
     double m_treatmentSeekingFactor;

--- a/model/Clinical/CMDecisionTree.cpp
+++ b/model/Clinical/CMDecisionTree.cpp
@@ -329,13 +329,13 @@ private:
 class CMDTTreatSimple : public CMDecisionTree {
 public:
     CMDTTreatSimple( const scnXml::DTTreatSimple& elt ) :
-        timeLiver(SimTime::zero()), timeBlood(SimTime::zero())
+        timeLiver(sim::zero()), timeBlood(sim::zero())
     {
         //NOTE: this code is currently identical to that in SimpleTreatComponent
         try{
             SimTime durL = UnitParse::readShortDuration( elt.getDurationLiver(), UnitParse::NONE ),
                 durB = UnitParse::readShortDuration( elt.getDurationBlood(), UnitParse::NONE );
-            SimTime neg1 = -SimTime::oneTS();
+            SimTime neg1 = -sim::oneTS();
             if( durL < neg1 || durB < neg1 ){
                 throw util::xml_scenario_error( "treatSimple: cannot have durationBlood or durationLiver less than -1" );
             }

--- a/model/Clinical/ClinicalModel.cpp
+++ b/model/Clinical/ClinicalModel.cpp
@@ -137,7 +137,7 @@ bool ClinicalModel::isDead( SimTime age ){
 
 void ClinicalModel::update (Human& human, double ageYears, bool newBorn) {
     if (doomed < NOT_DOOMED)	// Countdown to indirect mortality
-        doomed -= sim::oneTS().inDays();
+        doomed -= sim::oneTS();
     
     //indirect death: if this human's about to die, don't worry about further episodes:
     if (doomed <= DOOMED_EXPIRED) {	//clinical bout 6 intervals before

--- a/model/Clinical/ClinicalModel.cpp
+++ b/model/Clinical/ClinicalModel.cpp
@@ -37,7 +37,7 @@ bool opt_event_scheduler = false;
 bool opt_imm_outcomes = false;
 
 bool ClinicalModel::indirectMortBugfix;
-SimTime ClinicalModel::healthSystemMemory{ SimTime::never() };
+SimTime ClinicalModel::healthSystemMemory{ sim::never() };
 
 //log odds ratio of case-fatality in community compared to hospital
 double oddsRatioThreshold;
@@ -137,7 +137,7 @@ bool ClinicalModel::isDead( SimTime age ){
 
 void ClinicalModel::update (Human& human, double ageYears, bool newBorn) {
     if (doomed < NOT_DOOMED)	// Countdown to indirect mortality
-        doomed -= SimTime::oneTS().inDays();
+        doomed -= sim::oneTS().inDays();
     
     //indirect death: if this human's about to die, don't worry about further episodes:
     if (doomed <= DOOMED_EXPIRED) {	//clinical bout 6 intervals before
@@ -159,8 +159,8 @@ void ClinicalModel::update (Human& human, double ageYears, bool newBorn) {
 
 void ClinicalModel::updateInfantDeaths( SimTime age ){
     // update array for the infant death rates
-    if (age < SimTime::oneYear()){
-        size_t index = age / SimTime::oneTS();
+    if (age < sim::oneYear()){
+        size_t index = age / sim::oneTS();
         
         // Testing doomed == DOOMED_NEXT_TS gives very slightly different results than
         // testing doomed == DOOMED_INDIRECT (due to above if(..))

--- a/model/Clinical/DecisionTree5Day.cpp
+++ b/model/Clinical/DecisionTree5Day.cpp
@@ -88,7 +88,7 @@ void DecisionTree5Day::uncomplicatedEvent ( Human& human, Episode::State pgState
     
     double x = human.rng().uniform_01();
     if( x < accessUCAny[regimen] * m_treatmentSeekingFactor ){
-        CMHostData hostData( human, human.age(sim::ts0()).inYears(), pgState );
+        CMHostData hostData( human, sim::inYears(human.age(sim::ts0())), pgState );
         
         // Run tree (which may deploy treatment)
         CMDTOut output = ( x < accessUCSelfTreat[regimen] * m_treatmentSeekingFactor ) ?

--- a/model/Clinical/Episode.cpp
+++ b/model/Clinical/Episode.cpp
@@ -32,7 +32,7 @@ Episode::~Episode ()
 
 void Episode::flush() {
     report();
-    time = SimTime::never();
+    time = sim::never();
 }
 
 
@@ -52,7 +52,7 @@ void Episode::update (const Host::Human& human, Episode::State newState)
 }
 
 void Episode::report () {
-    if (time < SimTime::zero())        // Nothing to report
+    if (time < sim::zero())        // Nothing to report
         return;
     
     // Reports malarial/non-malarial UC fever dependent on cause, not diagnosis.
@@ -105,7 +105,7 @@ void Episode::report () {
 
 void Episode::operator& (istream& stream) {
     time & stream;
-    if (time > SimTime::zero()) {
+    if (time > sim::zero()) {
         surveyPeriod & stream;
         ageGroup & stream;
         cohortSet & stream;
@@ -116,7 +116,7 @@ void Episode::operator& (istream& stream) {
 }
 void Episode::operator& (ostream& stream) {
     time & stream;
-    if (time >= SimTime::zero()) {
+    if (time >= sim::zero()) {
         surveyPeriod & stream;
         ageGroup & stream;
         cohortSet & stream;

--- a/model/Clinical/Episode.h
+++ b/model/Clinical/Episode.h
@@ -109,7 +109,7 @@ private:
     void report();
     
     /// Time of event, potentially never
-    SimTime time;
+    SimTime time = sim::never();
     /// Survey during which the event occured
     size_t surveyPeriod;
     /// Age group of the individual when the episode's first bout occurred

--- a/model/Clinical/Episode.h
+++ b/model/Clinical/Episode.h
@@ -76,7 +76,7 @@ public:
     };
     
     Episode() :
-            time(SimTime::never()),
+            time(sim::never()),
             surveyPeriod(mon::NOT_USED),
             ageGroup(),
             cohortSet(0),

--- a/model/Clinical/EventScheduler.cpp
+++ b/model/Clinical/EventScheduler.cpp
@@ -378,7 +378,7 @@ void ClinicalEventScheduler::doClinicalUpdate (Human& human, double ageYears){
 		if (human.rng().uniform_01() < pDeath) {
 		    pgState = Episode::State (pgState | Episode::DIRECT_DEATH);
 		    // Human is killed at end of time at risk
-		    timeOfRecovery += extraDaysAtRisk;	// may be re-set later (see ATORWD)
+		    timeOfRecovery = timeOfRecovery + extraDaysAtRisk;	// may be re-set later (see ATORWD)
 		}
 	    }
 	    previousDensity = withinHostModel.getTotalDensity();
@@ -403,7 +403,7 @@ void ClinicalEventScheduler::doClinicalUpdate (Human& human, double ageYears){
 	    timeOfRecovery = sim::ts0() + complicatedCaseDuration;
 	    // Time should be adjusted to end of at-risk period when patient dies:
 	    if( pgState & Episode::DIRECT_DEATH )	// death may already have been determined
-		timeOfRecovery += extraDaysAtRisk;	// ATORWD (search keyword)
+		timeOfRecovery = timeOfRecovery + extraDaysAtRisk;	// ATORWD (search keyword)
 	} else {
 	    timeOfRecovery = sim::ts0() + uncomplicatedCaseDuration;
 	}

--- a/model/Clinical/EventScheduler.cpp
+++ b/model/Clinical/EventScheduler.cpp
@@ -32,10 +32,10 @@
 namespace OM { namespace Clinical {
     using namespace OM::util;
 
-SimTime ClinicalEventScheduler::maxUCSeekingMemory(SimTime::never());
-SimTime ClinicalEventScheduler::uncomplicatedCaseDuration(SimTime::never());
-SimTime ClinicalEventScheduler::complicatedCaseDuration(SimTime::never());
-SimTime ClinicalEventScheduler::extraDaysAtRisk(SimTime::never());
+SimTime ClinicalEventScheduler::maxUCSeekingMemory(sim::never());
+SimTime ClinicalEventScheduler::uncomplicatedCaseDuration(sim::never());
+SimTime ClinicalEventScheduler::complicatedCaseDuration(sim::never());
+SimTime ClinicalEventScheduler::extraDaysAtRisk(sim::never());
 vector<double> ClinicalEventScheduler::cumDailyPrImmUCTS;
 double ClinicalEventScheduler::neg_v;
 double ClinicalEventScheduler::alpha;
@@ -57,7 +57,7 @@ AgeGroupInterpolator ClinicalEventScheduler::MF_need_antibiotic;
 
 void ClinicalEventScheduler::init( const Parameters& parameters, const scnXml::Clinical& clinical )
 {
-    if( SimTime::oneTS() != SimTime::oneDay() )
+    if( sim::oneTS() != sim::oneDay() )
         throw util::xml_scenario_error ("ClinicalEventScheduler is only designed for a 1-day time step.");
     
     opt_non_malaria_fevers = util::ModelOptions::option( util::NON_MALARIA_FEVERS );
@@ -89,15 +89,15 @@ void ClinicalEventScheduler::init( const Parameters& parameters, const scnXml::C
 void ClinicalEventScheduler::setParameters(const scnXml::HSEventScheduler& esData) {
     const scnXml::ClinicalOutcomes& coData = esData.getClinicalOutcomes();
     
-    maxUCSeekingMemory = SimTime::fromDays(coData.getMaxUCSeekingMemory());
-    uncomplicatedCaseDuration = SimTime::fromDays(coData.getUncomplicatedCaseDuration());
-    complicatedCaseDuration = SimTime::fromDays(coData.getComplicatedCaseDuration());
-    extraDaysAtRisk = SimTime::fromDays(coData.getComplicatedRiskDuration()) - complicatedCaseDuration;
-    if( uncomplicatedCaseDuration < SimTime::fromDays(1)
-	|| complicatedCaseDuration < SimTime::fromDays(1)
-	|| maxUCSeekingMemory < SimTime::zero()
-	|| extraDaysAtRisk + complicatedCaseDuration < SimTime::fromDays(1) // at risk at least 1 day
-	|| extraDaysAtRisk > SimTime::zero()        // at risk longer than case duration
+    maxUCSeekingMemory = sim::fromDays(coData.getMaxUCSeekingMemory());
+    uncomplicatedCaseDuration = sim::fromDays(coData.getUncomplicatedCaseDuration());
+    complicatedCaseDuration = sim::fromDays(coData.getComplicatedCaseDuration());
+    extraDaysAtRisk = sim::fromDays(coData.getComplicatedRiskDuration()) - complicatedCaseDuration;
+    if( uncomplicatedCaseDuration < sim::fromDays(1)
+	|| complicatedCaseDuration < sim::fromDays(1)
+	|| maxUCSeekingMemory < sim::zero()
+	|| extraDaysAtRisk + complicatedCaseDuration < sim::fromDays(1) // at risk at least 1 day
+	|| extraDaysAtRisk > sim::zero()        // at risk longer than case duration
     ){
 	throw util::xml_scenario_error(
             "Clinical outcomes: constraints on case/risk/memory duration not met (see documentation)");
@@ -138,9 +138,9 @@ void ClinicalEventScheduler::setParameters(const scnXml::HSEventScheduler& esDat
 
 ClinicalEventScheduler::ClinicalEventScheduler (double tSF) :
         pgState (Episode::NONE),
-        caseStartTime (SimTime::never()),
-        timeOfRecovery (SimTime::never()),
-        timeLastTreatment (SimTime::never()),
+        caseStartTime (sim::never()),
+        timeOfRecovery (sim::never()),
+        timeLastTreatment (sim::never()),
         previousDensity (numeric_limits<double>::quiet_NaN())
 {
     if( tSF != 1.0 ){
@@ -231,13 +231,13 @@ void ClinicalEventScheduler::doClinicalUpdate (Human& human, double ageYears){
                     assert(false);      // should have uVariate < 1 = cumDailyPrImmUCTS[len-1]
                     gotDelay:
                     // set start time: current time plus length of delay (days)
-                    caseStartTime = sim::ts0() + SimTime::fromDays(i);
+                    caseStartTime = sim::ts0() + sim::fromDays(i);
                 }
             }
         }
         
         if (indirectMortality && doomed == NOT_DOOMED)
-            doomed = -SimTime::oneTS().inDays(); // start indirect mortality countdown
+            doomed = -sim::oneTS().inDays(); // start indirect mortality countdown
     }
     
     if( caseStartTime == sim::ts0() && (pgState & Episode::RUN_CM_TREE) ){

--- a/model/Clinical/EventScheduler.cpp
+++ b/model/Clinical/EventScheduler.cpp
@@ -237,7 +237,7 @@ void ClinicalEventScheduler::doClinicalUpdate (Human& human, double ageYears){
         }
         
         if (indirectMortality && doomed == NOT_DOOMED)
-            doomed = -sim::oneTS().inDays(); // start indirect mortality countdown
+            doomed = -sim::oneTS(); // start indirect mortality countdown
     }
     
     if( caseStartTime == sim::ts0() && (pgState & Episode::RUN_CM_TREE) ){

--- a/model/Clinical/EventScheduler.h
+++ b/model/Clinical/EventScheduler.h
@@ -120,14 +120,14 @@ private:
      * is started (UC & severe behaviour different).
      *
      * Note: medications are not delayed by this. */
-    SimTime caseStartTime;
+    SimTime caseStartTime = sim::never();
 
     /** The individual recovers when sim::ts0() >= timeOfRecovery,
      * assuming they didn't die. */
-    SimTime timeOfRecovery;
+    SimTime timeOfRecovery = sim::never();
 
     /// Time at which last treatment was recieved (for second-case considerations).
-    SimTime timeLastTreatment;
+    SimTime timeLastTreatment = sim::never();
 
     /// Total parasite density at last time step (used during a bout).
     double previousDensity;

--- a/model/Host/Human.cpp
+++ b/model/Host/Human.cpp
@@ -67,7 +67,7 @@ Human::Human(SimTime dateOfBirth) :
     nextCtsDist(0)
 {
     // Initial humans are created at time 0 and may have DOB in past. Otherwise DOB must be now.
-    assert( m_DOB == sim::nowOrTs1() || (sim::now() == SimTime::zero() && m_DOB < sim::now()) );
+    assert( m_DOB == sim::nowOrTs1() || (sim::now() == sim::zero() && m_DOB < sim::now()) );
     
     HumanHet het = HumanHet::sample(m_rng);
     withinHostModel = WithinHost::WHInterface::createWithinHostModel( m_rng, het.comorbidityFactor );
@@ -131,7 +131,7 @@ void Human::update(Transmission::TransmissionModel& transmission) {
             _vaccine.getFactor(interventions::Vaccine::BSV));
     
     // ageYears1 used to get case fatality and sequelae probabilities, determine pathogenesis
-    clinicalModel->update( *this, ageYears1, age0 == SimTime::zero() );
+    clinicalModel->update( *this, ageYears1, age0 == sim::zero() );
     clinicalModel->updateInfantDeaths( age0 );
 }
 
@@ -163,7 +163,7 @@ void Human::summarize() {
 }
 
 void Human::reportDeployment( ComponentId id, SimTime duration ){
-    if( duration <= SimTime::zero() ) return; // nothing to do
+    if( duration <= sim::zero() ) return; // nothing to do
     m_subPopExp[id] = sim::nowOrTs1() + duration;
     m_cohortSet = mon::updateCohortSet( m_cohortSet, id, true );
 }

--- a/model/Host/Human.cpp
+++ b/model/Host/Human.cpp
@@ -100,7 +100,7 @@ void Human::update(Transmission::TransmissionModel& transmission) {
         return;
     }
     
-    util::streamValidate( age0.inDays() );
+    util::streamValidate( age0 );
     // Age at  the end of the update period. In most cases
     // the difference between this and age at the start is not especially
     // important in the model design, but since we parameterised with

--- a/model/Host/Human.cpp
+++ b/model/Host/Human.cpp
@@ -105,7 +105,7 @@ void Human::update(Transmission::TransmissionModel& transmission) {
     // the difference between this and age at the start is not especially
     // important in the model design, but since we parameterised with
     // ageYears1 we should stick with it.
-    double ageYears1 = age(sim::ts1()).inYears();
+    double ageYears1 = sim::inYears(age(sim::ts1()));
     // monitoringAgeGroup is the group for the start of the time step.
     monitoringAgeGroup.update( age0 );
     // check sub-pop expiry
@@ -152,7 +152,7 @@ void Human::summarize() {
     }
     
     mon::reportStatMHI( mon::MHR_HOSTS, *this, 1 );
-    mon::reportStatMHF( mon::MHF_AGE, *this, age(sim::now()).inYears() );
+    mon::reportStatMHF( mon::MHF_AGE, *this, sim::inYears(age(sim::now())) );
     bool patent = withinHostModel->summarize (*this);
     infIncidence->summarize (*this);
     

--- a/model/Host/Human.h
+++ b/model/Host/Human.h
@@ -201,7 +201,7 @@ private:
   
   LocalRng m_rng;
   
-  SimTime m_DOB;        // date of birth; humans are always born at the end of a time step
+  SimTime m_DOB = sim::never();        // date of birth; humans are always born at the end of a time step
   bool m_remove;    // TODO: we only need this because dead-person replacement can be delayed by 2 steps
   
   /// Vaccines

--- a/model/Host/ImportedInfections.cpp
+++ b/model/Host/ImportedInfections.cpp
@@ -31,7 +31,7 @@ void ImportedInfections::init( const scnXml::ImportedInfections& iiElt ){
     try{
         //NOTE: if changing XSD, this should not have a default unit:
         period = UnitParse::readDuration( tElt.getPeriod(), UnitParse::STEPS );
-        if( period < SimTime::zero() ){
+        if( period < sim::zero() ){
             throw util::format_error( "cannot be negative" );
         }
     }catch( const util::format_error& e ){
@@ -40,14 +40,14 @@ void ImportedInfections::init( const scnXml::ImportedInfections& iiElt ){
     rate.reserve( tElt.getRate().size() );
     try{
         for( auto it = tElt.getRate().begin(); it != tElt.getRate().end(); ++it ){
-            SimDate date = UnitParse::readDate( it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/ );
+            SimTime date = UnitParse::readDate( it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/ );
             // convert to per-time-step, per-person
             double rateVal = it->getValue() * sim::yearsPerStep() * (1.0 / 1000.0);
             rate.push_back( Rate( date - sim::startDate(), rateVal ) );
         }
         sort( rate.begin(), rate.end() );
         if( rate.size() > 0 ){
-            if( period != SimTime::zero() && rate[0].time != SimTime::zero() ){
+            if( period != sim::zero() && rate[0].time != sim::zero() ){
                 throw util::xml_scenario_error( "must specify rate at time zero when period is not zero" );
             }
             // remove useless repeated entries from list
@@ -69,8 +69,8 @@ void ImportedInfections::init( const scnXml::ImportedInfections& iiElt ){
 void ImportedInfections::import( Population& population ){
     if( rate.size() == 0 ) return;      // no imported infections
     SimTime now = sim::intervTime();
-    assert( now >= SimTime::zero() );
-    if( period > SimTime::zero() ){
+    assert( now >= sim::zero() );
+    if( period > sim::zero() ){
         now = mod_nn(now, period);
     }
     if( rate[lastIndex].time > now ){

--- a/model/Host/ImportedInfections.h
+++ b/model/Host/ImportedInfections.h
@@ -61,11 +61,11 @@ namespace Host {
         }
         
     private:
-        SimTime period;
+        SimTime period = sim::never();
         uint32_t lastIndex;
         struct Rate {
             Rate( SimTime t, double v ): time(t), value(v) {}
-            SimTime time;
+            SimTime time = sim::never();
             double value;
             inline bool operator< (const Rate& that) const{
                 return time < that.time;

--- a/model/Host/ImportedInfections.h
+++ b/model/Host/ImportedInfections.h
@@ -32,7 +32,7 @@ namespace Host {
 
     class ImportedInfections {
     public:
-        ImportedInfections() : period(SimTime::zero()), lastIndex(0) {}
+        ImportedInfections() : period(sim::zero()), lastIndex(0) {}
         
         /** Initialise, passing intervention description
          * 

--- a/model/Host/InfectionIncidenceModel.cpp
+++ b/model/Host/InfectionIncidenceModel.cpp
@@ -175,12 +175,12 @@ double InfectionIncidenceModel::getModelExpectedInfections (LocalRng& rng, doubl
   // First two lines are availability adjustment: S_1(i,t) from AJTMH 75 (suppl 2) p12 eqn. (5)
   // Note that NegBinomMAII and LogNormalMAII supercede this model; see below
   return (Sinf+(1-Sinf) / 
-    (1 + effectiveEIR/sim::oneTS().inDays()*EstarInv)) *
+    (1 + effectiveEIR/sim::oneTS()*EstarInv)) *
     susceptibility() * effectiveEIR;
 }
 double HeterogeneityWorkaroundII::getModelExpectedInfections (LocalRng& rng, double effectiveEIR, const Transmission::PerHost& phTrans) {
   return (Sinf+(1-Sinf) / 
-    (1 + effectiveEIR/(sim::oneTS().inDays()*phTrans.relativeAvailabilityHet())*EstarInv)) *
+    (1 + effectiveEIR/(sim::oneTS()*phTrans.relativeAvailabilityHet())*EstarInv)) *
     susceptibility() * effectiveEIR;
 }
 double NegBinomMAII::getModelExpectedInfections (LocalRng& rng, double effectiveEIR, const Transmission::PerHost&) {

--- a/model/Host/InfectionIncidenceModel.cpp
+++ b/model/Host/InfectionIncidenceModel.cpp
@@ -175,12 +175,12 @@ double InfectionIncidenceModel::getModelExpectedInfections (LocalRng& rng, doubl
   // First two lines are availability adjustment: S_1(i,t) from AJTMH 75 (suppl 2) p12 eqn. (5)
   // Note that NegBinomMAII and LogNormalMAII supercede this model; see below
   return (Sinf+(1-Sinf) / 
-    (1 + effectiveEIR/SimTime::oneTS().inDays()*EstarInv)) *
+    (1 + effectiveEIR/sim::oneTS().inDays()*EstarInv)) *
     susceptibility() * effectiveEIR;
 }
 double HeterogeneityWorkaroundII::getModelExpectedInfections (LocalRng& rng, double effectiveEIR, const Transmission::PerHost& phTrans) {
   return (Sinf+(1-Sinf) / 
-    (1 + effectiveEIR/(SimTime::oneTS().inDays()*phTrans.relativeAvailabilityHet())*EstarInv)) *
+    (1 + effectiveEIR/(sim::oneTS().inDays()*phTrans.relativeAvailabilityHet())*EstarInv)) *
     susceptibility() * effectiveEIR;
 }
 double NegBinomMAII::getModelExpectedInfections (LocalRng& rng, double effectiveEIR, const Transmission::PerHost&) {

--- a/model/Host/NeonatalMortality.cpp
+++ b/model/Host/NeonatalMortality.cpp
@@ -60,7 +60,7 @@ const WithinHost::Diagnostic* neonatalDiagnostic = 0;
 
 void NeonatalMortality::init( const scnXml::Clinical& clinical ){
     SimTime fiveMonths = sim::fromDays( 5 * 30 );
-    prevByGestationalAge.assign( fiveMonths.inSteps(), 0.0 );
+    prevByGestationalAge.assign( sim::inSteps(fiveMonths), 0.0 );
     
     if( clinical.getNeonatalMortality().present() ){
         neonatalDiagnostic = &WithinHost::diagnostics::get(
@@ -120,7 +120,7 @@ void NeonatalMortality::update (Population& population) {
     
     double maxPrev = prev2025;
     //update the vector containing the prevalence by gestational age
-    size_t index = sim::ts0().moduloSteps(prevByGestationalAge.size());
+    size_t index = sim::moduloSteps(sim::ts0(), prevByGestationalAge.size());
     prevByGestationalAge[index] = prev2025;
     for(size_t i = 0; i < prevByGestationalAge.size(); ++i) {
         if (prevByGestationalAge[i] > maxPrev) {

--- a/model/Host/NeonatalMortality.cpp
+++ b/model/Host/NeonatalMortality.cpp
@@ -51,7 +51,7 @@ double riskFromMaternalInfection = 0.0;
 std::vector<double> prevByGestationalAge;
 
 /// Lower and upper bounds for potential mothers (as in model description)
-SimTime ageLb = SimTime::fromYearsI(20), ageUb = SimTime::fromYearsI(25);
+SimTime ageLb = sim::fromYearsI(20), ageUb = sim::fromYearsI(25);
 
 // The model is parameterised based on patency levels; the diagnostic
 // used for this may be important.
@@ -59,7 +59,7 @@ const WithinHost::Diagnostic* neonatalDiagnostic = 0;
 
 
 void NeonatalMortality::init( const scnXml::Clinical& clinical ){
-    SimTime fiveMonths = SimTime::fromDays( 5 * 30 );
+    SimTime fiveMonths = sim::fromDays( 5 * 30 );
     prevByGestationalAge.assign( fiveMonths.inSteps(), 0.0 );
     
     if( clinical.getNeonatalMortality().present() ){

--- a/model/Population.cpp
+++ b/model/Population.cpp
@@ -117,7 +117,7 @@ void Population::checkpoint (istream& stream)
     for(size_t i = 0; i < populationSize && !stream.eof(); ++i) {
         // Note: calling this constructor of Host::Human is slightly wasteful, but avoids the need for another
         // ctor and leaves less opportunity for uninitialized memory.
-        population.push_back( Host::Human (SimTime::zero()) );
+        population.push_back( Host::Human (sim::zero()) );
         population.back() & stream;
     }
     if (population.size() != populationSize)
@@ -153,7 +153,7 @@ void Population::createInitialHumans()
     {
         int targetPop = AgeStructure::targetCumPop( iage, populationSize );
         while (cumulativePop < targetPop) {
-            SimTime dob = SimTime::zero() - SimTime::fromTS(iage);
+            SimTime dob = sim::zero() - sim::fromTS(iage);
             util::streamValidate( dob.inDays() );
             population.push_back( Host::Human (dob) );
             ++cumulativePop;
@@ -162,7 +162,7 @@ void Population::createInitialHumans()
     
     // Vector setup dependant on human population structure (we *want* to
     // include all humans, whether they'll survive to vector init phase or not).
-    assert( sim::now() == SimTime::zero() );      // assumed below
+    assert( sim::now() == sim::zero() );      // assumed below
 }
 
 
@@ -320,7 +320,7 @@ void Population::ctsGVICoverage (ostream& stream){
 //     double meanVar = 0.0;
 //     int nNets = 0;
 //     for(Iter iter = population.begin(); iter != population.end(); ++iter) {
-//         if( iter->perHostTransmission.getITN().timeOfDeployment() >= SimTime::zero() ){
+//         if( iter->perHostTransmission.getITN().timeOfDeployment() >= sim::zero() ){
 //             ++nNets;
 //             meanVar += iter->perHostTransmission.getITN().getHoleIndex();
 //         }

--- a/model/Population.cpp
+++ b/model/Population.cpp
@@ -199,7 +199,7 @@ void Population::update(Transmission::TransmissionModel& transmission, SimTime f
         // "outmigrate" some to maintain population shape
         //NOTE: better to use age(sim::ts0())? Possibly, but the difference will not be very significant.
         // Also see targetPop = ... comment above
-        bool outmigrate = cumPop >= AgeStructure::targetCumPop(iter->age(sim::ts1()).inSteps(), targetPop);
+        bool outmigrate = cumPop >= AgeStructure::targetCumPop(sim::inSteps(iter->age(sim::ts1())), targetPop);
         
         if( isDead || outmigrate ){
             iter = population.erase (iter);
@@ -229,7 +229,7 @@ void Population::ctsHostDemography (ostream& stream){
     auto iter = population.crbegin();
     int cumCount = 0;
     for( double ubound : ctsDemogAgeGroups ){
-        while( iter != population.crend() && iter->age(sim::now()).inYears() < ubound ){
+        while( iter != population.crend() && sim::inYears(iter->age(sim::now())) < ubound ){
             ++cumCount;
             ++iter;
         }
@@ -287,7 +287,7 @@ void Population::ctsMeanAgeAvailEffect (ostream& stream){
     for(Iter iter = population.begin(); iter != population.end(); ++iter) {
         if( !iter->perHostTransmission.isOutsideTransmission() ){
             ++nHumans;
-            avail += iter->perHostTransmission.relativeAvailabilityAge(iter->age(sim::now()).inYears());
+            avail += iter->perHostTransmission.relativeAvailabilityAge(sim::inYears(iter->age(sim::now())));
         }
     }
     stream << '\t' << avail/nHumans;

--- a/model/Population.cpp
+++ b/model/Population.cpp
@@ -154,7 +154,7 @@ void Population::createInitialHumans()
         int targetPop = AgeStructure::targetCumPop( iage, populationSize );
         while (cumulativePop < targetPop) {
             SimTime dob = sim::zero() - sim::fromTS(iage);
-            util::streamValidate( dob.inDays() );
+            util::streamValidate( dob );
             population.push_back( Host::Human (dob) );
             ++cumulativePop;
         }

--- a/model/PopulationAgeStructure.cpp
+++ b/model/PopulationAgeStructure.cpp
@@ -211,7 +211,7 @@ void AgeStructure::calcCumAgeProp ()
 {
     cumAgeProp[0] = 0.0;
     for(size_t j=1;j < cumAgeProp.size(); ++j) {
-	SimTime age = SimTime::fromTS( cumAgeProp.size() - j - 1 );
+	SimTime age = sim::fromTS( cumAgeProp.size() - j - 1 );
 	double ageYears = age.inYears();
 	double M1s = (mu0 * (1.0 - exp (-alpha0 * ageYears)) / alpha0);
 	double M2s = (mu1 * (exp (alpha1 * ageYears) - 1.0) / alpha1);

--- a/model/PopulationAgeStructure.cpp
+++ b/model/PopulationAgeStructure.cpp
@@ -46,7 +46,7 @@ vector<double> AgeStructure::cumAgeProp;
 
 void AgeStructure::init( const scnXml::Demography& demography ){
     // this number of cells are needed:
-    cumAgeProp.resize( sim::maxHumanAge().inSteps() + 1 );
+    cumAgeProp.resize( sim::inSteps(sim::maxHumanAge()) + 1 );
     
     estimateRemovalRates( demography );
     calcCumAgeProp();
@@ -212,7 +212,7 @@ void AgeStructure::calcCumAgeProp ()
     cumAgeProp[0] = 0.0;
     for(size_t j=1;j < cumAgeProp.size(); ++j) {
 	SimTime age = sim::fromTS( cumAgeProp.size() - j - 1 );
-	double ageYears = age.inYears();
+	double ageYears = sim::inYears(age);
 	double M1s = (mu0 * (1.0 - exp (-alpha0 * ageYears)) / alpha0);
 	double M2s = (mu1 * (exp (alpha1 * ageYears) - 1.0) / alpha1);
 	double Ms = M1s + M2s;

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -214,7 +214,7 @@ void AnophelesModel::initEIR(vector<double> &initialisationEIR, vector<double> F
 
     // Add to the TransmissionModel's EIR, used for the initalization phase.
     // Note: sum stays the same, units changes to per-time-step.
-    for (SimTime i = sim::zero(); i < sim::oneYear(); i += sim::oneDay())
+    for (SimTime i = sim::zero(); i < sim::oneYear(); i = i + sim::oneDay())
         initialisationEIR[mod_nn(sim::inSteps(i), sim::stepsPerYear())] += speciesEIR[i];
 
     if (util::CommandLine::option(util::CommandLine::PRINT_ANNUAL_EIR))
@@ -526,7 +526,7 @@ void AnophelesModel::advancePeriod(double sum_avail, double sigma_df, vector<dou
     // The code within the for loop needs to run per-day, wheras the main
     // simulation uses one or five day time steps.
     const SimTime nextTS = sim::ts0() + sim::oneTS();
-    for (SimTime d0 = sim::ts0(); d0 < nextTS; d0 += sim::oneDay())
+    for (SimTime d0 = sim::ts0(); d0 < nextTS; d0 = d0 + sim::oneDay())
     {
         update(d0, tsP_A, tsP_Amu, tsP_A1, tsP_Ah, tsP_df, sigma_dif, tsP_dff, isDynamic, partialEIR, availDivisor);
     }

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -215,7 +215,7 @@ void AnophelesModel::initEIR(vector<double> &initialisationEIR, vector<double> F
     // Add to the TransmissionModel's EIR, used for the initalization phase.
     // Note: sum stays the same, units changes to per-time-step.
     for (SimTime i = sim::zero(); i < sim::oneYear(); i += sim::oneDay())
-        initialisationEIR[mod_nn(i.inSteps(), sim::stepsPerYear())] += speciesEIR[i];
+        initialisationEIR[mod_nn(sim::inSteps(i), sim::stepsPerYear())] += speciesEIR[i];
 
     if (util::CommandLine::option(util::CommandLine::PRINT_ANNUAL_EIR))
         cout << "Annual EIR for " << mosq.name << ": " << vectors::sum(speciesEIR) << endl;

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -45,22 +45,22 @@ void AnophelesModel::initialise(size_t species, MosquitoParams mosqParams)
 {
     mosq = mosqParams;
 
-    N_v_length = (mosq.EIPDuration + mosq.restDuration).inDays();
+    N_v_length = (mosq.EIPDuration + mosq.restDuration);
 
     // -----  allocate memory  -----
     // Set up fArray and ftauArray. Each step, all elements not set here are
     // calculated, even if they aren't directly used in the end;
     // however all calculated values are used in calculating the next value.
-    fArray.resize((mosq.EIPDuration - mosq.restDuration + sim::oneDay()).inDays());
-    fArray[sim::zero().inDays()] = 1.0;
-    ftauArray.resize(mosq.EIPDuration.inDays());
-    for (int i = 0; i < mosq.restDuration.inDays(); i += 1)
+    fArray.resize((mosq.EIPDuration - mosq.restDuration + sim::oneDay()));
+    fArray[sim::zero()] = 1.0;
+    ftauArray.resize(mosq.EIPDuration);
+    for (int i = 0; i < mosq.restDuration; i += 1)
     {
         ftauArray[i] = 0.0;
     }
-    ftauArray[mosq.restDuration.inDays()] = 1.0;
+    ftauArray[mosq.restDuration] = 1.0;
     uninfected_v.resize(N_v_length);
-    uninfected_v[sim::zero().inDays()] = numeric_limits<double>::quiet_NaN(); // index not used
+    uninfected_v[sim::zero()] = numeric_limits<double>::quiet_NaN(); // index not used
 }
 
 void AnophelesModel::initAvailability(size_t species, const vector<NhhParams> &nhhs, int populationSize)
@@ -201,7 +201,7 @@ void AnophelesModel::initEIR(vector<double> &initialisationEIR, vector<double> F
     double targetEIR = targetEIRInit;
 
     // EIR for this species, with index 0 refering to value over first interval
-    std::vector<double> speciesEIR(sim::oneYear().inDays());
+    std::vector<double> speciesEIR(sim::oneYear());
 
     // Now we rescale to get an EIR of targetEIR.
     // Calculate current sum as is usually done.
@@ -215,7 +215,7 @@ void AnophelesModel::initEIR(vector<double> &initialisationEIR, vector<double> F
     // Add to the TransmissionModel's EIR, used for the initalization phase.
     // Note: sum stays the same, units changes to per-time-step.
     for (SimTime i = sim::zero(); i < sim::oneYear(); i += sim::oneDay())
-        initialisationEIR[mod_nn(i.inSteps(), sim::stepsPerYear())] += speciesEIR[i.inDays()];
+        initialisationEIR[mod_nn(i.inSteps(), sim::stepsPerYear())] += speciesEIR[i];
 
     if (util::CommandLine::option(util::CommandLine::PRINT_ANNUAL_EIR))
         cout << "Annual EIR for " << mosq.name << ": " << vectors::sum(speciesEIR) << endl;
@@ -539,15 +539,15 @@ void AnophelesModel::update(SimTime d0, double tsP_A, double tsP_Amu, double tsP
     for (size_t i = 0; i < emergenceReduction.size(); ++i)
         interventionSurvival *= 1.0 - emergenceReduction[i].current_value(sim::ts0());
 
-    int d1 = d0.inDays() + 1; //sim::oneDay(); // end of step
+    int d1 = d0 + 1; //sim::oneDay(); // end of step
 
     // We add N_v_length so that we can use mod_nn() instead of mod().
     int d1Mod = d1 + N_v_length;
     assert(d1Mod >= N_v_length);
     // Indecies for end time, start time, and mosqRestDuration days before end time:
     int t1 = util::mod_nn(d1, N_v_length);
-    int t0 = util::mod_nn(d0.inDays(), N_v_length);
-    int ttau = util::mod_nn(d1Mod - mosq.restDuration.inDays(), N_v_length);
+    int t0 = util::mod_nn(d0, N_v_length);
+    int ttau = util::mod_nn(d1Mod - mosq.restDuration, N_v_length);
 
     // These only need to be calculated once per time step, but should be
     // present in each of the previous N_v_length - 1 positions of arrays.
@@ -562,33 +562,33 @@ void AnophelesModel::update(SimTime d0, double tsP_A, double tsP_Amu, double tsP
 
     // BEGIN cache calculation: fArray, ftauArray, uninfected_v
     // Set up array with n in 1..θ_s−τ for f(d1Mod-n) (NDEMD eq. 1.6)
-    for (int n = 1; n <= mosq.restDuration.inDays(); n ++)
+    for (int n = 1; n <= mosq.restDuration; n ++)
     {
         const int tn = util::mod_nn(d1Mod - n, N_v_length);
         fArray[n] = fArray[n - 1] * P_A[tn];
     }
-    fArray[mosq.restDuration.inDays()] += P_df[ttau];
+    fArray[mosq.restDuration] += P_df[ttau];
 
-    const int fAEnd = mosq.EIPDuration.inDays() - mosq.restDuration.inDays();
-    for (int n = mosq.restDuration.inDays() + 1; n <= fAEnd; n++)
+    const int fAEnd = mosq.EIPDuration - mosq.restDuration;
+    for (int n = mosq.restDuration + 1; n <= fAEnd; n++)
     {
         const int tn = util::mod_nn(d1Mod - n, N_v_length);
-        fArray[n] = P_df[tn] * fArray[n - mosq.restDuration.inDays()] + P_A[tn] * fArray[n - 1];
+        fArray[n] = P_df[tn] * fArray[n - mosq.restDuration] + P_A[tn] * fArray[n - 1];
     }
 
     // Set up array with n in 1..θ_s−1 for f_τ(d1Mod-n) (NDEMD eq. 1.7)
-    const int fProdEnd = mosq.restDuration.inDays() * 2;
-    for (int n = mosq.restDuration.inDays() + 1; n <= fProdEnd; n++)
+    const int fProdEnd = mosq.restDuration * 2;
+    for (int n = mosq.restDuration + 1; n <= fProdEnd; n++)
     {
         int tn = util::mod_nn(d1Mod - n, N_v_length);
         ftauArray[n] = ftauArray[n - 1] * P_A[tn];
     }
     ftauArray[fProdEnd] += P_df[util::mod_nn(d1Mod - fProdEnd, N_v_length)];
 
-    for (int n = fProdEnd + 1; n < mosq.EIPDuration.inDays(); n++)
+    for (int n = fProdEnd + 1; n < mosq.EIPDuration; n++)
     {
         int tn = util::mod_nn(d1Mod - n, N_v_length);
-        ftauArray[n] = P_df[tn] * ftauArray[n - mosq.restDuration.inDays()] + P_A[tn] * ftauArray[n - 1];
+        ftauArray[n] = P_df[tn] * ftauArray[n - mosq.restDuration] + P_A[tn] * ftauArray[n - 1];
     }
 
     for (int d = 1; d < N_v_length; d++)
@@ -610,20 +610,20 @@ void AnophelesModel::update(SimTime d0, double tsP_A, double tsP_Amu, double tsP
         // found a host tau days ago and survived a feeding cycle.
         // O_v.at(t1, genotype) = P_dif.at(ttau, genotype) * uninfected_v[mosq.restDuration] + P_A[t0] * O_v.at(t0, genotype) +
         //                        P_df[ttau] * O_v.at(ttau, genotype);
-        O_v[t1 * Genotypes::N() + genotype] = P_dif[ttau * Genotypes::N() + genotype] * uninfected_v[mosq.restDuration.inDays()] + P_A[t0] * O_v[t0 * Genotypes::N() + genotype] +
+        O_v[t1 * Genotypes::N() + genotype] = P_dif[ttau * Genotypes::N() + genotype] * uninfected_v[mosq.restDuration] + P_A[t0] * O_v[t0 * Genotypes::N() + genotype] +
                                P_df[ttau] * O_v[ttau * Genotypes::N() + genotype];            
         // BEGIN S_v
         double sum = 0.0;
-        const int ts = d1Mod - mosq.EIPDuration.inDays();
-        for (int l = 1; l < mosq.restDuration.inDays(); l++)
+        const int ts = d1Mod - mosq.EIPDuration;
+        for (int l = 1; l < mosq.restDuration; l++)
         {
             const int tsl = util::mod_nn(ts - l, N_v_length); // index d1Mod - theta_s - l
-            sum += P_dif[tsl * Genotypes::N() + genotype] * P_df[ttau] * (uninfected_v[mosq.EIPDuration.inDays() + l]) *
-                   ftauArray[mosq.EIPDuration.inDays() + l - mosq.restDuration.inDays()];
+            sum += P_dif[tsl * Genotypes::N() + genotype] * P_df[ttau] * (uninfected_v[mosq.EIPDuration + l]) *
+                   ftauArray[mosq.EIPDuration + l - mosq.restDuration];
         }
 
         const int tsm = util::mod_nn(ts, N_v_length); // index d1Mod - theta_s
-        S_v[t1 * Genotypes::N() + genotype] = P_dif[tsm * Genotypes::N() + genotype] * fArray[mosq.EIPDuration.inDays() - mosq.restDuration.inDays()] * (uninfected_v[mosq.EIPDuration.inDays()]) +
+        S_v[t1 * Genotypes::N() + genotype] = P_dif[tsm * Genotypes::N() + genotype] * fArray[mosq.EIPDuration - mosq.restDuration] * (uninfected_v[mosq.EIPDuration]) +
                                sum + P_A[t0] * S_v[t0 * Genotypes::N() + genotype] + P_df[ttau] * S_v[ttau * Genotypes::N() + genotype];
 
         if (isDynamic)
@@ -647,7 +647,7 @@ void AnophelesModel::update(SimTime d0, double tsP_A, double tsP_Amu, double tsP
     }
 
     // We use time at end of step (i.e. start + 1) in index:
-    int d5Year = util::mod_nn(d1, sim::fromYearsI(5).inDays());
+    int d5Year = util::mod_nn(d1, sim::fromYearsI(5));
     quinquennialS_v[d5Year] = total_S_v;
 
     const double nOvipositing = P_dff[ttau] * N_v[ttau]; // number ovipositing on this step
@@ -678,11 +678,11 @@ double sum1(const std::vector<double> &arr, int end, int N_v_length)
     double val = 0.0;
     // Last time step ended at sim::now(). Values are stored per day, and for
     // the last time step values at sim::now() and four previos were set.
-    for (int d1 = end - sim::oneTS().inDays(); d1 < end; d1++)
+    for (int d1 = end - sim::oneTS(); d1 < end; d1++)
     {
         val += arr[util::mod_nn(d1, N_v_length)];
     }
-    return val / sim::oneTS().inDays();
+    return val / sim::oneTS();
 }
 
 double sum2(const std::vector<double> &arr, int end, int N_v_length)
@@ -690,7 +690,7 @@ double sum2(const std::vector<double> &arr, int end, int N_v_length)
     double val = 0.0;
     // Last time step ended at sim::now(). Values are stored per day, and for
     // the last time step values at sim::now() and four previos were set.
-    for (int d1 = end - sim::oneTS().inDays(); d1 < end; d1++)
+    for (int d1 = end - sim::oneTS(); d1 < end; d1++)
     {
         int i1 = util::mod_nn(d1, N_v_length);
         for (size_t g = 0; g < Genotypes::N(); ++g)
@@ -698,7 +698,7 @@ double sum2(const std::vector<double> &arr, int end, int N_v_length)
             val += arr[i1 * Genotypes::N() + g]; //.at(i1, g);
         }
     }
-    return val / sim::oneTS().inDays();
+    return val / sim::oneTS();
 }
 
 double sum3(const std::vector<double> &arr, size_t g, int end, int N_v_length)
@@ -706,11 +706,11 @@ double sum3(const std::vector<double> &arr, size_t g, int end, int N_v_length)
     double val = 0.0;
     // Last time step ended at sim::now(). Values are stored per day, and for
     // the last time step values at sim::now() and four previos were set.
-    for (int d1 = end - sim::oneTS().inDays(); d1 < end; d1++)
+    for (int d1 = end - sim::oneTS(); d1 < end; d1++)
     {
         val += arr[util::mod_nn(d1, N_v_length) * Genotypes::N() + g];// .at(mod_nn(d1, N_v_length), g);
     }
-    return val / sim::oneTS().inDays();
+    return val / sim::oneTS();
 }
 
 double AnophelesModel::getLastVecStat(VecStat vs) const
@@ -718,7 +718,7 @@ double AnophelesModel::getLastVecStat(VecStat vs) const
     // Last time step ended at sim::now(). Values are stored per day, and for
     // the last time step values at sim::now() and four previos were set.
     // One plus last, plus (0 mod N_v_length) to avoid negatives:
-    int end = sim::now().inDays() + 1 + N_v_length;
+    int end = sim::now() + 1 + N_v_length;
     switch (vs)
     {
         case PA: return sum1(P_A, end, N_v_length);
@@ -739,7 +739,7 @@ void AnophelesModel::summarize(size_t species) const
     // Last time step ended at sim::now(). Values are stored per day, and for
     // the last time step values at sim::now() and four previos were set.
     // One plus last, plus (0 mod N_v_length) to avoid negatives:
-    int end = sim::now().inDays() + 1 + N_v_length;
+    int end = sim::now() + 1 + N_v_length;
     mon::reportStatMSF(mon::MVF_LAST_NV0, species, getLastN_v0());
     mon::reportStatMSF(mon::MVF_LAST_NV, species, sum1(N_v, end, N_v_length));
     for (size_t g = 0; g < Genotypes::N(); ++g)

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -192,9 +192,9 @@ public:
             N_v_length(0),
             timeStep_N_v0(0.0)
     {
-        forcedS_v.resize (sim::oneYear().inDays());
-        quinquennialS_v.resize (sim::fromYearsI(5).inDays(), 0.0);
-        mosqEmergeRate.resize (sim::oneYear().inDays(), 0.0);
+        forcedS_v.resize (sim::oneYear());
+        quinquennialS_v.resize (sim::fromYearsI(5), 0.0);
+        mosqEmergeRate.resize (sim::oneYear(), 0.0);
     }
     
     AnophelesModel(const AnophelesModel&) = delete;            //disable copy-constructor
@@ -313,7 +313,7 @@ public:
         // Get emergence at start of step:
         SimTime dYear1 = mod_nn(d0, sim::oneYear());
         // Simple model: fixed emergence scaled by larviciding
-        return mosqEmergeRate[dYear1.inDays()];
+        return mosqEmergeRate[dYear1];
     }
 
     /** Update by one day (may be called multiple times for 1 time-step update).
@@ -350,7 +350,7 @@ public:
 
     /// Get mean emergence per day during last time-step
     inline double getLastN_v0 () const{
-        return timeStep_N_v0 / sim::oneTS().inDays();
+        return timeStep_N_v0 / sim::oneTS();
     }
     
     /// Get mean P_A/P_df/P_dif/N_v/O_v/S_v during last time-step
@@ -521,7 +521,7 @@ public:
      *
      * Values at index ((d-1) mod N_v_length) are used to derive the state of
      * the population on day d. The state during days (t×I+1) through to ((t+1)×I)
-     * where t is sim::ts0() and I is sim::oneTS().inDays() is what
+     * where t is sim::ts0() and I is sim::oneTS() is what
      * drives the transmission at time-step t.
      * 
      * These arrays should be checkpointed. */

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -128,14 +128,14 @@ struct MosquitoParams
      * Set in initialise function from XML data; no need to checkpoint.
      * Duration of feeding cycle (equals duration of resting period) for mosquito (τ).
      * Units: days. */
-    SimTime restDuration;
+    SimTime restDuration = sim::never();
 
     /** Duration of the extrinsic incubation period (sporozoite development time)
     * (θ_s).
     * Units: Days.
     *
     * Doesn't need checkpointing. */
-    SimTime EIPDuration;
+    SimTime EIPDuration = sim::never();
 
     string name;
 };
@@ -155,7 +155,7 @@ struct Nhh {
     double P_C_I;
     double P_D_I;
     double rel_fecundity;
-    SimTime expiry;
+    SimTime expiry = sim::never();
 };
 
 struct TrapParams {
@@ -170,8 +170,8 @@ struct TrapData {
     size_t instance; // index in trapParams
     double initialAvail; // initial availability (avail per trap * num traps)
     DecayFuncHet availHet; // parameter for decay of availability
-    SimTime deployTime; // deploy time (for decay function)
-    SimTime expiry; // date at which this intervention should be deleted
+    SimTime deployTime = sim::never(); // deploy time (for decay function)
+    SimTime expiry = sim::never(); // date at which this intervention should be deleted
 };
 
 class AnophelesModel

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -192,9 +192,9 @@ public:
             N_v_length(0),
             timeStep_N_v0(0.0)
     {
-        forcedS_v.resize (SimTime::oneYear().inDays());
-        quinquennialS_v.resize (SimTime::fromYearsI(5).inDays(), 0.0);
-        mosqEmergeRate.resize (SimTime::oneYear().inDays(), 0.0);
+        forcedS_v.resize (sim::oneYear().inDays());
+        quinquennialS_v.resize (sim::fromYearsI(5).inDays(), 0.0);
+        mosqEmergeRate.resize (sim::oneYear().inDays(), 0.0);
     }
     
     AnophelesModel(const AnophelesModel&) = delete;            //disable copy-constructor
@@ -311,7 +311,7 @@ public:
     virtual double getEmergenceRate(const SimTime &d0, const std::vector<double>& mosqEmergeRate, double nOvipositing)
     {   
         // Get emergence at start of step:
-        SimTime dYear1 = mod_nn(d0, SimTime::oneYear());
+        SimTime dYear1 = mod_nn(d0, sim::oneYear());
         // Simple model: fixed emergence scaled by larviciding
         return mosqEmergeRate[dYear1.inDays()];
     }
@@ -350,7 +350,7 @@ public:
 
     /// Get mean emergence per day during last time-step
     inline double getLastN_v0 () const{
-        return timeStep_N_v0 / SimTime::oneTS().inDays();
+        return timeStep_N_v0 / sim::oneTS().inDays();
     }
     
     /// Get mean P_A/P_df/P_dif/N_v/O_v/S_v during last time-step
@@ -521,7 +521,7 @@ public:
      *
      * Values at index ((d-1) mod N_v_length) are used to derive the state of
      * the population on day d. The state during days (t×I+1) through to ((t+1)×I)
-     * where t is sim::ts0() and I is SimTime::oneTS().inDays() is what
+     * where t is sim::ts0() and I is sim::oneTS().inDays() is what
      * drives the transmission at time-step t.
      * 
      * These arrays should be checkpointed. */

--- a/model/Transmission/Anopheles/AnophelesModelFitter.h
+++ b/model/Transmission/Anopheles/AnophelesModelFitter.h
@@ -51,10 +51,10 @@ public:
 
     bool fit(AnophelesModel &m)
     {
-        std::vector<double> avgAnnualS_v(SimTime::oneYear().inDays(), 0.0);
-        for (SimTime i = SimTime::fromYearsI(4); i < SimTime::fromYearsI(5); i += SimTime::oneDay())
+        std::vector<double> avgAnnualS_v(sim::oneYear().inDays(), 0.0);
+        for (SimTime i = sim::fromYearsI(4); i < sim::fromYearsI(5); i += sim::oneDay())
         {
-            avgAnnualS_v[mod_nn(i, SimTime::oneYear()).inDays()] = m.quinquennialS_v[i.inDays()];
+            avgAnnualS_v[mod_nn(i, sim::oneYear()).inDays()] = m.quinquennialS_v[i.inDays()];
         }
 
         double factor = vectors::sum(m.forcedS_v) / vectors::sum(avgAnnualS_v);

--- a/model/Transmission/Anopheles/AnophelesModelFitter.h
+++ b/model/Transmission/Anopheles/AnophelesModelFitter.h
@@ -52,7 +52,7 @@ public:
     bool fit(AnophelesModel &m)
     {
         std::vector<double> avgAnnualS_v(sim::oneYear(), 0.0);
-        for (SimTime i = sim::fromYearsI(4); i < sim::fromYearsI(5); i += sim::oneDay())
+        for (SimTime i = sim::fromYearsI(4); i < sim::fromYearsI(5); i = i + sim::oneDay())
         {
             avgAnnualS_v[mod_nn(i, sim::oneYear())] = m.quinquennialS_v[i];
         }

--- a/model/Transmission/Anopheles/AnophelesModelFitter.h
+++ b/model/Transmission/Anopheles/AnophelesModelFitter.h
@@ -46,15 +46,15 @@ public:
     AnophelesModelFitter(AnophelesModel &m) : scaleFactor(1.0), rotated(false), scaled(false)
     {
         // usually around 20 days; no real analysis for effect of changing EIPDuration or mosqRestDuration
-        shiftAngle = m.EIRRotateAngle - (m.mosq.EIPDuration.inDays() + 10) / 365. * 2. *M_PI; 
+        shiftAngle = m.EIRRotateAngle - (m.mosq.EIPDuration + 10) / 365. * 2. *M_PI; 
     }
 
     bool fit(AnophelesModel &m)
     {
-        std::vector<double> avgAnnualS_v(sim::oneYear().inDays(), 0.0);
+        std::vector<double> avgAnnualS_v(sim::oneYear(), 0.0);
         for (SimTime i = sim::fromYearsI(4); i < sim::fromYearsI(5); i += sim::oneDay())
         {
-            avgAnnualS_v[mod_nn(i, sim::oneYear()).inDays()] = m.quinquennialS_v[i.inDays()];
+            avgAnnualS_v[mod_nn(i, sim::oneYear())] = m.quinquennialS_v[i];
         }
 
         double factor = vectors::sum(m.forcedS_v) / vectors::sum(avgAnnualS_v);

--- a/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
+++ b/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
@@ -173,7 +173,7 @@ private:
     // -----  model parameters (loaded from XML)  -----
 
     /** Duration of development (time from egg laying to emergence) in days. */
-    SimTime developmentDuration;
+    SimTime developmentDuration = sim::never();
 
     /** Survival probability of a mosquito from egg to emergence in the absence
      * of density dependent mortality. */

--- a/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
+++ b/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
@@ -40,8 +40,8 @@ public:
         , probPreadultSurvival(probPreadultSurvival)
         , fEggsLaidByOviposit(fEggsLaidByOviposit)
     {
-        quinquennialOvipositing.resize(SimTime::fromYearsI(5).inDays(), 0.0);
-        invLarvalResources.resize(SimTime::oneYear().inDays(), 0.0);
+        quinquennialOvipositing.resize(sim::fromYearsI(5).inDays(), 0.0);
+        invLarvalResources.resize(sim::oneYear().inDays(), 0.0);
         nOvipositingDelayed.resize(developmentDuration.inDays(), 0.0);
     }
 
@@ -72,7 +72,7 @@ public:
         double tsP_dff = sigma_dff * availDivisor * mosq.probMosqSurvivalOvipositing;
 
         // Initialise nOvipositingDelayed
-        int y1 = SimTime::oneYear().inDays();
+        int y1 = sim::oneYear().inDays();
         int tau = mosq.restDuration.inDays();
         for (int t = 0; t < developmentDuration.inDays(); t++)
         {
@@ -81,7 +81,7 @@ public:
 
         // Used when calculating invLarvalResources (but not a hard constraint):
         assert(tau + developmentDuration <= y1);
-        for (int t = 0; t < SimTime::oneYear().inDays(); t++)
+        for (int t = 0; t < sim::oneYear().inDays(); t++)
         {
             double yt = fEggsLaidByOviposit * tsP_dff * initNvFromSv * forcedS_v[util::mod_nn(t + y1 - tau - developmentDuration.inDays(), y1)];
             invLarvalResources[t] = (probPreadultSurvival * yt - mosqEmergeRate[t]) / (mosqEmergeRate[t] * yt);
@@ -102,8 +102,8 @@ public:
     {
         bool fitted = AnophelesModel::initIterate();
 
-        int y1 = SimTime::oneYear().inDays(), y2 = SimTime::fromYearsI(2).inDays(), y3 = SimTime::fromYearsI(3).inDays(), y4 = SimTime::fromYearsI(4).inDays(),
-                y5 = SimTime::fromYearsI(5).inDays();
+        int y1 = sim::oneYear().inDays(), y2 = sim::fromYearsI(2).inDays(), y3 = sim::fromYearsI(3).inDays(), y4 = sim::fromYearsI(4).inDays(),
+                y5 = sim::fromYearsI(5).inDays();
         assert(mosqEmergeRate.size() == y1);
 
         for (int t = 0; t < y1; t++)
@@ -129,9 +129,9 @@ public:
         int d1 = d0.inDays() + 1;
 
         double yt = fEggsLaidByOviposit * nOvipositingDelayed[util::mod_nn(d1, developmentDuration.inDays())];
-        double emergence = probPreadultSurvival * yt / (1.0 + invLarvalResources[mod_nn(d0, SimTime::oneYear()).inDays()] * yt);
+        double emergence = probPreadultSurvival * yt / (1.0 + invLarvalResources[mod_nn(d0, sim::oneYear()).inDays()] * yt);
         nOvipositingDelayed[util::mod_nn(d1, developmentDuration.inDays())] = nOvipositing;
-        quinquennialOvipositing[util::mod_nn(d1, SimTime::fromYearsI(5).inDays())] = nOvipositing;
+        quinquennialOvipositing[util::mod_nn(d1, sim::fromYearsI(5).inDays())] = nOvipositing;
         return emergence;
     }
 
@@ -141,14 +141,14 @@ public:
     {
         // TODO: why offset by one time step? This is effectively getting the resources available on the last time step
         // TODO: only have to add one year because of offset
-        SimTime start = sim::now() - SimTime::oneTS() + SimTime::oneYear();
+        SimTime start = sim::now() - sim::oneTS() + sim::oneYear();
         double total = 0;
-        for (SimTime i = start, end = start + SimTime::oneTS(); i < end; i += SimTime::oneDay())
+        for (SimTime i = start, end = start + sim::oneTS(); i < end; i += sim::oneDay())
         {
-            SimTime dYear1 = mod_nn(i, SimTime::oneYear());
+            SimTime dYear1 = mod_nn(i, sim::oneYear());
             total += 1.0 / invLarvalResources[dYear1.inDays()];
         }
-        return total / SimTime::oneTS().inDays();
+        return total / sim::oneTS().inDays();
     }
 
     virtual double getResRequirements() const { return numeric_limits<double>::quiet_NaN(); }

--- a/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
+++ b/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
@@ -40,9 +40,9 @@ public:
         , probPreadultSurvival(probPreadultSurvival)
         , fEggsLaidByOviposit(fEggsLaidByOviposit)
     {
-        quinquennialOvipositing.resize(sim::fromYearsI(5).inDays(), 0.0);
-        invLarvalResources.resize(sim::oneYear().inDays(), 0.0);
-        nOvipositingDelayed.resize(developmentDuration.inDays(), 0.0);
+        quinquennialOvipositing.resize(sim::fromYearsI(5), 0.0);
+        invLarvalResources.resize(sim::oneYear(), 0.0);
+        nOvipositingDelayed.resize(developmentDuration, 0.0);
     }
 
     /** Initialisation which must wait until a human population is available.
@@ -72,18 +72,18 @@ public:
         double tsP_dff = sigma_dff * availDivisor * mosq.probMosqSurvivalOvipositing;
 
         // Initialise nOvipositingDelayed
-        int y1 = sim::oneYear().inDays();
-        int tau = mosq.restDuration.inDays();
-        for (int t = 0; t < developmentDuration.inDays(); t++)
+        int y1 = sim::oneYear();
+        int tau = mosq.restDuration;
+        for (int t = 0; t < developmentDuration; t++)
         {
-            nOvipositingDelayed[util::mod_nn(t + tau, developmentDuration.inDays())] = tsP_dff * initNvFromSv * forcedS_v[t];
+            nOvipositingDelayed[util::mod_nn(t + tau, developmentDuration)] = tsP_dff * initNvFromSv * forcedS_v[t];
         }
 
         // Used when calculating invLarvalResources (but not a hard constraint):
         assert(tau + developmentDuration <= y1);
-        for (int t = 0; t < sim::oneYear().inDays(); t++)
+        for (int t = 0; t < sim::oneYear(); t++)
         {
-            double yt = fEggsLaidByOviposit * tsP_dff * initNvFromSv * forcedS_v[util::mod_nn(t + y1 - tau - developmentDuration.inDays(), y1)];
+            double yt = fEggsLaidByOviposit * tsP_dff * initNvFromSv * forcedS_v[util::mod_nn(t + y1 - tau - developmentDuration, y1)];
             invLarvalResources[t] = (probPreadultSurvival * yt - mosqEmergeRate[t]) / (mosqEmergeRate[t] * yt);
         }
     }
@@ -102,13 +102,13 @@ public:
     {
         bool fitted = AnophelesModel::initIterate();
 
-        int y1 = sim::oneYear().inDays(), y2 = sim::fromYearsI(2).inDays(), y3 = sim::fromYearsI(3).inDays(), y4 = sim::fromYearsI(4).inDays(),
-                y5 = sim::fromYearsI(5).inDays();
+        int y1 = sim::oneYear(), y2 = sim::fromYearsI(2), y3 = sim::fromYearsI(3), y4 = sim::fromYearsI(4),
+                y5 = sim::fromYearsI(5);
         assert(mosqEmergeRate.size() == y1);
 
         for (int t = 0; t < y1; t++)
         {
-            int ttj = t - developmentDuration.inDays();
+            int ttj = t - developmentDuration;
             // b · P_df · avg_N_v(t - θj - τ):
             double yt = fEggsLaidByOviposit * 0.2 *
                         (quinquennialOvipositing[ttj + y1] + quinquennialOvipositing[ttj + y2] + quinquennialOvipositing[ttj + y3] +
@@ -126,12 +126,12 @@ public:
         // adult population, resources available, and larviciding.
         // See: A Simple Periodically-Forced Difference Equation Model for
         // Mosquito Population Dynamics, N. Chitnis, 2012. TODO: publish & link.
-        int d1 = d0.inDays() + 1;
+        int d1 = d0 + 1;
 
-        double yt = fEggsLaidByOviposit * nOvipositingDelayed[util::mod_nn(d1, developmentDuration.inDays())];
-        double emergence = probPreadultSurvival * yt / (1.0 + invLarvalResources[mod_nn(d0, sim::oneYear()).inDays()] * yt);
-        nOvipositingDelayed[util::mod_nn(d1, developmentDuration.inDays())] = nOvipositing;
-        quinquennialOvipositing[util::mod_nn(d1, sim::fromYearsI(5).inDays())] = nOvipositing;
+        double yt = fEggsLaidByOviposit * nOvipositingDelayed[util::mod_nn(d1, developmentDuration)];
+        double emergence = probPreadultSurvival * yt / (1.0 + invLarvalResources[mod_nn(d0, sim::oneYear())] * yt);
+        nOvipositingDelayed[util::mod_nn(d1, developmentDuration)] = nOvipositing;
+        quinquennialOvipositing[util::mod_nn(d1, sim::fromYearsI(5))] = nOvipositing;
         return emergence;
     }
 
@@ -146,9 +146,9 @@ public:
         for (SimTime i = start, end = start + sim::oneTS(); i < end; i += sim::oneDay())
         {
             SimTime dYear1 = mod_nn(i, sim::oneYear());
-            total += 1.0 / invLarvalResources[dYear1.inDays()];
+            total += 1.0 / invLarvalResources[dYear1];
         }
-        return total / sim::oneTS().inDays();
+        return total / sim::oneTS();
     }
 
     virtual double getResRequirements() const { return numeric_limits<double>::quiet_NaN(); }

--- a/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
+++ b/model/Transmission/Anopheles/SimpleMPDAnophelesModel.h
@@ -143,7 +143,7 @@ public:
         // TODO: only have to add one year because of offset
         SimTime start = sim::now() - sim::oneTS() + sim::oneYear();
         double total = 0;
-        for (SimTime i = start, end = start + sim::oneTS(); i < end; i += sim::oneDay())
+        for (SimTime i = start, end = start + sim::oneTS(); i < end; i = i + sim::oneDay())
         {
             SimTime dYear1 = mod_nn(i, sim::oneYear());
             total += 1.0 / invLarvalResources[dYear1];

--- a/model/Transmission/Anopheles/rotate.h
+++ b/model/Transmission/Anopheles/rotate.h
@@ -40,7 +40,7 @@ inline double findAngle(const double EIRRotageAngle, const vector<double> & FSCo
 
         // Minimize l1-norm
         double sum = 0.0;
-        for(int i=0; i<sim::oneYear().inDays(); i++)
+        for(int i=0; i<sim::oneYear(); i++)
         {
             double v = fabs(temp[i] - sim[i]);
             sum += v*v;

--- a/model/Transmission/Anopheles/rotate.h
+++ b/model/Transmission/Anopheles/rotate.h
@@ -40,7 +40,7 @@ inline double findAngle(const double EIRRotageAngle, const vector<double> & FSCo
 
         // Minimize l1-norm
         double sum = 0.0;
-        for(int i=0; i<SimTime::oneYear().inDays(); i++)
+        for(int i=0; i<sim::oneYear().inDays(); i++)
         {
             double v = fabs(temp[i] - sim[i]);
             sum += v*v;

--- a/model/Transmission/NonVectorModel.h
+++ b/model/Transmission/NonVectorModel.h
@@ -268,7 +268,7 @@ private:
 
     //! The duration of sporogony in time steps
     // doesn't need checkpointing
-    SimTime nSpore;
+    SimTime nSpore = sim::never();
     //@}
 
     /** EIR per time interval during the intervention period. Value at index

--- a/model/Transmission/NonVectorModel.h
+++ b/model/Transmission/NonVectorModel.h
@@ -172,14 +172,14 @@ public:
     virtual void update(const Population &population)
     {
         double currentKappa = TransmissionModel::updateKappa(population);
-        if (simulationMode == forcedEIR) { initialKappa[sim::ts1().moduloSteps(initialKappa.size())] = currentKappa; }
+        if (simulationMode == forcedEIR) { initialKappa[sim::moduloSteps(sim::ts1(), initialKappa.size())] = currentKappa; }
     }
 
     virtual void calculateEIR(Host::Human &human, double ageYears, vector<double> &EIR) const
     {
         EIR.resize(1); // no support for per-genotype tracking in this model (possible, but we're lazy)
         // where the full model, with estimates of human mosquito transmission is in use, use this:
-        if (simulationMode == forcedEIR) { EIR[0] = initialisationEIR[sim::ts0().moduloYearSteps()]; }
+        if (simulationMode == forcedEIR) { EIR[0] = initialisationEIR[sim::moduloYearSteps(sim::ts0())]; }
         else if (simulationMode == transientEIRknown)
         {
             // where the EIR for the intervention phase is known, obtain this from
@@ -188,7 +188,7 @@ public:
         }
         else if (simulationMode == dynamicEIR)
         {
-            EIR[0] = initialisationEIR[sim::ts0().moduloYearSteps()];
+            EIR[0] = initialisationEIR[sim::moduloYearSteps(sim::ts0())];
             if (sim::intervTime() >= sim::zero())
             {
                 // we modulate the initialization based on the human infectiousness time steps ago in the

--- a/model/Transmission/NonVectorModel.h
+++ b/model/Transmission/NonVectorModel.h
@@ -54,7 +54,7 @@ public:
         if (daily.size() < static_cast<size_t>(sim::oneYear()))
             throw util::xml_scenario_error("insufficient EIRDaily data for a year");
 
-        for (SimTime mpcday = sim::zero(), endDay = sim::fromDays(daily.size()); mpcday < endDay; mpcday += sim::oneDay())
+        for (SimTime mpcday = sim::zero(), endDay = sim::fromDays(daily.size()); mpcday < endDay; mpcday = mpcday + sim::oneDay())
         {
             double EIRdaily = std::max(static_cast<double>(daily[mpcday]), minEIR);
 
@@ -142,7 +142,7 @@ public:
         }
         // The minimum EIR allowed in the array. The product of the average EIR and a constant.
         double minEIR = min_EIR_mult * averageEIR(nonVectorData);
-        for (SimTime mpcday = sim::zero(), endDay = sim::fromDays(daily.size()); mpcday < endDay; mpcday += sim::oneDay())
+        for (SimTime mpcday = sim::zero(), endDay = sim::fromDays(daily.size()); mpcday < endDay; mpcday = mpcday + sim::oneDay())
         {
             double EIRdaily = std::max(static_cast<double>(daily[mpcday]), minEIR);
 

--- a/model/Transmission/NonVectorModel.h
+++ b/model/Transmission/NonVectorModel.h
@@ -51,12 +51,12 @@ public:
         double minEIR = min_EIR_mult * averageEIR(nonVectorData);
 
         const scnXml::NonVector::EIRDailySequence &daily = nonVectorData.getEIRDaily();
-        if (daily.size() < static_cast<size_t>(sim::oneYear().inDays()))
+        if (daily.size() < static_cast<size_t>(sim::oneYear()))
             throw util::xml_scenario_error("insufficient EIRDaily data for a year");
 
         for (SimTime mpcday = sim::zero(), endDay = sim::fromDays(daily.size()); mpcday < endDay; mpcday += sim::oneDay())
         {
-            double EIRdaily = std::max(static_cast<double>(daily[mpcday.inDays()]), minEIR);
+            double EIRdaily = std::max(static_cast<double>(daily[mpcday]), minEIR);
 
             // Index 0 of initialisationEIR refers to the EIR affecting the
             // first day(s) of the year. Correspondingly, the first 1 or 5 values
@@ -71,7 +71,7 @@ public:
         // divide by number of records assigned to each interval (usually one per day)
         for (size_t indTS = 0; indTS < sim::stepsPerYear(); indTS += 1)
         {
-            initialisationEIR[indTS] *= sim::oneTS().inDays() / static_cast<double>(nDays[indTS]);
+            initialisationEIR[indTS] *= sim::oneTS() / static_cast<double>(nDays[indTS]);
             annualEIR += initialisationEIR[indTS];
         }
 
@@ -134,7 +134,7 @@ public:
         const scnXml::NonVector::EIRDailySequence &daily = nonVectorData.getEIRDaily();
         vector<int> nDays(sim::fromDays(daily.size() - 1).inSteps() + 1, 0);
         interventionEIR.assign(nDays.size(), 0.0);
-        size_t required_days = static_cast<size_t>((sim::endDate() - sim::startDate()).inDays() + 1);
+        size_t required_days = static_cast<size_t>((sim::endDate() - sim::startDate()) + 1);
         if (daily.size() < required_days)
         {
             cerr << "Days: " << daily.size() << "\nIntervals: " << nDays.size() << "\nRequired: " << required_days << endl;
@@ -144,7 +144,7 @@ public:
         double minEIR = min_EIR_mult * averageEIR(nonVectorData);
         for (SimTime mpcday = sim::zero(), endDay = sim::fromDays(daily.size()); mpcday < endDay; mpcday += sim::oneDay())
         {
-            double EIRdaily = std::max(static_cast<double>(daily[mpcday.inDays()]), minEIR);
+            double EIRdaily = std::max(static_cast<double>(daily[mpcday]), minEIR);
 
             // istep is the time period to which the day is assigned.
             size_t istep = mpcday.inSteps();
@@ -154,7 +154,7 @@ public:
         // divide by number of records assigned to each interval (usually one per day)
         for (size_t i = 0; i < interventionEIR.size(); ++i)
         {
-            interventionEIR[i] *= sim::oneTS().inDays() / static_cast<double>(nDays[i]);
+            interventionEIR[i] *= sim::oneTS() / static_cast<double>(nDays[i]);
         }
 
         // I've no idea what this should be, so until someone asks it can be NaN.

--- a/model/Transmission/PerHost.cpp
+++ b/model/Transmission/PerHost.cpp
@@ -75,7 +75,7 @@ void PerHost::deployComponent( LocalRng& rng, const HumanVectorInterventionCompo
 
 
 // Note: in the case an intervention is not present, we can use the approximation
-// of Weibull decay over the time span now - SimTime::never()
+// of Weibull decay over the time span now - sim::never()
 // (easily large enough for conceivable Weibull params that the value is 0.0 when
 // rounded to a double. Performance-wise it's perhaps slightly slower than using
 // an if() when interventions aren't present.

--- a/model/Transmission/PerHost.h
+++ b/model/Transmission/PerHost.h
@@ -98,7 +98,7 @@ protected:
     /// Checkpointing: write
     virtual void checkpoint( ostream& stream ) =0;
     
-    SimTime deployTime;        // time of deployment or sim::never()
+    SimTime deployTime = sim::never();        // time of deployment or sim::never()
     interventions::ComponentId m_id;       // component id; don't change
 };
 

--- a/model/Transmission/PerHost.h
+++ b/model/Transmission/PerHost.h
@@ -80,7 +80,7 @@ public:
     inline interventions::ComponentId id() const { return m_id; }
     
     /// Return true if this component is deployed (i.e. currently active)
-    inline bool isDeployed() const{ return deployTime != SimTime::never(); }
+    inline bool isDeployed() const{ return deployTime != sim::never(); }
     
     /// Checkpointing (write only)
     void operator& (ostream& stream) {
@@ -98,7 +98,7 @@ protected:
     /// Checkpointing: write
     virtual void checkpoint( ostream& stream ) =0;
     
-    SimTime deployTime;        // time of deployment or SimTime::never()
+    SimTime deployTime;        // time of deployment or sim::never()
     interventions::ComponentId m_id;       // component id; don't change
 };
 
@@ -243,7 +243,7 @@ public:
     /** Get the age at which individuals are considered adults (i.e. where
      * availability to mosquitoes reaches its maximum). */
     static inline SimTime adultAge() {
-        return SimTime::fromYearsD( relAvailAge.firstGlobalMaximum() );
+        return sim::fromYearsD( relAvailAge.firstGlobalMaximum() );
     }
     
     /** Get whether the user has any active deployments of interventions of

--- a/model/Transmission/TransmissionModel.h
+++ b/model/Transmission/TransmissionModel.h
@@ -141,7 +141,7 @@ public:
      * Overriding functions should call this base version too. */
     virtual void summarize()
     {
-        mon::reportStatMF(mon::MVF_NUM_TRANSMIT, laggedKappa[sim::now().moduloSteps(laggedKappa.size())]);
+        mon::reportStatMF(mon::MVF_NUM_TRANSMIT, laggedKappa[sim::moduloSteps(sim::now(), laggedKappa.size())]);
         mon::reportStatMF(mon::MVF_ANN_AVG_K, _annualAverageKappa);
 
         if (!mon::isReported()) return; // cannot use counters below when not reporting
@@ -275,7 +275,7 @@ protected:
             if (riskTrans > 0.0) ++numTransmittingHumans;
         }
 
-        size_t lKMod = sim::ts1().moduloSteps(laggedKappa.size()); // now
+        size_t lKMod = sim::moduloSteps(sim::ts1(), laggedKappa.size()); // now
         if (population.size() == 0)
         {                             // this is valid
             laggedKappa[lKMod] = 0.0; // no humans: no infectiousness
@@ -291,7 +291,7 @@ protected:
             laggedKappa[lKMod] = sumWt_kappa / sumWeight;
         }
 
-        size_t tmod = sim::ts0().moduloYearSteps();
+        size_t tmod = sim::moduloYearSteps(sim::ts0());
 
         // Calculate time-weighted average of kappa
         _sumAnnualKappa += laggedKappa[lKMod] * initialisationEIR[tmod];
@@ -357,7 +357,7 @@ private:
     void ctsCbKappa(ostream &stream)
     {
         // The latest time-step's kappa:
-        stream << '\t' << laggedKappa[sim::now().moduloSteps(laggedKappa.size())];
+        stream << '\t' << laggedKappa[sim::moduloSteps(sim::now(), laggedKappa.size())];
     }
     void ctsCbNumTransmittingHumans(ostream &stream) { stream << '\t' << numTransmittingHumans; }
 
@@ -423,10 +423,10 @@ private:
      * Units: infectious bites/adult/inter-survey period. */
     double surveySimulatedEIR;
     /** Time of last survey. */
-    SimTime lastSurveyTime;
+    SimTime lastSurveyTime = sim::never();
 
     /// age at which an individual is considered an adult
-    SimTime adultAge;
+    SimTime adultAge = sim::never();
 
     /// For "num transmitting humans" cts output.
     int numTransmittingHumans;

--- a/model/Transmission/TransmissionModel.h
+++ b/model/Transmission/TransmissionModel.h
@@ -146,7 +146,7 @@ public:
 
         if (!mon::isReported()) return; // cannot use counters below when not reporting
 
-        double duration = (sim::now() - lastSurveyTime).inSteps();
+        double duration = sim::inSteps(sim::now() - lastSurveyTime);
         if (duration > 0.0)
         {
             mon::reportStatMF(mon::MVF_INPUT_EIR, surveyInputEIR / duration);
@@ -266,7 +266,7 @@ protected:
         {
             // NOTE: calculate availability relative to age at end of time step;
             // not my preference but consistent with TransmissionModel::getEIR().
-            const double avail = human.perHostTransmission.relativeAvailabilityHetAge(human.age(sim::ts1()).inYears());
+            const double avail = human.perHostTransmission.relativeAvailabilityHetAge(sim::inYears(human.age(sim::ts1())));
             sumWeight += avail;
             const double tbvFactor = human.getVaccine().getFactor(interventions::Vaccine::TBV);
             const double pTransmit = human.withinHostModel->probTransmissionToMosquito(tbvFactor, 0);

--- a/model/Transmission/TransmissionModel.h
+++ b/model/Transmission/TransmissionModel.h
@@ -349,7 +349,7 @@ private:
     // The times here should be for the last updated index of arrays:
     void ctsCbInputEIR(ostream &stream)
     {
-        int prevStep = (sim::now() - SimTime::oneTS()) / SimTime::oneTS();
+        int prevStep = (sim::now() - sim::oneTS()) / sim::oneTS();
         // Note: prevStep may be negative, hence util::mod not mod_nn:
         stream << '\t' << initialisationEIR[util::mod(prevStep, sim::stepsPerYear())];
     }

--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -101,7 +101,7 @@ void VectorModel::ctsCbAlpha(const Population &population, ostream &stream)
         double total = 0.0;
         for (Population::ConstIter iter = population.cbegin(); iter != population.cend(); ++iter)
         {
-            total += iter->perHostTransmission.entoAvailabilityFull(i, iter->age(sim::now()).inYears());
+            total += iter->perHostTransmission.entoAvailabilityFull(i, sim::inYears(iter->age(sim::now())));
         }
         stream << '\t' << total / population.size();
     }
@@ -259,7 +259,7 @@ void VectorModel::init2(const Population &population)
     double sumRelativeAvailability = 0.0;
     for (const Host::Human &human : population.getHumans())
     {
-        sumRelativeAvailability += human.perHostTransmission.relativeAvailabilityAge(human.age(sim::now()).inYears());
+        sumRelativeAvailability += human.perHostTransmission.relativeAvailabilityAge(sim::inYears(human.age(sim::now())));
     }
     int popSize = population.size();
     // value should be unimportant when no humans are available, though inf/nan is not acceptable
@@ -279,7 +279,7 @@ void VectorModel::init2(const Population &population)
         for (const Host::Human &human : population.getHumans())
         {
             const OM::Transmission::PerHost &host = human.perHostTransmission;
-            double prod = host.entoAvailabilityFull(i, human.age(sim::now()).inYears());
+            double prod = host.entoAvailabilityFull(i, sim::inYears(human.age(sim::now())));
             sum_avail += prod;
             prod *= host.probMosqBiting(i);
             sigma_f += prod;
@@ -382,7 +382,7 @@ void VectorModel::calculateEIR(Host::Human &human, double ageYears, vector<doubl
     host.update(human);
     if (simulationMode == forcedEIR)
     {
-        double eir = initialisationEIR[sim::ts0().moduloYearSteps()] * host.relativeAvailabilityHetAge(ageYears);
+        double eir = initialisationEIR[sim::moduloYearSteps(sim::ts0())] * host.relativeAvailabilityHetAge(ageYears);
         mon::reportStatMACGF(mon::MVF_INOCS, ag, cs, 0, eir);
         EIR.assign(1, eir);
     }
@@ -445,7 +445,7 @@ void VectorModel::vectorUpdate(const Population &population)
             // NOTE: calculate availability relative to age at end of time step;
             // not my preference but consistent with TransmissionModel::getEIR().
             // TODO: even stranger since probTransmission comes from the previous time step
-            const double avail = host.entoAvailabilityFull(s, human.age(sim::ts1()).inYears());
+            const double avail = host.entoAvailabilityFull(s, sim::inYears(human.age(sim::ts1())));
             sum_avail[s] += avail;
             const double df = avail * host.probMosqBiting(s) * host.probMosqResting(s);
             sigma_df[s] += df;

--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -135,7 +135,7 @@ void VectorModel::ctsNetInsecticideContent(const Population &population, ostream
     //     double meanVar = 0.0;
     //     int n = 0;
     //     for(Population::ConstIter iter = population.cbegin(); iter != population.cend(); ++iter) {
-    //         if( iter->perHostTransmission.getITN().timeOfDeployment() >= SimTime::zero() ){
+    //         if( iter->perHostTransmission.getITN().timeOfDeployment() >= sim::zero() ){
     //             ++n;
     //             meanVar += iter->perHostTransmission.getITN().getInsecticideContent(_ITNParams);
     //         }
@@ -329,26 +329,26 @@ void VectorModel::scaleEIR(double factor)
 
 SimTime VectorModel::minPreinitDuration()
 {
-    if (interventionMode == forcedEIR) { return SimTime::zero(); }
+    if (interventionMode == forcedEIR) { return sim::zero(); }
     // Data is summed over 5 years; add an extra 50 for stabilization.
     // 50 years seems a reasonable figure from a few tests
-    return SimTime::fromYearsI(55);
+    return sim::fromYearsI(55);
 }
-SimTime VectorModel::expectedInitDuration() { return SimTime::oneYear(); }
+SimTime VectorModel::expectedInitDuration() { return sim::oneYear(); }
 
 SimTime VectorModel::initIterate()
 {
     if (interventionMode != dynamicEIR)
     {
         // allow forcing equilibrium mode like with non-vector model
-        return SimTime::zero(); // no initialization to do
+        return sim::zero(); // no initialization to do
     }
 
     // Fitting is done
     if (initIterations < 0)
     {
         simulationMode = dynamicEIR;
-        return SimTime::zero();
+        return sim::zero();
     }
 
     if (++initIterations > 30) { throw TRACED_EXCEPTION("Transmission warmup exceeded 30 iterations!", util::Error::VectorWarmup); }
@@ -364,13 +364,13 @@ SimTime VectorModel::initIterate()
     if (needIterate)
     {
         // stabilization + 5 years data-collection time:
-        return SimTime::oneYear() + SimTime::fromYearsI(5);
+        return sim::oneYear() + sim::fromYearsI(5);
     }
     else
     {
         // One year stabilisation, then we're finished:
         initIterations = -1;
-        return SimTime::oneYear();
+        return sim::oneYear();
     }
 }
 

--- a/model/Transmission/transmission.h
+++ b/model/Transmission/transmission.h
@@ -88,8 +88,8 @@ static Anopheles::AnophelesModel *createAnophelesModel(size_t i, const scnXml::A
 
         const scnXml::SimpleMPD& smpd = anoph.getSimpleMPD().get();
 
-        SimTime developmentDuration = SimTime::fromDays(smpd.getDevelopmentDuration().getValue());
-        if (!(developmentDuration > SimTime::zero()))
+        SimTime developmentDuration = sim::fromDays(smpd.getDevelopmentDuration().getValue());
+        if (!(developmentDuration > sim::zero()))
             throw util::xml_scenario_error("entomology.vector.simpleMPD.developmentDuration: "
                 "must be positive");
         double probPreadultSurvival = smpd.getDevelopmentSurvival().getValue();
@@ -193,11 +193,11 @@ static Anopheles::AnophelesModel *createAnophelesModel(size_t i, const scnXml::A
     mosqParams.probOvipositing = mosq.getMosqProbOvipositing().getValue();
     mosqParams.seekingDuration = mosq.getMosqSeekingDuration().getValue();
     mosqParams.probMosqSurvivalOvipositing = mosq.getMosqProbOvipositing().getValue();
-    mosqParams.restDuration = SimTime::fromDays(mosq.getMosqRestDuration().getValue());
-    mosqParams.EIPDuration = SimTime::fromDays(mosq.getExtrinsicIncubationPeriod().getValue());
+    mosqParams.restDuration = sim::fromDays(mosq.getMosqRestDuration().getValue());
+    mosqParams.EIPDuration = sim::fromDays(mosq.getExtrinsicIncubationPeriod().getValue());
     mosqParams.minInfectedThreshold = mosq.getMinInfectedThreshold();
 
-    if (SimTime::oneDay() > mosqParams.restDuration || mosqParams.restDuration * 2 >= mosqParams.EIPDuration)
+    if (sim::oneDay() > mosqParams.restDuration || mosqParams.restDuration * 2 >= mosqParams.EIPDuration)
     {
         // TODO: limit was EIPDuration >= mosqRestDuration >= 1
         // but in usage of ftauArray this wasn't enough. Check why.

--- a/model/WithinHost/CommonWithinHost.cpp
+++ b/model/WithinHost/CommonWithinHost.cpp
@@ -66,7 +66,7 @@ void CommonWithinHost::init( const scnXml::Scenario& scenario ){
 CommonWithinHost::CommonWithinHost( LocalRng& rng, double comorbidityFactor ) :
         WHFalciparum( rng, comorbidityFactor )
 {
-    assert( SimTime::oneTS() == SimTime::fromDays(1) || SimTime::oneTS() == SimTime::fromDays(5) );
+    assert( sim::oneTS() == sim::fromDays(1) || sim::oneTS() == sim::fromDays(5) );
     
     // Sample a weight heterogeneity factor
 #ifndef NDEBUG
@@ -161,7 +161,7 @@ void CommonWithinHost::update(LocalRng& rng,
     
     double body_mass = massByAge.eval( ageInYears ) * hetMassMultiplier;
     
-    for( SimTime now = sim::ts0(), end = sim::ts0() + SimTime::oneTS(); now < end; now += SimTime::oneDay() ){
+    for( SimTime now = sim::ts0(), end = sim::ts0() + sim::oneTS(); now < end; now += sim::oneDay() ){
         // every day, medicate drugs, update each infection, then decay drugs
         pkpdModel.medicate(rng);
         

--- a/model/WithinHost/CommonWithinHost.cpp
+++ b/model/WithinHost/CommonWithinHost.cpp
@@ -161,7 +161,7 @@ void CommonWithinHost::update(LocalRng& rng,
     
     double body_mass = massByAge.eval( ageInYears ) * hetMassMultiplier;
     
-    for( SimTime now = sim::ts0(), end = sim::ts0() + sim::oneTS(); now < end; now += sim::oneDay() ){
+    for( SimTime now = sim::ts0(), end = sim::ts0() + sim::oneTS(); now < end; now = now + sim::oneDay() ){
         // every day, medicate drugs, update each infection, then decay drugs
         pkpdModel.medicate(rng);
         

--- a/model/WithinHost/CommonWithinHost.cpp
+++ b/model/WithinHost/CommonWithinHost.cpp
@@ -211,7 +211,7 @@ void CommonWithinHost::update(LocalRng& rng,
     assert( (std::isfinite)(totalDensity) );        // inf probably wouldn't be a problem but NaN would be
     
     // Cache total density for infectiousness calculations
-    int y_lag_i = sim::ts1().moduloSteps(y_lag_len);
+    int y_lag_i = sim::moduloSteps(sim::ts1(), y_lag_len);
     for( size_t g = 0; g < Genotypes::N(); ++g ) m_y_lag[y_lag_i * Genotypes::N() + g] = 0.0;
     for( auto inf = infections.begin(); inf != infections.end(); ++inf ){
         m_y_lag[y_lag_i * Genotypes::N() + (*inf)->genotype()] += (*inf)->getDensity();

--- a/model/WithinHost/DescriptiveWithinHost.cpp
+++ b/model/WithinHost/DescriptiveWithinHost.cpp
@@ -46,7 +46,7 @@ void DescriptiveWithinHostModel::initDescriptive(){
 DescriptiveWithinHostModel::DescriptiveWithinHostModel( LocalRng& rng, double comorbidityFactor ) :
         WHFalciparum( rng, comorbidityFactor )
 {
-    assert( SimTime::oneTS() == SimTime::fromDays(5) );
+    assert( sim::oneTS() == sim::fromDays(5) );
 }
 
 DescriptiveWithinHostModel::~DescriptiveWithinHostModel() {}
@@ -159,7 +159,7 @@ void DescriptiveWithinHostModel::update(LocalRng& rng,
     // As in AJTMH p22, cumulative_h (X_h + 1) doesn't include infections added
     // this time-step and cumulative_Y only includes past densities.
     m_cumulative_h += nNewInfs;
-    m_cumulative_Y += SimTime::oneTS().inDays() * totalDensity;
+    m_cumulative_Y += sim::oneTS().inDays() * totalDensity;
     
     util::streamValidate( totalDensity );
     util::streamValidate( hrp2Density );

--- a/model/WithinHost/DescriptiveWithinHost.cpp
+++ b/model/WithinHost/DescriptiveWithinHost.cpp
@@ -166,7 +166,7 @@ void DescriptiveWithinHostModel::update(LocalRng& rng,
     assert( (std::isfinite)(totalDensity) );        // inf probably wouldn't be a problem but NaN would be
     
     // Cache total density for infectiousness calculations
-    int y_lag_i = sim::ts1().moduloSteps(y_lag_len);
+    int y_lag_i = sim::moduloSteps(sim::ts1(), y_lag_len);
     for( size_t g = 0; g < Genotypes::N(); ++g ) m_y_lag[y_lag_i * Genotypes::N() + g] = 0.0;
     for( auto inf = infections.begin(); inf != infections.end(); ++inf ){
         m_y_lag[y_lag_i * Genotypes::N() + inf->genotype()] += inf->getDensity();

--- a/model/WithinHost/DescriptiveWithinHost.cpp
+++ b/model/WithinHost/DescriptiveWithinHost.cpp
@@ -159,7 +159,7 @@ void DescriptiveWithinHostModel::update(LocalRng& rng,
     // As in AJTMH p22, cumulative_h (X_h + 1) doesn't include infections added
     // this time-step and cumulative_Y only includes past densities.
     m_cumulative_h += nNewInfs;
-    m_cumulative_Y += sim::oneTS().inDays() * totalDensity;
+    m_cumulative_Y += sim::oneTS() * totalDensity;
     
     util::streamValidate( totalDensity );
     util::streamValidate( hrp2Density );

--- a/model/WithinHost/Infection/CommonInfection.h
+++ b/model/WithinHost/Infection/CommonInfection.h
@@ -60,7 +60,7 @@ public:
      * @returns True when the infection goes extinct. */
     inline bool update( LocalRng& rng, double survivalFactor, SimTime now, double body_mass ){
 	SimTime bsAge = now - m_startDate - s_latentP;	// age of post-latent-period blood stage
-	if( bsAge < SimTime::zero() )
+	if( bsAge < sim::zero() )
 	    return false;	// latent period (liver stage) — don't do anything
 	else
 	    return updateDensity( rng, survivalFactor, bsAge, body_mass );
@@ -73,7 +73,7 @@ protected:
      *
      * @param survivalFactor Density multiplier to introduce drug & vaccine
      *   effects
-     * @param bsAge Age of the patent blood-stage infection (SimTime::zero() on
+     * @param bsAge Age of the patent blood-stage infection (sim::zero() on
      *  first day). Note that liver and pre-patent blood stages occur before
      *  this, but this function is not called during those stages.
      * @param body_mass Body mass of host in kg

--- a/model/WithinHost/Infection/DescriptiveInfection.cpp
+++ b/model/WithinHost/Infection/DescriptiveInfection.cpp
@@ -46,7 +46,7 @@ bool bugfix_max_dens = true, bugfix_innate_max_dens = true;
 
 void DescriptiveInfection::init (const Parameters& parameters) {
     // Error checks
-    if( sim::oneTS().inDays() != 5 ){
+    if( sim::oneTS() != 5 ){
         // To support non-5-day time-step models, either different data would
         // be needed or times need to be adjusted when accessing
         // meanLogParasiteCount. Probably the rest would be fine.
@@ -120,7 +120,7 @@ DescriptiveInfection::DescriptiveInfection (LocalRng& rng, uint32_t genotype) :
         m_duration(infectionDuration(rng)),
         notPrintedMDWarning(true)
 {
-    assert( sim::oneTS().inDays() == 5 );
+    assert( sim::oneTS() == 5 );
 }
 
 SimTime DescriptiveInfection::infectionDuration(LocalRng& rng) {
@@ -131,7 +131,7 @@ SimTime DescriptiveInfection::infectionDuration(LocalRng& rng) {
     
     //TODO:
     // Model did say infection is cleared on day dur+1 converted to a time-step
-    // let interval = sim::oneTS().inDays() in:
+    // let interval = sim::oneTS() in:
     // ((1+floor(dur))/interval); now it says the last interval is:
     // floor((1+dur)/interval)-1 = floor((dur+1-interval)/interval)
     // Is this reasonable, or should we change?
@@ -180,9 +180,9 @@ void DescriptiveInfection::determineDensities(
             double meanlog = log(m_density) - stdlog*stdlog / 2.0;
             m_density = rng.log_normal(meanlog, stdlog);
             // Calculate additional samples for T-1 days (T=days per step):
-            if( true /*sim::oneTS().inDays() > 1, always true for this model*/ ){
+            if( true /*sim::oneTS() > 1, always true for this model*/ ){
                 timeStepMaxDensity = rng.max_multi_log_normal (m_density,
-                        sim::oneTS().inDays() - 1, meanlog, stdlog);
+                        sim::oneTS() - 1, meanlog, stdlog);
             } else {
                 timeStepMaxDensity = m_density;
             }
@@ -200,7 +200,7 @@ void DescriptiveInfection::determineDensities(
         //Include here the effect of blood stage vaccination
         m_density *= bsvFactor;
         
-        m_cumulativeExposureJ += sim::oneTS().inDays() * m_density;
+        m_cumulativeExposureJ += sim::oneTS() * m_density;
     }
     
     if (bugfix_innate_max_dens) timeStepMaxDensity *= innateImmSurvFact;

--- a/model/WithinHost/Infection/DescriptiveInfection.cpp
+++ b/model/WithinHost/Infection/DescriptiveInfection.cpp
@@ -158,8 +158,8 @@ void DescriptiveInfection::determineDensities(
     }else{
         timeStepMaxDensity = 0.0;
         
-        int32_t infAge = min( infage.inSteps(), maxDurationTS );
-        int32_t infDur = min( m_duration.inSteps(), maxDurationTS );
+        int32_t infAge = min( sim::inSteps(infage), maxDurationTS );
+        int32_t infDur = min( sim::inSteps(m_duration), maxDurationTS );
         m_density=max (exp(meanLogParasiteCount[infAge][infDur]), 1.0);
         
         // The expected parasite density in the non naive host (AJTM p.9 eq. 9)

--- a/model/WithinHost/Infection/DescriptiveInfection.cpp
+++ b/model/WithinHost/Infection/DescriptiveInfection.cpp
@@ -46,7 +46,7 @@ bool bugfix_max_dens = true, bugfix_innate_max_dens = true;
 
 void DescriptiveInfection::init (const Parameters& parameters) {
     // Error checks
-    if( SimTime::oneTS().inDays() != 5 ){
+    if( sim::oneTS().inDays() != 5 ){
         // To support non-5-day time-step models, either different data would
         // be needed or times need to be adjusted when accessing
         // meanLogParasiteCount. Probably the rest would be fine.
@@ -120,7 +120,7 @@ DescriptiveInfection::DescriptiveInfection (LocalRng& rng, uint32_t genotype) :
         m_duration(infectionDuration(rng)),
         notPrintedMDWarning(true)
 {
-    assert( SimTime::oneTS().inDays() == 5 );
+    assert( sim::oneTS().inDays() == 5 );
 }
 
 SimTime DescriptiveInfection::infectionDuration(LocalRng& rng) {
@@ -131,11 +131,11 @@ SimTime DescriptiveInfection::infectionDuration(LocalRng& rng) {
     
     //TODO:
     // Model did say infection is cleared on day dur+1 converted to a time-step
-    // let interval = SimTime::oneTS().inDays() in:
+    // let interval = sim::oneTS().inDays() in:
     // ((1+floor(dur))/interval); now it says the last interval is:
     // floor((1+dur)/interval)-1 = floor((dur+1-interval)/interval)
     // Is this reasonable, or should we change?
-    return SimTime::fromDays( static_cast<int>(1.0 + dur) ) - SimTime::oneTS();
+    return sim::fromDays( static_cast<int>(1.0 + dur) ) - sim::oneTS();
 }
 
 
@@ -152,7 +152,7 @@ void DescriptiveInfection::determineDensities(
     // Age of patent blood stage infection. Note: liver stage is fixed at one
     // 5-day time step and prepatent blood stage is latentp - 1 time steps.
     SimTime infage = sim::ts0() - m_startDate - s_latentP;
-    if ( infage < SimTime::zero()) {
+    if ( infage < sim::zero()) {
         m_density = 0.0;
         if (bugfix_max_dens) timeStepMaxDensity = 0.0;
     }else{
@@ -180,9 +180,9 @@ void DescriptiveInfection::determineDensities(
             double meanlog = log(m_density) - stdlog*stdlog / 2.0;
             m_density = rng.log_normal(meanlog, stdlog);
             // Calculate additional samples for T-1 days (T=days per step):
-            if( true /*SimTime::oneTS().inDays() > 1, always true for this model*/ ){
+            if( true /*sim::oneTS().inDays() > 1, always true for this model*/ ){
                 timeStepMaxDensity = rng.max_multi_log_normal (m_density,
-                        SimTime::oneTS().inDays() - 1, meanlog, stdlog);
+                        sim::oneTS().inDays() - 1, meanlog, stdlog);
             } else {
                 timeStepMaxDensity = m_density;
             }
@@ -200,7 +200,7 @@ void DescriptiveInfection::determineDensities(
         //Include here the effect of blood stage vaccination
         m_density *= bsvFactor;
         
-        m_cumulativeExposureJ += SimTime::oneTS().inDays() * m_density;
+        m_cumulativeExposureJ += sim::oneTS().inDays() * m_density;
     }
     
     if (bugfix_innate_max_dens) timeStepMaxDensity *= innateImmSurvFact;
@@ -211,7 +211,7 @@ void DescriptiveInfection::determineDensities(
 // ———  checkpointing  ———
 
 DescriptiveInfection::DescriptiveInfection (istream& stream) :
-        Infection(stream), m_duration(SimTime::never())
+        Infection(stream), m_duration(sim::never())
 {
     m_duration & stream;
     notPrintedMDWarning & stream;

--- a/model/WithinHost/Infection/DescriptiveInfection.h
+++ b/model/WithinHost/Infection/DescriptiveInfection.h
@@ -113,7 +113,7 @@ protected:
     virtual void checkpoint (ostream& stream);
     
     // Arbitrary predetermined maximum duration of the infection
-    SimTime m_duration; 
+    SimTime m_duration = sim::never(); 
     
     bool notPrintedMDWarning;
     

--- a/model/WithinHost/Infection/EmpiricalInfection.cpp
+++ b/model/WithinHost/Infection/EmpiricalInfection.cpp
@@ -163,14 +163,14 @@ bool EmpiricalInfection::updateDensity( LocalRng& rng, double survivalFactor, Si
   //to avoid the formula for the linear predictor being excessively long we introduce L for the lagged densities
   # define L _laggedLogDensities
   
-  if (bsAge.inDays() >= _maximumDurationInDays || !(L[0] > -999999.9))	// Note: second test is extremely unlikely to fail
+  if (bsAge >= _maximumDurationInDays || !(L[0] > -999999.9))	// Note: second test is extremely unlikely to fail
     return true;	// cut-off point
   
   // constraints to ensure the density is defined and not exploding
   double upperLimitoflogDensity=log(_maximumPermittedAmplificationPerCycle*exp(L[1])/_inflationMean);
   double amplificationPerCycle;
   double localDensity;	// density before scaling by _overallMultiplier
-  size_t ageDays = bsAge.inDays();
+  size_t ageDays = bsAge;
   for(int tries0 = 0; tries0 < EI_MAX_SAMPLES; ++tries0) {
     double logDensity;
     for(int tries1 = 0; tries1 < EI_MAX_SAMPLES; ++tries1) {

--- a/model/WithinHost/Infection/Infection.h
+++ b/model/WithinHost/Infection/Infection.h
@@ -114,7 +114,7 @@ protected:
     
     /// Date of inoculation of infection (start of liver stage)
     /// This is the step of inoculation (ts0()).
-    SimTime m_startDate;
+    SimTime m_startDate = sim::never();
     
     /// Current density of the infection
     double m_density;

--- a/model/WithinHost/Infection/Infection.h
+++ b/model/WithinHost/Infection/Infection.h
@@ -42,7 +42,7 @@ public:
         m_genotype(genotype)
     {}
     Infection (istream& stream) :
-        m_startDate(SimTime::never())
+        m_startDate(sim::never())
     {
         m_startDate & stream;
         m_density & stream;
@@ -70,7 +70,7 @@ public:
      * first update (though due to the latent period densities will still be
      * low). */
     inline bool bloodStage() const{
-        return sim::latestTs0() - m_startDate > SimTime::fromDays(5);
+        return sim::latestTs0() - m_startDate > sim::fromDays(5);
     }
     
     /// Get the density of the infection as of the last update

--- a/model/WithinHost/Infection/MolineauxInfection.cpp
+++ b/model/WithinHost/Infection/MolineauxInfection.cpp
@@ -268,7 +268,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     // ———  1. Update m_density (Pc), Pi and related  ———
     double Pi[v] = { 0.0f };
     
-    if (age_BS == SimTime::zero()){
+    if (age_BS == sim::zero()){
         // The first variant starts with a pre-set density (regardless of blood
         // volume; this is an assumption by DH; paper assumes fixed volume)
         variants.resize(1);

--- a/model/WithinHost/Infection/MolineauxInfection.cpp
+++ b/model/WithinHost/Infection/MolineauxInfection.cpp
@@ -295,7 +295,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     // Every other step (if bsAge is even) we calculate new densities (the
     // Molineaux model uses a 2-day step; we have simply added interpolation
     // for the interleaving densities). In other cases we are finished now.
-    if( mod_nn(age_BS, 2) != 0 ){
+    if( mod_nn(int(age_BS), 2) != 0 ){
         return false;   // end of update, not extinct
     }
     

--- a/model/WithinHost/Infection/MolineauxInfection.cpp
+++ b/model/WithinHost/Infection/MolineauxInfection.cpp
@@ -295,7 +295,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     // Every other step (if bsAge is even) we calculate new densities (the
     // Molineaux model uses a 2-day step; we have simply added interpolation
     // for the interleaving densities). In other cases we are finished now.
-    if( mod_nn(age_BS.inDays(), 2) != 0 ){
+    if( mod_nn(age_BS, 2) != 0 ){
         return false;   // end of update, not extinct
     }
     
@@ -312,7 +312,7 @@ bool MolineauxInfection::updateDensity( LocalRng&, double survival_factor, SimTi
     
     // ———  3. variant-transcending immune response (equations 7, 8)  ———
     // 3.a) Update the sum in (7), based on previous result
-    const size_t tau = mod_nn(age_BS.inDays() / 2, taus);    // 8 days ago has same index as today
+    const size_t tau = mod_nn(age_BS / 2, taus);    // 8 days ago has same index as today
     // NOTE: rho == 0 so we can optimise this code:
     //Sm_summation = Sm_summation * exp(-2.0*rho) + laggedPc[index];
     Sm_summation = Sm_summation + lagged_Pc[tau];

--- a/model/WithinHost/Infection/MolineauxInfection.h
+++ b/model/WithinHost/Infection/MolineauxInfection.h
@@ -71,7 +71,7 @@ private:
     
     float mi[v];        // base multiplication factor per two-day cycle of variant i
     float Sm_summation; // sum in eqn 7
-    // index: we use ((bsAge.inDays()/2) mod 4) for τ = t - δ_v respectively τ = t
+    // index: we use ((bsAge/2) mod 4) for τ = t - δ_v respectively τ = t
     float lagged_Pc[taus];       // Pc(τ) for τ ∈ {t - δ_v, ..., t - 2}
     /* Pc_star, Pm_star: two host-specific critical densities.
      * These two values depend on the first local maximum or the difference
@@ -88,7 +88,7 @@ private:
         
         float Pi1, Pi2;   // Pi(t+1), Pi(t+2): variant's i density (PRBC/μl blood)
         float Si_summation;     // sum in eqn 6
-        // index: we use ((bsAge.inDays()/2) mod 4) for τ = t - δ_v respectively τ = t
+        // index: we use ((bsAge/2) mod 4) for τ = t - δ_v respectively τ = t
         float lagged_Pi[taus];   // Pi(τ) for τ ∈ {t - δ_v, ..., t - 2}
     };
     // variant-specific data; variants[i-1] corresponds to variant i in the paper

--- a/model/WithinHost/Infection/PennyInfection.cpp
+++ b/model/WithinHost/Infection/PennyInfection.cpp
@@ -193,7 +193,7 @@ PennyInfection::PennyInfection(LocalRng& rng, uint32_t protID):
 
 bool PennyInfection::updateDensity( LocalRng& rng, double survivalFactor, SimTime bsAge, double ){
     int ageDays = bsAge.inDays();       // lazy
-    if( bsAge == SimTime::zero() ){
+    if( bsAge == sim::zero() ){
         // assign initial densities (Y circulating, X sequestered)
         size_t today = mod_nn(ageDays, delta_C);
         

--- a/model/WithinHost/Infection/PennyInfection.cpp
+++ b/model/WithinHost/Infection/PennyInfection.cpp
@@ -192,7 +192,7 @@ PennyInfection::PennyInfection(LocalRng& rng, uint32_t protID):
 
 
 bool PennyInfection::updateDensity( LocalRng& rng, double survivalFactor, SimTime bsAge, double ){
-    int ageDays = bsAge.inDays();       // lazy
+    int ageDays = bsAge;       // lazy
     if( bsAge == sim::zero() ){
         // assign initial densities (Y circulating, X sequestered)
         size_t today = mod_nn(ageDays, delta_C);

--- a/model/WithinHost/Pathogenesis/Submodels.cpp
+++ b/model/WithinHost/Pathogenesis/Submodels.cpp
@@ -74,7 +74,7 @@ void PyrogenPathogenesis::init( const Parameters& parameters ){
     
     //alpha: factor determining increase in pyrogenic threshold
     double alpha14 = parameters[Parameters::ALPHA];
-    a = alpha14 * SimTime::oneTS().inDays() * delt;  
+    a = alpha14 * sim::oneTS().inDays() * delt;  
     
     //Ystar1: critical value of parasite density in determing increase in pyrog t
     Ystar1_26 = parameters[Parameters::Y_STAR_1];

--- a/model/WithinHost/Pathogenesis/Submodels.cpp
+++ b/model/WithinHost/Pathogenesis/Submodels.cpp
@@ -74,7 +74,7 @@ void PyrogenPathogenesis::init( const Parameters& parameters ){
     
     //alpha: factor determining increase in pyrogenic threshold
     double alpha14 = parameters[Parameters::ALPHA];
-    a = alpha14 * sim::oneTS().inDays() * delt;  
+    a = alpha14 * sim::oneTS() * delt;  
     
     //Ystar1: critical value of parasite density in determing increase in pyrog t
     Ystar1_26 = parameters[Parameters::Y_STAR_1];

--- a/model/WithinHost/Treatments.cpp
+++ b/model/WithinHost/Treatments.cpp
@@ -47,7 +47,7 @@ Treatments::Stages stageFromString( const std::string& str ){
     throw util::format_error( std::string("stage must be liver, blood or both, not ").append(str) );
 }
 Treatments::Treatments( const scnXml::TreatmentOption& elt ) :
-    TriggeredDeployments(elt), timeLiver(SimTime::zero()), timeBlood(SimTime::zero())
+    TriggeredDeployments(elt), timeLiver(sim::zero()), timeBlood(sim::zero())
 {
     for( auto it = elt.getClearInfections().begin(), end = elt.getClearInfections().end();
         it != end; ++it )
@@ -55,17 +55,17 @@ Treatments::Treatments( const scnXml::TreatmentOption& elt ) :
         try{
             //NOTE: if changing XSD, this should not be called "timesteps" or have a default unit
             SimTime len = UnitParse::readShortDuration( it->getTimesteps(), UnitParse::STEPS );
-            if( len < -SimTime::oneTS() || len == SimTime::zero() ){ 
+            if( len < -sim::oneTS() || len == sim::zero() ){ 
                 throw util::format_error( "timesteps must be ≥ 1 or have special value -1" );
             }
             Stages stage = stageFromString( it->getStage() );
             if( stage & LIVER ){
-                if( timeLiver != SimTime::zero() )   // existing treatment configuration
+                if( timeLiver != sim::zero() )   // existing treatment configuration
                     throw util::format_error( "multiple specification of liver stage effect" );
                 timeLiver = len;
             }
             if( stage & BLOOD ){
-                if( timeBlood != SimTime::zero() )   // existing treatment configuration
+                if( timeBlood != sim::zero() )   // existing treatment configuration
                     throw util::format_error( "multiple specification of blood stage effect" );
                 timeBlood = len;
             }

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -95,7 +95,7 @@ void WHFalciparum::init( const OM::Parameters& parameters, const scnXml::Model& 
     alpha_m = 1.0 - exp(-parameters[Parameters::NEG_LOG_ONE_MINUS_ALPHA_M]);
     decayM = parameters[Parameters::DECAY_M];
     
-    y_lag_len = SimTime::fromDays(20).inSteps() + 1;
+    y_lag_len = sim::fromDays(20).inSteps() + 1;
     
     //NOTE: should also call cleanup() on the PathogenesisModel, but it only frees memory which the OS does anyway
     Pathogenesis::PathogenesisModel::init( parameters, model.getClinical(), false );
@@ -180,9 +180,9 @@ double WHFalciparum::probTransmissionToMosquito( double tbvFactor, double *sumX 
     
     // Take weighted sum of total asexual blood stage density 10, 15 and 20 days
     // before. Add y_lag_len to index to ensure positive.
-    size_t d10 = mod_nn(y_lag_len + (sim::ts1() - SimTime::fromDays(10)).inSteps(), y_lag_len);
-    size_t d15 = mod_nn(y_lag_len + (sim::ts1() - SimTime::fromDays(15)).inSteps(), y_lag_len);
-    size_t d20 = mod_nn(y_lag_len + (sim::ts1() - SimTime::fromDays(20)).inSteps(), y_lag_len);
+    size_t d10 = mod_nn(y_lag_len + (sim::ts1() - sim::fromDays(10)).inSteps(), y_lag_len);
+    size_t d15 = mod_nn(y_lag_len + (sim::ts1() - sim::fromDays(15)).inSteps(), y_lag_len);
+    size_t d20 = mod_nn(y_lag_len + (sim::ts1() - sim::fromDays(20)).inSteps(), y_lag_len);
     // Sum lagged densities across genotypes:
     double y10 = 0.0, y15 = 0.0, y20 = 0.0;
     for( size_t genotype = 0; genotype < Genotypes::N(); ++genotype ){
@@ -219,8 +219,8 @@ double WHFalciparum::pTransGenotype(double pTrans, double sumX, size_t genotype)
     
     // Take weighted sum of total asexual blood stage density 10, 15 and 20 days
     // before. Add y_lag_len to index to ensure positive.
-    const int i10 = (sim::ts0() - SimTime::fromDays(10) + SimTime::oneTS()).inSteps() + y_lag_len;
-    const int i5d = SimTime::fromDays(5).inSteps();
+    const int i10 = (sim::ts0() - sim::fromDays(10) + sim::oneTS()).inSteps() + y_lag_len;
+    const int i5d = sim::fromDays(5).inSteps();
     const int i10d = 2 * i5d;
     const double x =
         PTM_beta1 * m_y_lag[mod_nn(i10, y_lag_len) * Genotypes::N() + genotype] +
@@ -244,15 +244,15 @@ void WHFalciparum::treatment( Host::Human& human, TreatmentId treatId ){
                   interventions::VaccineLimits(/*default initialise: no limits*/) );
 }
 bool WHFalciparum::treatSimple( Host::Human& human, SimTime timeLiver, SimTime timeBlood ){
-    if( timeLiver != SimTime::zero() ){
-        if( timeLiver < SimTime::zero() )
+    if( timeLiver != sim::zero() ){
+        if( timeLiver < sim::zero() )
             clearInfections( Treatments::LIVER );
         else
             treatExpiryLiver = max( treatExpiryLiver, sim::nowOrTs1() + timeLiver );
         mon::reportEventMHI( mon::MHT_LS_TREATMENTS, human, 1 );
     }
-    if( timeBlood != SimTime::zero() ){
-        if( timeBlood < SimTime::zero() )
+    if( timeBlood != sim::zero() ){
+        if( timeBlood < sim::zero() )
             clearInfections( Treatments::BLOOD );
         else
             treatExpiryBlood = max( treatExpiryBlood, sim::nowOrTs1() + timeBlood );

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -124,7 +124,8 @@ WHFalciparum::WHFalciparum( LocalRng& rng, double comorbidityFactor ):
     WHInterface(),
     m_cumulative_h(0.0), m_cumulative_Y(0.0), m_cumulative_Y_lag(0.0),
     totalDensity(0.0), hrp2Density(0.0), timeStepMaxDensity(0.0),
-    pathogenesisModel( Pathogenesis::PathogenesisModel::createPathogenesisModel( comorbidityFactor ) )
+    pathogenesisModel( Pathogenesis::PathogenesisModel::createPathogenesisModel( comorbidityFactor ) ),
+    treatExpiryLiver(0), treatExpiryBlood(0)
 {
     // NOTE: negating a Gaussian sample with mean 0 is pointless — except that
     // the individual samples change. In any case the overhead is negligible.

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -248,14 +248,14 @@ bool WHFalciparum::treatSimple( Host::Human& human, SimTime timeLiver, SimTime t
         if( timeLiver < sim::zero() )
             clearInfections( Treatments::LIVER );
         else
-            treatExpiryLiver = max( treatExpiryLiver, sim::nowOrTs1() + timeLiver );
+            treatExpiryLiver = max( int(treatExpiryLiver), int(sim::nowOrTs1()) + timeLiver );
         mon::reportEventMHI( mon::MHT_LS_TREATMENTS, human, 1 );
     }
     if( timeBlood != sim::zero() ){
         if( timeBlood < sim::zero() )
             clearInfections( Treatments::BLOOD );
         else
-            treatExpiryBlood = max( treatExpiryBlood, sim::nowOrTs1() + timeBlood );
+            treatExpiryBlood = max( int(treatExpiryBlood), int(sim::nowOrTs1()) + timeBlood );
         return true;    // blood stage treatment
     }
     return false;    // no blood stage treatment

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -76,7 +76,7 @@ static double alpha_m;
 /// decay rate of maternal protection in years^(-1).
 static double decayM;
 
-SimTime Infection::s_latentP;
+SimTime Infection::s_latentP = sim::never();
 int WHFalciparum::y_lag_len = 0;
 
 

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -180,9 +180,9 @@ double WHFalciparum::probTransmissionToMosquito( double tbvFactor, double *sumX 
     
     // Take weighted sum of total asexual blood stage density 10, 15 and 20 days
     // before. Add y_lag_len to index to ensure positive.
-    size_t d10 = mod_nn(y_lag_len + (sim::ts1() - sim::fromDays(10)).inSteps(), y_lag_len);
-    size_t d15 = mod_nn(y_lag_len + (sim::ts1() - sim::fromDays(15)).inSteps(), y_lag_len);
-    size_t d20 = mod_nn(y_lag_len + (sim::ts1() - sim::fromDays(20)).inSteps(), y_lag_len);
+    size_t d10 = mod_nn(y_lag_len + sim::inSteps(sim::ts1() - sim::fromDays(10)), y_lag_len);
+    size_t d15 = mod_nn(y_lag_len + sim::inSteps(sim::ts1() - sim::fromDays(15)), y_lag_len);
+    size_t d20 = mod_nn(y_lag_len + sim::inSteps(sim::ts1() - sim::fromDays(20)), y_lag_len);
     // Sum lagged densities across genotypes:
     double y10 = 0.0, y15 = 0.0, y20 = 0.0;
     for( size_t genotype = 0; genotype < Genotypes::N(); ++genotype ){
@@ -219,8 +219,8 @@ double WHFalciparum::pTransGenotype(double pTrans, double sumX, size_t genotype)
     
     // Take weighted sum of total asexual blood stage density 10, 15 and 20 days
     // before. Add y_lag_len to index to ensure positive.
-    const int i10 = (sim::ts0() - sim::fromDays(10) + sim::oneTS()).inSteps() + y_lag_len;
-    const int i5d = sim::fromDays(5).inSteps();
+    const int i10 = sim::inSteps(sim::ts0() - sim::fromDays(10) + sim::oneTS()) + y_lag_len;
+    const int i5d = sim::inSteps(sim::fromDays(5));
     const int i10d = 2 * i5d;
     const double x =
         PTM_beta1 * m_y_lag[mod_nn(i10, y_lag_len) * Genotypes::N() + genotype] +

--- a/model/WithinHost/WHFalciparum.cpp
+++ b/model/WithinHost/WHFalciparum.cpp
@@ -95,7 +95,7 @@ void WHFalciparum::init( const OM::Parameters& parameters, const scnXml::Model& 
     alpha_m = 1.0 - exp(-parameters[Parameters::NEG_LOG_ONE_MINUS_ALPHA_M]);
     decayM = parameters[Parameters::DECAY_M];
     
-    y_lag_len = sim::fromDays(20).inSteps() + 1;
+    y_lag_len = sim::inSteps(sim::fromDays(20)) + 1;
     
     //NOTE: should also call cleanup() on the PathogenesisModel, but it only frees memory which the OS does anyway
     Pathogenesis::PathogenesisModel::init( parameters, model.getClinical(), false );

--- a/model/WithinHost/WHVivax.cpp
+++ b/model/WithinHost/WHVivax.cpp
@@ -79,7 +79,7 @@ private:
 // ———  parameters  ———
 
 // Set from the parameters block:
-SimTime latentP;       // attribute on parameters block
+SimTime latentP = sim::never();       // attribute on parameters block
 
 // Set from <vivax .../> element:
 double probBloodStageInfectiousToMosq = numeric_limits<double>::signaling_NaN();
@@ -87,7 +87,7 @@ int maxNumberHypnozoites = -1;
 double baseNumberHypnozoites = numeric_limits<double>::signaling_NaN();
 HypnozoiteReleaseDistribution latentRelapse1st, latentRelapse2nd;
 double pSecondRelease = numeric_limits<double>::signaling_NaN();
-SimTime bloodStageProtectionLatency;
+SimTime bloodStageProtectionLatency = sim::never();
 WeibullSampler bloodStageLength;    // units: days
 double pPrimaryA = numeric_limits<double>::signaling_NaN(),
     pPrimaryB = numeric_limits<double>::signaling_NaN();

--- a/model/WithinHost/WHVivax.cpp
+++ b/model/WithinHost/WHVivax.cpp
@@ -68,7 +68,7 @@ struct HypnozoiteReleaseDistribution: private LognormalSampler {
         } while( delay > liverStageMaximumDays || delay < 0.0  );
         
         assert( delay >= 0 && delay < liverStageMaximumDays );
-        return SimTime::roundToTSFromDays( delay + latentRelapse );
+        return sim::roundToTSFromDays( delay + latentRelapse );
     }
     
 private:
@@ -248,7 +248,7 @@ VivaxBrood::UpdResult VivaxBrood::update(LocalRng& rng){
         result.newBS = true;
         
         double lengthDays = bloodStageLength.sample(rng);
-        bloodStageClearDate = sim::ts0() + SimTime::roundToTSFromDays( lengthDays );
+        bloodStageClearDate = sim::ts0() + sim::roundToTSFromDays( lengthDays );
         // Assume gametocytes emerge at the same time (they mature quickly and
         // we have little data, thus assume coincedence of start)
     }
@@ -261,7 +261,7 @@ void VivaxBrood::treatmentBS(){
     // Blood stage treatment: clear both asexual and sexual parasites from the
     // blood. NOTE: we assume infections removed via treatment do not leave
     // protective immunity since the patient was unable to self-clear.
-    bloodStageClearDate = SimTime::never();
+    bloodStageClearDate = sim::never();
 }
 
 void VivaxBrood::treatmentLS(){
@@ -470,7 +470,7 @@ bool WHVivax::treatSimple( Host::Human& human, SimTime timeLiver, SimTime timeBl
     // update instead of now)
     
     // liver-stage treatment is only via "LiverStageDrug" option, if at all
-    if( timeLiver != SimTime::zero() ){
+    if( timeLiver != sim::zero() ){
         if( pReceivePQ > 0.0 ){
             // This is only really disallowed to prevent simultaneous treatment through both methods
             throw util::xml_scenario_error("simple treatment for vivax liver "
@@ -478,7 +478,7 @@ bool WHVivax::treatSimple( Host::Human& human, SimTime timeLiver, SimTime timeBl
             "(liverStageDrug) option; it is suggested to use the former over the latter");
         }
         if( (ignoreNoPQ || !noPQ) && (effectivenessPQ == 1.0 || human.rng().bernoulli(effectivenessPQ)) ){
-            if( timeLiver >= SimTime::zero() ){
+            if( timeLiver >= sim::zero() ){
                 treatExpiryLiver = max( treatExpiryLiver, sim::nowOrTs1() + timeLiver );
             }else{
                 for( auto it = infections.begin(); it != infections.end(); ++it ){
@@ -490,8 +490,8 @@ bool WHVivax::treatSimple( Host::Human& human, SimTime timeLiver, SimTime timeBl
     }
     
     // there probably will be blood-stage treatment
-    if( timeBlood != SimTime::zero() ){
-        if( timeBlood < SimTime::zero() ){
+    if( timeBlood != sim::zero() ){
+        if( timeBlood < sim::zero() ){
             // legacy mode: retroactive clearance
             for( auto it = infections.begin(); it != infections.end(); ++it ){
                 it->treatmentBS();
@@ -566,7 +566,7 @@ void WHVivax::init( const OM::Parameters& parameters, const scnXml::Model& model
         pSecondRelease = hr.getPSecondRelease();
         assert( pSecondRelease >= 0 && pSecondRelease <= 1 );
     } // else pSecondRelease is NaN and other values don't get used
-    bloodStageProtectionLatency = SimTime::roundToTSFromDays( elt.getBloodStageProtectionLatency().getValue() );
+    bloodStageProtectionLatency = sim::roundToTSFromDays( elt.getBloodStageProtectionLatency().getValue() );
     bloodStageLength.setParams(elt.getBloodStageLengthDays());
     
     const scnXml::ClinicalEvents& ce = elt.getClinicalEvents();

--- a/model/WithinHost/WHVivax.cpp
+++ b/model/WithinHost/WHVivax.cpp
@@ -479,7 +479,7 @@ bool WHVivax::treatSimple( Host::Human& human, SimTime timeLiver, SimTime timeBl
         }
         if( (ignoreNoPQ || !noPQ) && (effectivenessPQ == 1.0 || human.rng().bernoulli(effectivenessPQ)) ){
             if( timeLiver >= sim::zero() ){
-                treatExpiryLiver = max( treatExpiryLiver, sim::nowOrTs1() + timeLiver );
+                treatExpiryLiver = max( int(treatExpiryLiver), sim::nowOrTs1() + timeLiver );
             }else{
                 for( auto it = infections.begin(); it != infections.end(); ++it ){
                     it->treatmentLS();
@@ -497,7 +497,7 @@ bool WHVivax::treatSimple( Host::Human& human, SimTime timeLiver, SimTime timeBl
                 it->treatmentBS();
             }
         }else{
-            treatExpiryBlood = max( treatExpiryBlood, sim::nowOrTs1() + timeBlood );
+            treatExpiryBlood = max( int(treatExpiryBlood), sim::nowOrTs1() + timeBlood );
         }
         return true;    // blood stage treatment
     }

--- a/model/WithinHost/WHVivax.cpp
+++ b/model/WithinHost/WHVivax.cpp
@@ -284,6 +284,7 @@ void VivaxBrood::treatmentLS(){
 
 WHVivax::WHVivax( LocalRng& rng, double comorbidityFactor ) :
     cumPrimInf(0),
+    treatExpiryLiver(0), treatExpiryBlood(0),
     pEvent( numeric_limits<double>::quiet_NaN() ),
     pFirstRelapseEvent( numeric_limits<double>::quiet_NaN() ),
     pSevere( 0.0 )

--- a/model/WithinHost/WHVivax.h
+++ b/model/WithinHost/WHVivax.h
@@ -105,7 +105,7 @@ private:
     
     // Either sim::never() (no blood stage) or the start of the time step on
     // which the blood stage will clear.
-    SimTime bloodStageClearDate;
+    SimTime bloodStageClearDate = sim::never();
     
     // Whether the primary blood stage infection has started
     bool primaryHasStarted;

--- a/model/WithinHost/WHVivax.h
+++ b/model/WithinHost/WHVivax.h
@@ -103,7 +103,7 @@ private:
     // time of release, soonest last (i.e. last element is next one to release)
     vector<SimTime> releaseDates;
     
-    // Either SimTime::never() (no blood stage) or the start of the time step on
+    // Either sim::never() (no blood stage) or the start of the time step on
     // which the blood stage will clear.
     SimTime bloodStageClearDate;
     

--- a/model/interventions/Deployments.hpp
+++ b/model/interventions/Deployments.hpp
@@ -222,7 +222,7 @@ public:
     
     virtual void print_details( std::ostream& out )const{
         out << date << "\t"
-            << minAge.inYears() << "y\t" << maxAge.inYears() << "t\t";
+            << sim::inYears(minAge) << "y\t" << sim::inYears(maxAge) << "t\t";
         if( subPop == ComponentId::wholePop() ) out << "(none)";
         else out << subPop.id;
         out << '\t' << complement << '\t' << coverage << '\t';
@@ -520,14 +520,14 @@ public:
         if( deployAge <= sim::zero() ){
             ostringstream msg;
             msg << "continuous intervention with target age "<<elt.getTargetAgeYrs();
-            msg << " years corresponds to time step " << deployAge.inSteps();
+            msg << " years corresponds to time step " << sim::inSteps(deployAge);
             msg << "; must be at least 1.";
             throw util::xml_scenario_error( msg.str() );
         }
         if( deployAge > sim::maxHumanAge() ){
             ostringstream msg;
             msg << "continuous intervention must have target age no greater than ";
-            msg << sim::maxHumanAge().inYears();
+            msg << sim::inYears(sim::maxHumanAge());
             throw util::xml_scenario_error( msg.str() );
         }
     }
@@ -560,7 +560,7 @@ public:
         out << begin << "\t";
         if( end == sim::future() ) out << "(none)";
         else out << end << 't';
-        out << '\t' << deployAge.inYears() << "y\t";
+        out << '\t' << sim::inYears(deployAge) << "y\t";
         if( subPop == ComponentId::wholePop() ) out << "(none)";
         else out << subPop.id;
         out << '\t' << complement << '\t' << coverage << '\t';

--- a/model/interventions/Deployments.hpp
+++ b/model/interventions/Deployments.hpp
@@ -44,7 +44,7 @@ struct ByDeployTime;    // forward decl for friend
 class TimedDeployment {
 public:
     /// Create, passing time of deployment
-    explicit TimedDeployment(SimDate deployDate) :
+    explicit TimedDeployment(SimTime deployDate) :
             date( deployDate )
     {
         if( deployDate < sim::startDate() ){
@@ -61,7 +61,7 @@ public:
     virtual void print_details( std::ostream& out )const =0;
     
     // Read access required in this file; don't really need protection:
-    SimDate date;
+    SimTime date;
 };
 
 class DummyTimedDeployment : public TimedDeployment {
@@ -73,7 +73,7 @@ public:
         // within the intervention period. We want this time to be after the
         // last time-step, so set the time here after TimedDeployment's ctor
         // check has been done (hacky).
-        date = SimDate::future();
+        date = sim::future();
     }
     virtual void deploy (Population& population, Transmission::TransmissionModel& transmission) {}
     virtual void print_details( std::ostream& out )const{
@@ -83,7 +83,7 @@ public:
 
 class TimedChangeHSDeployment : public TimedDeployment {
 public:
-    TimedChangeHSDeployment( SimDate date, const scnXml::ChangeHS::TimedDeploymentType& hs ) :
+    TimedChangeHSDeployment( SimTime date, const scnXml::ChangeHS::TimedDeploymentType& hs ) :
         TimedDeployment( date ),
         newHS( hs._clone() )
     {}
@@ -102,7 +102,7 @@ private:
 
 class TimedChangeEIRDeployment : public TimedDeployment {
 public:
-    TimedChangeEIRDeployment( SimDate date, const scnXml::ChangeEIR::TimedDeploymentType& nv ) :
+    TimedChangeEIRDeployment( SimTime date, const scnXml::ChangeEIR::TimedDeploymentType& nv ) :
         TimedDeployment( date ),
         newEIR( nv._clone() )
     {}
@@ -121,7 +121,7 @@ private:
 
 class TimedUninfectVectorsDeployment : public TimedDeployment {
 public:
-    TimedUninfectVectorsDeployment( SimDate date ) :
+    TimedUninfectVectorsDeployment( SimTime date ) :
         TimedDeployment( date )
     {}
     virtual void deploy (Population& population, Transmission::TransmissionModel& transmission) {
@@ -190,19 +190,19 @@ public:
      * @param intervention The HumanIntervention to deploy.
      * @param subPop Either ComponentId::wholePop() or a sub-population to which deployment is restricted
      */
-    TimedHumanDeployment( SimDate date,
+    TimedHumanDeployment( SimTime date,
                            const scnXml::MassDeployment& mass,
                            shared_ptr<const HumanIntervention> intervention,
                            ComponentId subPop, bool complement ) :
         TimedDeployment( date ),
         HumanDeploymentBase( mass, intervention, subPop, complement ),
-        minAge( SimTime::fromYearsN( mass.getMinAge() ) ),
-        maxAge( SimTime::future() )
+        minAge( sim::fromYearsN( mass.getMinAge() ) ),
+        maxAge( sim::future() )
     {
         if( mass.getMaxAge().present() )
-            maxAge = SimTime::fromYearsN( mass.getMaxAge().get() );
+            maxAge = sim::fromYearsN( mass.getMaxAge().get() );
             
-        if( minAge < SimTime::zero() || maxAge < minAge ){
+        if( minAge < sim::zero() || maxAge < minAge ){
             throw util::xml_scenario_error("timed intervention must have 0 <= minAge <= maxAge");
         }
     }
@@ -245,7 +245,7 @@ public:
      * @param subPop Either ComponentId::wholePop() or a sub-population to which deployment is restricted
      * @param cumCuvId Id of component to test coverage for
      */
-    TimedCumulativeHumanDeployment( SimDate date,
+    TimedCumulativeHumanDeployment( SimTime date,
                            const scnXml::MassDeployment& mass,
                            shared_ptr<const HumanIntervention> intervention,
                            ComponentId subPop, bool complement,
@@ -292,7 +292,7 @@ protected:
 
 class TimedVectorDeployment : public TimedDeployment {
 public:
-    TimedVectorDeployment( SimDate date, size_t instance ) :
+    TimedVectorDeployment( SimTime date, size_t instance ) :
         TimedDeployment( date ),
         inst(instance)
     {}
@@ -311,7 +311,7 @@ private:
 
 class TimedTrapDeployment : public TimedDeployment {
 public:
-    TimedTrapDeployment( SimDate date, size_t instance, double ratio, SimTime lifespan ) :
+    TimedTrapDeployment( SimTime date, size_t instance, double ratio, SimTime lifespan ) :
         TimedDeployment(date), inst(instance), ratio(ratio), lifespan(lifespan)
     {}
     virtual void deploy (Population& population, Transmission::TransmissionModel& transmission) {
@@ -334,7 +334,7 @@ private:
 
 class TimedNonHumanHostsDeployment : public TimedDeployment {
 public:
-    TimedNonHumanHostsDeployment( SimDate date, size_t instance, string intervName, const scnXml::Description2::AnophelesSequence list, const scnXml::DecayFunction &decay, Transmission::TransmissionModel& transmission) :
+    TimedNonHumanHostsDeployment( SimTime date, size_t instance, string intervName, const scnXml::Description2::AnophelesSequence list, const scnXml::DecayFunction &decay, Transmission::TransmissionModel& transmission) :
         TimedDeployment( date ),
         instance(instance),
         intervName(intervName)
@@ -427,7 +427,7 @@ const string vec_mode_err = "vector interventions can only be used in dynamic tr
 
 class TimedAddNonHumanHostsDeployment : public TimedDeployment {
 public:
-    TimedAddNonHumanHostsDeployment( SimDate date, const string &intervName, SimTime lifespan, const scnXml::Description3::AnophelesSequence list, Transmission::TransmissionModel& transmission) :
+    TimedAddNonHumanHostsDeployment( SimTime date, const string &intervName, SimTime lifespan, const scnXml::Description3::AnophelesSequence list, Transmission::TransmissionModel& transmission) :
         TimedDeployment( date ), intervName(intervName), lifespan(lifespan)
     {
         Transmission::VectorModel *vectorModel = dynamic_cast<Transmission::VectorModel *>(&transmission);
@@ -506,18 +506,18 @@ private:
 class ContinuousHumanDeployment : protected HumanDeploymentBase {
 public:
     /// Create, passing deployment age
-    ContinuousHumanDeployment( SimDate begin, SimDate end,
+    ContinuousHumanDeployment( SimTime begin, SimTime end,
                                  const ::scnXml::ContinuousDeployment& elt,
                                  shared_ptr<const HumanIntervention> intervention,
                                  ComponentId subPop, bool complement ) :
             HumanDeploymentBase( elt, intervention, subPop, complement ),
             begin( begin ), end( end ),
-            deployAge( SimTime::fromYearsN( elt.getTargetAgeYrs() ) )
+            deployAge( sim::fromYearsN( elt.getTargetAgeYrs() ) )
     {
         if( begin < sim::startDate() || end < begin ){
             throw util::xml_scenario_error("continuous intervention must have startDate <= begin <= end");
         }
-        if( deployAge <= SimTime::zero() ){
+        if( deployAge <= sim::zero() ){
             ostringstream msg;
             msg << "continuous intervention with target age "<<elt.getTargetAgeYrs();
             msg << " years corresponds to time step " << deployAge.inSteps();
@@ -558,7 +558,7 @@ public:
     
     inline void print_details( std::ostream& out )const{
         out << begin << "\t";
-        if( end == SimDate::future() ) out << "(none)";
+        if( end == sim::future() ) out << "(none)";
         else out << end << 't';
         out << '\t' << deployAge.inYears() << "y\t";
         if( subPop == ComponentId::wholePop() ) out << "(none)";
@@ -568,7 +568,7 @@ public:
     }
     
 protected:
-    SimDate begin, end;    // first time step active and first time step no-longer active
+    SimTime begin, end;    // first time step active and first time step no-longer active
     SimTime deployAge;
     
     friend ByDeployTime;

--- a/model/interventions/Deployments.hpp
+++ b/model/interventions/Deployments.hpp
@@ -61,7 +61,7 @@ public:
     virtual void print_details( std::ostream& out )const =0;
     
     // Read access required in this file; don't really need protection:
-    SimTime date;
+    SimTime date = sim::never();
 };
 
 class DummyTimedDeployment : public TimedDeployment {
@@ -329,7 +329,7 @@ public:
 private:
     size_t inst;
     double ratio;
-    SimTime lifespan;
+    SimTime lifespan = sim::never();
 };
 
 class TimedNonHumanHostsDeployment : public TimedDeployment {
@@ -496,7 +496,7 @@ private:
         double hostFecundityFactor;
     };
     string intervName;
-    SimTime lifespan;
+    SimTime lifespan = sim::never();
     std::map<string, NhhParamsInterv> nhhParams; 
 };
 
@@ -569,7 +569,7 @@ public:
     
 protected:
     SimTime begin, end;    // first time step active and first time step no-longer active
-    SimTime deployAge;
+    SimTime deployAge = sim::never();
     
     friend ByDeployTime;
 };

--- a/model/interventions/HumanComponents.h
+++ b/model/interventions/HumanComponents.h
@@ -93,7 +93,7 @@ private:
      * vaccination reintroduces them to the EPI schedule). */
     uint32_t numDosesAdministered;
     /// Time of last vaccination with this vaccine type
-    SimTime timeLastDeployment;
+    SimTime timeLastDeployment = sim::never();
     /// Efficacy at last deployment (undecayed)
     double initialEfficacy;
     util::DecayFuncHet hetSample;

--- a/model/interventions/HumanInterventionComponents.hpp
+++ b/model/interventions/HumanInterventionComponents.hpp
@@ -160,14 +160,14 @@ void TriggeredDeployments::deploy(Human& human,
 
 TriggeredDeployments::SubList::SubList( const scnXml::TriggeredDeployments::DeployType& elt ) :
         HumanIntervention( elt.getComponent() ),
-        minAge( SimTime::fromYearsN( elt.getMinAge() ) ),
-        maxAge( SimTime::future() ),
+        minAge( sim::fromYearsN( elt.getMinAge() ) ),
+        maxAge( sim::future() ),
         coverage( elt.getP() )
 {
     if( elt.getMaxAge().present() )
-        maxAge = SimTime::fromYearsN( elt.getMaxAge().get() );
+        maxAge = sim::fromYearsN( elt.getMaxAge().get() );
     
-    if( minAge < SimTime::zero() || maxAge < minAge ){
+    if( minAge < sim::zero() || maxAge < minAge ){
         throw util::xml_scenario_error("triggered intervention must have 0 <= minAge <= maxAge");
     }
     
@@ -256,12 +256,12 @@ public:
         try{
             SimTime durL = UnitParse::readShortDuration( elt.getDurationLiver(), UnitParse::NONE ),
                 durB = UnitParse::readShortDuration( elt.getDurationBlood(), UnitParse::NONE );
-            SimTime neg1 = -SimTime::oneTS();
+            SimTime neg1 = -sim::oneTS();
             if( durL < neg1 || durB < neg1 ){
                 throw util::xml_scenario_error( "treatSimple: cannot have durationBlood or durationLiver less than -1" );
             }
             if( util::ModelOptions::option( util::VIVAX_SIMPLE_MODEL ) ){
-                if( durL != SimTime::zero() || durB != neg1 )
+                if( durL != sim::zero() || durB != neg1 )
                     throw util::unimplemented_exception( "vivax model only supports timestepsLiver=0, timestepsBlood=-1" );
                 // Actually, the model ignores these parameters; we just don't want somebody thinking it doesn't.
             }

--- a/model/interventions/HumanInterventionComponents.hpp
+++ b/model/interventions/HumanInterventionComponents.hpp
@@ -300,7 +300,7 @@ public:
     
     void deploy( Human& human, mon::Deploy::Method method, VaccineLimits ) const{
         mon::reportEventMHD( mon::MHD_TREAT, human, method );
-        double age = human.age(sim::nowOrTs1()).inYears();
+        double age = sim::inYears(human.age(sim::nowOrTs1()));
         human.withinHostModel->treatPkPd( schedule, dosage, age, delay_d );
     }
     
@@ -325,7 +325,7 @@ public:
     
     void deploy( Human& human, mon::Deploy::Method method, VaccineLimits )const{
         Clinical::CMDTOut out = tree.exec( Clinical::CMHostData(human,
-                human.age(sim::nowOrTs1()).inYears(),
+                sim::inYears(human.age(sim::nowOrTs1())),
                 Clinical::Episode::NONE /*parameter not needed*/) );
         if( out.treated ){
             mon::reportEventMHD( mon::MHD_TREAT, human, method );

--- a/model/interventions/ITN.cpp
+++ b/model/interventions/ITN.cpp
@@ -666,10 +666,10 @@ void HumanITN::redeploy(LocalRng& rng, const OM::Transmission::HumanVectorInterv
 
 void HumanITN::update(Host::Human& human){
     const ITNComponent& params = *ITNComponent::componentsByIndex[m_id.id];
-    if( deployTime != SimTime::never() ){
+    if( deployTime != sim::never() ){
         // First use is at age 0 relative to ts0()
         if( sim::ts0() >= disposalTime ){
-            deployTime = SimTime::never();
+            deployTime = sim::never();
             human.removeFromSubPop(id());
             return;
         }
@@ -681,27 +681,27 @@ void HumanITN::update(Host::Human& human){
 }
 
 double HumanITN::relativeAttractiveness(size_t speciesIndex) const{
-    if( deployTime == SimTime::never() ) return 1.0;
+    if( deployTime == sim::never() ) return 1.0;
     const ITNComponent& params = *ITNComponent::componentsByIndex[m_id.id];
     const ITNComponent::ITNAnopheles& anoph = params.species[speciesIndex];
     return anoph.relativeAttractiveness( holeIndex, getInsecticideContent(params) );
 }
 
 double HumanITN::preprandialSurvivalFactor(size_t speciesIndex) const{
-    if( deployTime == SimTime::never() ) return 1.0;
+    if( deployTime == sim::never() ) return 1.0;
     const ITNComponent& params = *ITNComponent::componentsByIndex[m_id.id];
     const ITNComponent::ITNAnopheles& anoph = params.species[speciesIndex];
     return anoph.preprandialSurvivalFactor( holeIndex, getInsecticideContent(params) );
 }
 
 double HumanITN::postprandialSurvivalFactor(size_t speciesIndex) const{
-    if( deployTime == SimTime::never() ) return 1.0;
+    if( deployTime == sim::never() ) return 1.0;
     const ITNComponent& params = *ITNComponent::componentsByIndex[m_id.id];
     const ITNComponent::ITNAnopheles& anoph = params.species[speciesIndex];
     return anoph.postprandialSurvivalFactor( holeIndex, getInsecticideContent(params) );
 }
 double HumanITN::relFecundity(size_t speciesIndex) const{
-    if( deployTime == SimTime::never() ) return 1.0;
+    if( deployTime == sim::never() ) return 1.0;
     const ITNComponent& params = *ITNComponent::componentsByIndex[m_id.id];
     const ITNComponent::ITNAnopheles& anoph = params.species[speciesIndex];
     return anoph.relFecundity( holeIndex, getInsecticideContent(params) );

--- a/model/interventions/ITN.h
+++ b/model/interventions/ITN.h
@@ -262,7 +262,7 @@ protected:
     
 private:
     // these parameters express the current state of the net:
-    SimTime disposalTime;	// time at which net will be disposed of (if it's not already been replaced)
+    SimTime disposalTime = sim::never();	// time at which net will be disposed of (if it's not already been replaced)
     int nHoles;				// total number of holes
     double holeIndex;		// a measure of both the number and size of holes
     double initialInsecticide;	// units: mg/m²

--- a/model/interventions/Interfaces.hpp
+++ b/model/interventions/Interfaces.hpp
@@ -134,7 +134,7 @@ private:
     HumanInterventionComponent& operator= ( const HumanInterventionComponent& ) = delete;
     
     ComponentId m_id;
-    SimTime m_duration;
+    SimTime m_duration = sim::never();
 };
 
 /** A description of a human intervention (as a list of components). */

--- a/model/interventions/InterventionManager.cpp
+++ b/model/interventions/InterventionManager.cpp
@@ -67,7 +67,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
             {
                 try
                 {
-                    SimDate date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
+                    SimTime date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                     timed.push_back(unique_ptr<TimedDeployment>(new TimedChangeHSDeployment(date, *it)));
                 }
                 catch (const util::format_error &e)
@@ -87,7 +87,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
             {
                 try
                 {
-                    SimDate date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
+                    SimTime date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                     timed.push_back(unique_ptr<TimedDeployment>(new TimedChangeEIRDeployment(date, *it)));
                 }
                 catch (const util::format_error &e)
@@ -124,14 +124,14 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
             ComponentId id(humanComponents.size()); // i.e. index of next item
             identifierMap.insert(make_pair(component.getId(), id));
 
-            SimTime expireAfter = SimTime::future();
+            SimTime expireAfter = sim::future();
             if (component.getSubPopRemoval().present())
             {
                 const scnXml::SubPopRemoval &removeOpts = component.getSubPopRemoval().get();
                 if (removeOpts.getOnFirstBout()) { removeAtIds[SubPopRemove::ON_FIRST_BOUT].push_back(id); }
                 if (removeOpts.getOnFirstInfection()) { removeAtIds[SubPopRemove::ON_FIRST_INFECTION].push_back(id); }
                 if (removeOpts.getOnFirstTreatment()) { removeAtIds[SubPopRemove::ON_FIRST_TREATMENT].push_back(id); }
-                if (removeOpts.getAfterYears().present()) { expireAfter = SimTime::fromYearsN(removeOpts.getAfterYears().get()); }
+                if (removeOpts.getAfterYears().present()) { expireAfter = sim::fromYearsN(removeOpts.getAfterYears().get()); }
             }
 
             HumanInterventionComponent *hiComponent;
@@ -212,13 +212,13 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                 {
                     try
                     {
-                        SimDate begin = sim::startDate();
+                        SimTime begin = sim::startDate();
                         if (it2->getBegin().present())
                         {
                             begin =
                                 UnitParse::readDate(it2->getBegin().get(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                         }
-                        SimDate end = SimDate::future();
+                        SimTime end = sim::future();
                         if (it2->getEnd().present())
                         {
                             end = UnitParse::readDate(it2->getEnd().get(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
@@ -243,10 +243,10 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                 }
                 try
                 {
-                    multimap<SimDate, const scnXml::MassDeployment *> deployTimes;
+                    multimap<SimTime, const scnXml::MassDeployment *> deployTimes;
                     for (auto it2 = timedIt->getDeploy().begin(), end2 = timedIt->getDeploy().end(); it2 != end2; ++it2)
                     {
-                        SimDate date = UnitParse::readDate(it2->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
+                        SimTime date = UnitParse::readDate(it2->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
 
                         if (it2->getRepeatStep().present() != it2->getRepeatEnd().present())
                         {
@@ -255,8 +255,8 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                         if (it2->getRepeatStep().present())
                         {
                             SimTime step = UnitParse::readDuration(it2->getRepeatStep().get(), UnitParse::NONE);
-                            if (step < SimTime::oneTS()) { throw util::xml_scenario_error("deploy: repeatStep must be >= 1"); }
-                            SimDate end = UnitParse::readDate(it2->getRepeatEnd().get(), UnitParse::NONE);
+                            if (step < sim::oneTS()) { throw util::xml_scenario_error("deploy: repeatStep must be >= 1"); }
+                            SimTime end = UnitParse::readDate(it2->getRepeatEnd().get(), UnitParse::NONE);
                             while (date < end)
                             {
                                 deployTimes.insert(make_pair(date, &*it2));
@@ -268,7 +268,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                             deployTimes.insert(make_pair(date, &*it2));
                         }
                     }
-                    SimDate lastDate = SimDate::never();
+                    SimTime lastDate = sim::never();
                     for (auto deploy = deployTimes.begin(), dpEnd = deployTimes.end(); deploy != dpEnd; ++deploy)
                     {
                         if (deploy->first == lastDate)
@@ -336,7 +336,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
             Vaccine::verifyEnabledForR_0();
             // timed deployments:
             for( auto it = elt.getTimedDeployment().begin(); it != elt.getTimedDeployment().end(); ++it ){
-                SimDate date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
+                SimTime date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                 timed.push_back( new TimedR_0Deployment( date ) );
             }
         }
@@ -350,7 +350,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
             // timed deployments:
             for (auto it = elt.getTimedDeployment().begin(); it != elt.getTimedDeployment().end(); ++it)
             {
-                SimDate date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
+                SimTime date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                 timed.push_back(unique_ptr<TimedDeployment>(new TimedUninfectVectorsDeployment(date)));
             }
         }
@@ -373,7 +373,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                     const scnXml::TimedBaseList::DeploySequence &seq = elt.getTimed().get().getDeploy();
                     for (auto it = seq.begin(); it != seq.end(); ++it)
                     {
-                        SimDate date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
+                        SimTime date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                         timed.push_back(unique_ptr<TimedDeployment>(new TimedVectorDeployment(date, instance)));
                     }
                     instance++;
@@ -398,7 +398,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                 {
                     for (const scnXml::Deploy2 &deploy : elt.getTimed().get().getDeploy())
                     {
-                        SimDate date =
+                        SimTime date =
                             UnitParse::readDate(deploy.getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                         SimTime lifespan = UnitParse::readDuration(deploy.getLifespan(), UnitParse::NONE);
                         timed.push_back(unique_ptr<TimedDeployment>(new TimedAddNonHumanHostsDeployment(date, elt.getName(), lifespan, elt.getDescription().getAnopheles(), transmission)));
@@ -427,7 +427,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                     const scnXml::TimedBaseList::DeploySequence &seq = elt.getTimed().get().getDeploy();
                     for (auto it = seq.begin(); it != seq.end(); ++it)
                     {
-                        SimDate date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
+                        SimTime date = UnitParse::readDate(it->getTime(), UnitParse::STEPS /*STEPS is only for backwards compatibility*/);
                         timed.push_back(
                             unique_ptr<TimedDeployment>(new TimedNonHumanHostsDeployment(date, instance, elt.getNonHumanHostsName(), elt.getDescription().getAnopheles(), decay, transmission)));
                     }
@@ -451,7 +451,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                 {
                     for (const scnXml::Deploy1 &deploy : trap.getTimed().get().getDeploy())
                     {
-                        SimDate date = UnitParse::readDate(deploy.getTime(), UnitParse::STEPS);
+                        SimTime date = UnitParse::readDate(deploy.getTime(), UnitParse::STEPS);
                         double ratio = deploy.getRatioToHumans();
                         SimTime lifespan = UnitParse::readDuration(deploy.getLifespan(), UnitParse::NONE);
                         timed.push_back(unique_ptr<TimedDeployment>(new TimedTrapDeployment(date, instance, ratio, lifespan)));
@@ -511,7 +511,7 @@ ComponentId InterventionManager::getComponentId(const string textId)
 
 void InterventionManager::loadFromCheckpoint(Population &population, Transmission::TransmissionModel &transmission)
 {
-    SimDate date = sim::intervDate();
+    SimTime date = sim::intervDate();
     // We need to re-deploy changeHS and changeEIR interventions, but nothing
     // else. nextTimed should be zero so we can go through all past interventions.
     // Only redeploy those which happened before this time step.
@@ -532,13 +532,13 @@ void InterventionManager::loadFromCheckpoint(Population &population, Transmissio
 
 void InterventionManager::deploy(Population &population, Transmission::TransmissionModel &transmission)
 {
-    if (sim::intervTime() < SimTime::zero()) return;
+    if (sim::intervTime() < sim::zero()) return;
 
     // deploy imported infections (not strictly speaking an intervention)
     importedInfections.import(population);
 
     // deploy timed interventions
-    SimDate now = sim::intervDate();
+    SimTime now = sim::intervDate();
     while (timed[nextTimed]->date <= now)
     {
         timed[nextTimed]->deploy(population, transmission);

--- a/model/interventions/InterventionManager.cpp
+++ b/model/interventions/InterventionManager.cpp
@@ -285,7 +285,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                                 }
                                 msg << cp->getId();
                             }
-                            msg << " has multiple deplyoments at date " << lastDate << " (step " << (lastDate - sim::startDate()).inSteps()
+                            msg << " has multiple deplyoments at date " << lastDate << " (step " << sim::inSteps(lastDate - sim::startDate())
                                 << ')';
                             throw util::xml_scenario_error(msg.str());
                         }

--- a/model/interventions/InterventionManager.cpp
+++ b/model/interventions/InterventionManager.cpp
@@ -260,7 +260,7 @@ void InterventionManager::init(const scnXml::Interventions &intervElt, const Pop
                             while (date < end)
                             {
                                 deployTimes.insert(make_pair(date, &*it2));
-                                date += step;
+                                date = date + step;
                             }
                         }
                         else

--- a/model/mon/Continuous.cpp
+++ b/model/mon/Continuous.cpp
@@ -202,7 +202,7 @@ namespace OM { namespace mon {
         } else {
             if( mod_nn(sim::now(), ctsPeriod) != sim::zero() )
                 return;
-            ctsOStream << sim::now().inSteps() << '\t';
+            ctsOStream << sim::inSteps(sim::now()) << '\t';
         }
 	
         if( duringInit && sim::intervTime() < sim::zero() ){
@@ -210,7 +210,7 @@ namespace OM { namespace mon {
         }else{
             // NOTE: we could switch this to output dates, but (1) it would be
             // breaking change and (2) it may be harder to use.
-            ctsOStream << sim::intervTime().inSteps();
+            ctsOStream << sim::inSteps(sim::intervTime());
         }
 	for( size_t i = 0; i < toReport.size(); ++i )
 	    toReport[i]->call( population, ctsOStream );

--- a/model/mon/Continuous.cpp
+++ b/model/mon/Continuous.cpp
@@ -78,7 +78,7 @@ namespace OM { namespace mon {
     
     // List that we report.
     vector< Callback* > toReport;
-    SimTime ctsPeriod = SimTime::zero();
+    SimTime ctsPeriod = sim::zero();
     bool duringInit = false;
     
     
@@ -96,13 +96,13 @@ namespace OM { namespace mon {
     void ContinuousType::init (const scnXml::Monitoring& monitoring, bool isCheckpoint) {
 	const scnXml::Monitoring::ContinuousOptional& ctsOpt = monitoring.getContinuous();
 	if( ctsOpt.present() == false ) {
-	    ctsPeriod = SimTime::zero();
+	    ctsPeriod = sim::zero();
 	    return;
 	}
 	try{
             //NOTE: if changing XSD, this should not have a default unit:
             ctsPeriod = UnitParse::readShortDuration( ctsOpt.get().getPeriod(), UnitParse::STEPS );
-            if( ctsPeriod < SimTime::oneTS() )
+            if( ctsPeriod < sim::oneTS() )
                 throw util::format_error("must be >= 1 time step");
         }catch( const util::format_error& e ){
             throw xml_scenario_error( string("monitoring/continuous/period: ").append(e.message()) );
@@ -158,13 +158,13 @@ namespace OM { namespace mon {
     }
 
     void ContinuousType::checkpoint (ostream& stream){
-        if( ctsPeriod == SimTime::zero() )
+        if( ctsPeriod == sim::zero() )
             return;	// output disabled
 	
 	streamOff & stream;
     }
     void ContinuousType::checkpoint (istream& stream){
-        if( ctsPeriod == SimTime::zero() )
+        if( ctsPeriod == sim::zero() )
             return;	// output disabled
 	
 	/* We attempt to resume output correctly after a reload by recording
@@ -193,19 +193,19 @@ namespace OM { namespace mon {
     }
     
     void ContinuousType::update (const Population& population){
-        if( ctsPeriod == SimTime::zero() )
+        if( ctsPeriod == sim::zero() )
             return;	// output disabled
         if( !duringInit ){
-            if( sim::intervTime() < SimTime::zero()
-                || mod_nn(sim::intervTime(), ctsPeriod) != SimTime::zero() )
+            if( sim::intervTime() < sim::zero()
+                || mod_nn(sim::intervTime(), ctsPeriod) != sim::zero() )
                 return;
         } else {
-            if( mod_nn(sim::now(), ctsPeriod) != SimTime::zero() )
+            if( mod_nn(sim::now(), ctsPeriod) != sim::zero() )
                 return;
             ctsOStream << sim::now().inSteps() << '\t';
         }
 	
-        if( duringInit && sim::intervTime() < SimTime::zero() ){
+        if( duringInit && sim::intervTime() < sim::zero() ){
             ctsOStream << "nan";
         }else{
             // NOTE: we could switch this to output dates, but (1) it would be

--- a/model/mon/info.h
+++ b/model/mon/info.h
@@ -37,7 +37,7 @@ namespace impl {
     // Variables (checkpointed):
     extern bool isInit; // set true after "initialisation" survey at intervention time 0
     extern size_t survNumEvent, survNumStat;
-    extern SimDate nextSurveyDate;
+    extern SimTime nextSurveyDate;
 }
 
 /// For surveys and measures to say something shouldn't be reported
@@ -56,9 +56,9 @@ inline size_t eventSurveyNumber(){ return impl::survNumEvent; }
 /// reported but acts like it is to set survey variables.
 inline bool isReported(){ return !impl::isInit || impl::survNumStat != NOT_USED; }
 
-/** Date the current (next) survey ends at, or SimTime::never() if no more
+/** Date the current (next) survey ends at, or sim::never() if no more
  * surveys take place. */
-inline SimDate nextSurveyDate() {
+inline SimTime nextSurveyDate() {
     return impl::nextSurveyDate;
 }
 

--- a/model/mon/management.h
+++ b/model/mon/management.h
@@ -36,7 +36,7 @@ namespace OM {
 namespace mon {
 
 /// Read survey times from XML. Return the date of the final survey.
-SimDate readSurveyDates( const scnXml::Monitoring& monitoring );
+SimTime readSurveyDates( const scnXml::Monitoring& monitoring );
 
 /// Call before start of simulation to set up outputs. Call readSurveyDates first.
 void initReporting( const scnXml::Scenario& scenario );

--- a/model/mon/misc.cpp
+++ b/model/mon/misc.cpp
@@ -39,7 +39,7 @@ namespace mon {
 // ———  surveys  ———
 
 struct SurveyDate {
-    SimTime date;       // date of survey
+    SimTime date = sim::never();       // date of survey
     size_t num; // if NOT_USED, the survey is not reported; if greater, this is the survey number
     
     /// Construct

--- a/model/mon/misc.cpp
+++ b/model/mon/misc.cpp
@@ -106,7 +106,7 @@ SimTime readSurveyDates( const scnXml::Monitoring& monitoring ){
                     }else{
                         surveys.insert(make_pair(cur, false));        // does not override existing pair with key 'cur'
                     }
-                    cur += step;
+                    cur = cur + step;
                 }
             }else{
                 if( reporting ){

--- a/model/mon/misc.cpp
+++ b/model/mon/misc.cpp
@@ -148,7 +148,7 @@ SimTime readSurveyDates( const scnXml::Monitoring& monitoring ){
             if( !surveyDate.isReported() ) continue;
             std::cout
                 << (surveyDate.num+1) << '\t'
-                << (surveyDate.date - sim::startDate()).inSteps() << '\t'
+                << sim::inSteps(surveyDate.date - sim::startDate()) << '\t'
                 << surveyDate.date << std::endl;
         }
     }

--- a/model/mon/mon.cpp
+++ b/model/mon/mon.cpp
@@ -52,7 +52,7 @@ namespace impl {
     bool isInit = false;
     size_t surveyIndex = 0;     // index in surveyTimes of next survey
     size_t survNumEvent = NOT_USED, survNumStat = NOT_USED;
-    SimDate nextSurveyDate = SimDate::future();
+    SimTime nextSurveyDate = sim::future();
     
     vector<Condition> conditions;
 }

--- a/model/openMalaria.cpp
+++ b/model/openMalaria.cpp
@@ -244,7 +244,7 @@ void loop(const SimTime humanWarmupLength, Population &population, TransmissionM
         if( errno != 0 )
         {
            char err[256];
-           sprintf(err, "t = %d Please report! Error: ", sim::now());
+           sprintf(err, "t = %d Please report! Error: ", int(sim::now()));
            std::perror(err);
            errno = 0;
         }
@@ -386,7 +386,7 @@ int main(int argc, char* argv[])
             SimTime iterate = transmission->initIterate();
             while(iterate > sim::zero())
             {
-                endTime += iterate;
+                endTime = endTime + iterate;
                 // adjust estimation of final time step: end of current period + length of main phase
                 estEndTime = endTime + (sim::endDate() - sim::startDate()) + sim::oneTS();
                 loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);

--- a/model/openMalaria.cpp
+++ b/model/openMalaria.cpp
@@ -244,7 +244,7 @@ void loop(const SimTime humanWarmupLength, Population &population, TransmissionM
         if( errno != 0 )
         {
            char err[256];
-           sprintf(err, "t = %d Please report! Error: ", sim::now().inDays());
+           sprintf(err, "t = %d Please report! Error: ", sim::now());
            std::perror(err);
            errno = 0;
         }

--- a/model/openMalaria.cpp
+++ b/model/openMalaria.cpp
@@ -333,8 +333,8 @@ int main(int argc, char* argv[])
         else
             startedFromCheckpoint = false;
 
-        sim::s_t0 = SimTime::zero();
-        sim::s_t1 = SimTime::zero();
+        sim::s_t0 = sim::zero();
+        sim::s_t1 = sim::zero();
         
         // Make sure warmup period is at least as long as a human lifespan, as the
         // length required by vector warmup, and is a whole number of years.
@@ -348,14 +348,14 @@ int main(int argc, char* argv[])
             cerr << "transmission (mode=\"forced\") or a longer life-span." << endl;
             humanWarmupLength = transmission->minPreinitDuration();
         }
-        humanWarmupLength = SimTime::fromYearsI( static_cast<int>(ceil(humanWarmupLength.inYears())) );
+        humanWarmupLength = sim::fromYearsI( static_cast<int>(ceil(humanWarmupLength.inYears())) );
         
         estEndTime = humanWarmupLength  // ONE_LIFE_SPAN
             + transmission->expectedInitDuration()
             // plus MAIN_PHASE: survey period plus one TS for last survey
             + (sim::endDate() - sim::startDate())
-            + SimTime::oneTS();
-        assert( estEndTime + SimTime::never() < SimTime::zero() );
+            + sim::oneTS();
+        assert( estEndTime + sim::never() < sim::zero() );
         
         bool skipWarmup = false;
         if (startedFromCheckpoint)
@@ -384,11 +384,11 @@ int main(int argc, char* argv[])
 
             // Transmission init phase
             SimTime iterate = transmission->initIterate();
-            while(iterate > SimTime::zero())
+            while(iterate > sim::zero())
             {
                 endTime += iterate;
                 // adjust estimation of final time step: end of current period + length of main phase
-                estEndTime = endTime + (sim::endDate() - sim::startDate()) + SimTime::oneTS();
+                estEndTime = endTime + (sim::endDate() - sim::startDate()) + sim::oneTS();
                 loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);
                 iterate = transmission->initIterate();
             }
@@ -401,7 +401,7 @@ int main(int argc, char* argv[])
                 (iii)       the intervention packages defined in Intervention()
                 (iv)        the survey times defined in Survey() */
             endTime = estEndTime;
-            sim::s_interv = SimTime::zero();
+            sim::s_interv = sim::zero();
             population->preMainSimInit();
             transmission->summarize();    // Only to reset TransmissionModel::inoculationsPerAgeGroup
             mon::initMainSim();

--- a/model/openMalaria.cpp
+++ b/model/openMalaria.cpp
@@ -198,7 +198,7 @@ void readCheckpoint(const string &checkpointFileName, SimTime &endTime, SimTime 
     checkpoint (in, endTime, estEndTime, population, transmission);
     in.close();
   
-    cerr << sim::now().inSteps() << "t loaded checkpoint" << endl;
+    cerr << sim::inSteps(sim::now()) << "t loaded checkpoint" << endl;
 }
 
 // Internal simulation loop
@@ -340,15 +340,15 @@ int main(int argc, char* argv[])
         // length required by vector warmup, and is a whole number of years.
         SimTime humanWarmupLength = sim::maxHumanAge();
         if( humanWarmupLength < transmission->minPreinitDuration() ){
-            cerr << "Warning: human life-span (" << humanWarmupLength.inYears();
+            cerr << "Warning: human life-span (" << sim::inYears(humanWarmupLength);
             cerr << ") shorter than length of warm-up requested by" << endl;
             cerr << "transmission model ("
-                << transmission->minPreinitDuration().inYears();
+                << sim::inYears(transmission->minPreinitDuration());
             cerr << "). Transmission may be unstable; perhaps use forced" << endl;
             cerr << "transmission (mode=\"forced\") or a longer life-span." << endl;
             humanWarmupLength = transmission->minPreinitDuration();
         }
-        humanWarmupLength = sim::fromYearsI( static_cast<int>(ceil(humanWarmupLength.inYears())) );
+        humanWarmupLength = sim::fromYearsI( static_cast<int>(ceil(sim::inYears(humanWarmupLength))) );
         
         estEndTime = humanWarmupLength  // ONE_LIFE_SPAN
             + transmission->expectedInitDuration()

--- a/model/sim.cpp
+++ b/model/sim.cpp
@@ -48,8 +48,8 @@ SimTime sim::s_max_human_age = sim::never();
 #ifndef NDEBUG
 bool sim::in_update = false;
 #endif
-SimTime sim::s_t0;
-SimTime sim::s_t1;
+SimTime sim::s_t0 = sim::never();
+SimTime sim::s_t1 = sim::never();
 
 SimTime sim::s_interv = sim::never();
 

--- a/model/sim.cpp
+++ b/model/sim.cpp
@@ -55,14 +55,14 @@ SimTime sim::s_interv = sim::never();
 
 using util::CommandLine;
 
-ostream& operator<<( ostream& stream, SimTime time ){
-    if( time.inDays() % sim::DAYS_IN_YEAR == 0 ){
-        stream << time.inYears() << 'y';
-    } else {
-        stream << time.inDays() << 'd';
-    }
-    return stream;
-}
+// ostream& operator<<( ostream& stream, SimTime time ){
+//     if( time % sim::DAYS_IN_YEAR == 0 ){
+//         stream << time.inYears() << 'y';
+//     } else {
+//         stream << time << 'd';
+//     }
+//     return stream;
+// }
 
 // ostream& operator<<( ostream& stream, SimTime date ){
 //     int days = date.d;

--- a/model/sim.cpp
+++ b/model/sim.cpp
@@ -39,10 +39,10 @@ int SimData::interval;
 size_t SimData::steps_per_year;
 double SimData::years_per_step;
 
-SimTime sim::s_start;
-SimTime sim::s_end;
+SimTime sim::s_start = sim::never();
+SimTime sim::s_end = sim::never();
 
-SimTime sim::s_max_human_age;
+SimTime sim::s_max_human_age = sim::never();
 
 // Global variables
 #ifndef NDEBUG
@@ -51,7 +51,7 @@ bool sim::in_update = false;
 SimTime sim::s_t0;
 SimTime sim::s_t1;
 
-SimTime sim::s_interv;
+SimTime sim::s_interv = sim::never();
 
 using util::CommandLine;
 

--- a/model/sim.cpp
+++ b/model/sim.cpp
@@ -39,8 +39,8 @@ int SimData::interval;
 size_t SimData::steps_per_year;
 double SimData::years_per_step;
 
-SimDate sim::s_start;
-SimDate sim::s_end;
+SimTime sim::s_start;
+SimTime sim::s_end;
 
 SimTime sim::s_max_human_age;
 
@@ -64,43 +64,43 @@ ostream& operator<<( ostream& stream, SimTime time ){
     return stream;
 }
 
-ostream& operator<<( ostream& stream, SimDate date ){
-    int days = date.d;
-    if (days < 0) {
-        // Shouldn't happen; best still to print something
-        stream << days << 'd';
-    } else {
-        int year = days / sim::DAYS_IN_YEAR;
-        days -= year * sim::DAYS_IN_YEAR;
+// ostream& operator<<( ostream& stream, SimTime date ){
+//     int days = date.d;
+//     if (days < 0) {
+//         // Shouldn't happen; best still to print something
+//         stream << days << 'd';
+//     } else {
+//         int year = days / sim::DAYS_IN_YEAR;
+//         days -= year * sim::DAYS_IN_YEAR;
         
-        int month = 0;
-        while( days >= UnitParse::monthStart[month+1] ) ++month;
-        days -= UnitParse::monthStart[month];
-        assert( month < 12 && days < UnitParse::monthLen[month] );
+//         int month = 0;
+//         while( days >= UnitParse::monthStart[month+1] ) ++month;
+//         days -= UnitParse::monthStart[month];
+//         assert( month < 12 && days < UnitParse::monthLen[month] );
         
-        // Inconsistency in year vs month and day: see parseDate()
-        stream << setfill('0') << setw(4) << year << '-'
-                << setw(2) << (month+1) << '-' << (days+1)
-                << setw(0) << setfill(' ');
-    }
-    return stream;
-}
+//         // Inconsistency in year vs month and day: see parseDate()
+//         stream << setfill('0') << setw(4) << year << '-'
+//                 << setw(2) << (month+1) << '-' << (days+1)
+//                 << setw(0) << setfill(' ');
+//     }
+//     return stream;
+// }
 
 void sim::init( const scnXml::Scenario& scenario ){
     SimData::interval = scenario.getModel().getParameters().getInterval();
-    SimData::steps_per_year = SimTime::oneYear().inSteps();
+    SimData::steps_per_year = sim::oneYear().inSteps();
     SimData::years_per_step = 1.0 / SimData::steps_per_year;
     
     sim::s_max_human_age =
-        SimTime::fromYearsD( scenario.getDemography().getMaximumAgeYrs() );
+        sim::fromYearsD( scenario.getDemography().getMaximumAgeYrs() );
     
-    sim::s_start = SimDate::origin();
+    sim::s_start = sim::origin();
     auto mon = scenario.getMonitoring();
     if( mon.getStartDate().present() ){
         try{
-            // on failure, this throws or returns SimDate::never()
+            // on failure, this throws or returns sim::never()
             sim::s_start = UnitParse::parseDate( mon.getStartDate().get() );
-            if( sim::s_start == SimDate::never() ){
+            if( sim::s_start == sim::never() ){
                 throw util::format_error( "invalid format (expected YYYY-MM-DD)" );
             }
         }catch( const util::format_error& e ){
@@ -108,7 +108,7 @@ void sim::init( const scnXml::Scenario& scenario ){
         }
     }
     
-    sim::s_interv = SimTime::never();    // large negative number
+    sim::s_interv = sim::never();    // large negative number
     
     sim::s_end = mon::readSurveyDates( mon );
 }

--- a/model/sim.cpp
+++ b/model/sim.cpp
@@ -88,7 +88,7 @@ using util::CommandLine;
 
 void sim::init( const scnXml::Scenario& scenario ){
     SimData::interval = scenario.getModel().getParameters().getInterval();
-    SimData::steps_per_year = sim::oneYear().inSteps();
+    SimData::steps_per_year = sim::inSteps(sim::oneYear());
     SimData::years_per_step = 1.0 / SimData::steps_per_year;
     
     sim::s_max_human_age =

--- a/model/sim.h
+++ b/model/sim.h
@@ -245,7 +245,6 @@ public:
     // Scenario constants
     static SimTime s_start;
     static SimTime s_end;
-    
     static SimTime s_max_human_age;
     
     // Global variables
@@ -254,11 +253,7 @@ public:
 #endif
     static SimTime s_t0;
     static SimTime s_t1;
-    
     static SimTime s_interv;
-    
-    friend class Simulator;
-    friend class ::UnittestUtil;
 };
 
 }

--- a/model/sim.h
+++ b/model/sim.h
@@ -74,7 +74,7 @@ class SimData {
 class SimTime {
     public:
     /** Construct, from a time in days. */
-    explicit SimTime( int days ) : d(days) {}
+    SimTime( int days ) : d(days) {}
     
     operator int() const { return d; }
 
@@ -83,65 +83,10 @@ class SimTime {
     /** Default construction; same as sim::never(). */
     SimTime() : d(0) {}
     
-    // /// Convert to years
-    // inline double inYears() const{ return d * (1.0 / SimData::DAYS_IN_YEAR); }
-    
-    // /// Convert to time steps (rounding down)
-    // inline int inSteps() const{ return d / SimData::interval; }
-    // //@}
-    
-
-    ///@brief Simple arithmatic modifiers (all return a copy)
-    //@{
-    inline SimTime operator-()const {
-        return SimTime( -d );
-    }
-    inline SimTime operator-( const SimTime rhs )const {
-        return SimTime( d - rhs.d );
-    }
-    inline SimTime operator+( const SimTime rhs )const {
-        return SimTime( d + rhs.d );
-    }
-    // scale by an integer
-    // inline SimTime operator*( int scalar )const {
-    //     return SimTime( d * scalar );
-    // }
-    // // scale by a double, rounding to nearest
-    // inline SimTime operator*( double scalar )const {
-    //     return SimTime( static_cast<int>(d * scalar + 0.5) );
-    // }
-    // Divide by another SimTime; result is unitless. Note integer division.
-    inline int operator/( const SimTime rhs )const{
-        return d / rhs.d;
-    }
-    //@}
-    
     ///@brief Self-modifying arithmatic
     //@{
     inline void operator+=( const SimTime rhs ) {
         d += rhs.d;
-    }
-    //@}
-    
-    ///@brief Comparators between two SimTimes (all return a boolean)
-    //@{
-    inline bool operator==( const SimTime rhs )const {
-        return  d == rhs.d;
-    }
-    inline bool operator!=( const SimTime rhs )const {
-        return  d != rhs.d;
-    }
-    inline bool operator>( const SimTime rhs )const {
-        return  d > rhs.d;
-    }
-    inline bool operator>=( const SimTime rhs )const {
-        return  d >= rhs.d;
-    }
-    inline bool operator<( const SimTime rhs )const {
-        return  d < rhs.d;
-    }
-    inline bool operator<=( const SimTime rhs )const {
-        return  d <= rhs.d;
     }
     //@}
     
@@ -154,14 +99,7 @@ class SimTime {
     
 private:
     int d;      // time in days
-    
-    friend SimTime mod_nn( const SimTime lhs, const SimTime rhs );
-    // friend ostream& operator<<( ostream& stream, SimTime date );
 };
-
-inline SimTime mod_nn( const SimTime lhs, const SimTime rhs ){
-    return SimTime(util::mod_nn(lhs.d, rhs.d));
-}
 
 /** Encapsulates static variables: sim time. */
 class sim {

--- a/model/sim.h
+++ b/model/sim.h
@@ -83,12 +83,12 @@ class SimTime {
     /** Default construction; same as sim::never(). */
     SimTime() : d(0) {}
     
-    ///@brief Self-modifying arithmatic
-    //@{
-    inline void operator+=( const SimTime rhs ) {
-        d += rhs.d;
-    }
-    //@}
+    // ///@brief Self-modifying arithmatic
+    // //@{
+    // inline void operator+=( const SimTime rhs ) {
+    //     d += rhs.d;
+    // }
+    // //@}
     
     /// Checkpointing
     template<class S>
@@ -261,7 +261,7 @@ public:
     
     // Start of update: called by Simulator
     static inline void start_update(){
-        s_t1 += sim::oneTS();
+        s_t1 = s_t1 + sim::oneTS();
 #ifndef NDEBUG
         in_update = true;
 #endif
@@ -272,7 +272,7 @@ public:
         in_update = false;
 #endif
         s_t0 = s_t1;
-        s_interv += sim::oneTS();
+        s_interv = s_interv + sim::oneTS();
     }
     
     // Scenario constants

--- a/model/sim.h
+++ b/model/sim.h
@@ -66,28 +66,7 @@ class SimData {
  * 
  * Granularity: 1 day.
  *****************************************************************************/
-class SimTime {
-    public:
-    /** Construct, from a time in days. */
-    SimTime( int days ) : d(days) {}
-    
-    operator int() const { return d; }
-
-    ///@brief Unparameterised constructors
-    //@{
-    /** Default construction; same as sim::never(). */
-    SimTime() = default;
-    
-    // ///@brief Self-modifying arithmatic
-    template<class S>
-    void operator& (S& stream) {
-        using namespace OM::util::checkpoint;
-        d & stream;
-    }
-    
-private:
-    int d;      // time in days
-};
+typedef int SimTime;
 
 /** Encapsulates static variables: sim time. */
 class sim {

--- a/model/sim.h
+++ b/model/sim.h
@@ -172,7 +172,7 @@ private:
     int d;      // time in days
     
     friend SimTime mod_nn( const SimTime lhs, const SimTime rhs );
-    friend ostream& operator<<( ostream& stream, SimTime date );
+    // friend ostream& operator<<( ostream& stream, SimTime date );
 };
 
 inline SimTime mod_nn( const SimTime lhs, const SimTime rhs ){

--- a/model/sim.h
+++ b/model/sim.h
@@ -83,23 +83,6 @@ class SimTime {
     /** Default construction; same as sim::never(). */
     SimTime() : d(0) {}
     
-    /** Return this time in time steps modulo some positive integer. */
-    inline int moduloSteps(int denominator){
-        return util::mod_nn(d / SimData::interval, denominator);
-    }
-    
-    /** Return this time in time steps modulo some positive integer. */
-    inline int moduloYearSteps(){
-        return util::mod_nn(d / SimData::interval, SimData::steps_per_year);
-    }
-
-    ///@brief Conversions to other types/units
-    //NOTE: these methods provide good documentation of the types of things
-    //one does with SimTimes (besides comparing with other SimTimes).
-    //@{
-    /// Get length of time in days. Currently this is simple no-op get.
-    inline int inDays() const{ return d; }
-    
     /// Convert to years
     inline double inYears() const{ return d * (1.0 / SimData::DAYS_IN_YEAR); }
     
@@ -107,6 +90,7 @@ class SimTime {
     inline int inSteps() const{ return d / SimData::interval; }
     //@}
     
+
     ///@brief Simple arithmatic modifiers (all return a copy)
     //@{
     inline SimTime operator-()const {
@@ -186,6 +170,15 @@ public:
     //@{
     /// Number of days in a year; defined as 365 (leap years are not simulated).
     enum { DAYS_IN_YEAR = 365 };
+    
+    ///@brief Conversions to other types/units
+    //@{
+    /// Convert to years
+    static inline double inYears(SimTime d) { return d * (1.0 / SimData::DAYS_IN_YEAR); }
+    
+    /// Convert to time steps (rounding down)
+    static inline int inSteps(SimTime d) { return d / SimData::interval; }
+    //@}
     
     /** Return this time in time steps modulo some positive integer. */
     static inline int moduloSteps(SimTime d, int denominator){

--- a/model/sim.h
+++ b/model/sim.h
@@ -55,14 +55,18 @@ class SimData {
 
 
 /******************************************************************************
- * Class encapsulating simulation durations and times relative to the start.
+ * Since version 43.1, SimTime is an integer instead of a class. Note: a 
+ * class can be used again simply by replacing the following typedef 
+ * definition by the old SimTime class.
+ * 
+ * SimTime is now always a number of days.
  * 
  * Time steps, days and dates are derived from this. The values and units of
- * internal variables are an implementation detail (i.e. code outside this
- * class should not need to know).
+ * internal variables are an implementation detail (i.e. code outside of
+ * sim should not need to know).
  * 
- * The simulation always starts at time zero. "Intervention time" is a separate
- * concept (see SimTime).
+ * The simulation always starts at time zero. "Intervention time" is the 
+ * beginning of the scenario and monitoring period.
  * 
  * Granularity: 1 day.
  *****************************************************************************/

--- a/model/sim.h
+++ b/model/sim.h
@@ -81,7 +81,7 @@ class SimTime {
     ///@brief Unparameterised constructors
     //@{
     /** Default construction; same as sim::never(). */
-    SimTime() : d(-0x3FFFFFFF) {}
+    SimTime() : d(0) {}
     
     /** Return this time in time steps modulo some positive integer. */
     inline int moduloSteps(int denominator){
@@ -206,7 +206,7 @@ public:
      * never() + x < zero() and x - never() will not to overflow for all valid
      * simulation times x (including any value now() may take as well as
      * never() and future()). */
-    static inline SimTime never(){ return SimTime(); }
+    static inline SimTime never(){ return SimTime(-0x3FFFFFFF); }
     
     /** Special value representing a time point always in the future, such that
      * now() < future() and now() + future() does not overflow. */

--- a/model/sim.h
+++ b/model/sim.h
@@ -83,12 +83,12 @@ class SimTime {
     /** Default construction; same as sim::never(). */
     SimTime() : d(0) {}
     
-    /// Convert to years
-    inline double inYears() const{ return d * (1.0 / SimData::DAYS_IN_YEAR); }
+    // /// Convert to years
+    // inline double inYears() const{ return d * (1.0 / SimData::DAYS_IN_YEAR); }
     
-    /// Convert to time steps (rounding down)
-    inline int inSteps() const{ return d / SimData::interval; }
-    //@}
+    // /// Convert to time steps (rounding down)
+    // inline int inSteps() const{ return d / SimData::interval; }
+    // //@}
     
 
     ///@brief Simple arithmatic modifiers (all return a copy)

--- a/model/sim.h
+++ b/model/sim.h
@@ -76,7 +76,7 @@ class SimTime {
     /** Construct, from a time in days. */
     explicit SimTime( int days ) : d(days) {}
     
-    operator int() { return d; }
+    operator int() const { return d; }
 
     ///@brief Unparameterised constructors
     //@{

--- a/model/sim.h
+++ b/model/sim.h
@@ -119,13 +119,13 @@ class SimTime {
         return SimTime( d + rhs.d );
     }
     // scale by an integer
-    inline SimTime operator*( int scalar )const {
-        return SimTime( d * scalar );
-    }
-    // scale by a double, rounding to nearest
-    inline SimTime operator*( double scalar )const {
-        return SimTime( static_cast<int>(d * scalar + 0.5) );
-    }
+    // inline SimTime operator*( int scalar )const {
+    //     return SimTime( d * scalar );
+    // }
+    // // scale by a double, rounding to nearest
+    // inline SimTime operator*( double scalar )const {
+    //     return SimTime( static_cast<int>(d * scalar + 0.5) );
+    // }
     // Divide by another SimTime; result is unitless. Note integer division.
     inline int operator/( const SimTime rhs )const{
         return d / rhs.d;
@@ -225,7 +225,7 @@ public:
     ///@brief Parameterised constructors
     //@{
     /** Convert. */
-    static inline SimTime fromTS(int ts){ return oneTS() * ts; }
+    static inline SimTime fromTS(int ts){ return SimTime(int(oneTS()) * ts); }
     
     /** Duration in days. Should be fast (currently no conversion required). */
     static inline SimTime fromDays(int days){ return SimTime(days); }

--- a/model/sim.h
+++ b/model/sim.h
@@ -76,11 +76,23 @@ class SimTime {
     /** Construct, from a time in days. */
     explicit SimTime( int days ) : d(days) {}
     
+    operator int() { return d; }
+
     ///@brief Unparameterised constructors
     //@{
     /** Default construction; same as sim::never(). */
     SimTime() : d(-0x3FFFFFFF) {}
     
+    /** Return this time in time steps modulo some positive integer. */
+    inline int moduloSteps(int denominator){
+        return util::mod_nn(d / SimData::interval, denominator);
+    }
+    
+    /** Return this time in time steps modulo some positive integer. */
+    inline int moduloYearSteps(){
+        return util::mod_nn(d / SimData::interval, SimData::steps_per_year);
+    }
+
     ///@brief Conversions to other types/units
     //NOTE: these methods provide good documentation of the types of things
     //one does with SimTimes (besides comparing with other SimTimes).
@@ -149,16 +161,6 @@ class SimTime {
     }
     //@}
     
-    /** Return this time in time steps modulo some positive integer. */
-    inline int moduloSteps(int denominator){
-        return util::mod_nn(d / SimData::interval, denominator);
-    }
-    
-    /** Return this time in time steps modulo some positive integer. */
-    inline int moduloYearSteps(){
-        return util::mod_nn(d / SimData::interval, SimData::steps_per_year);
-    }
-    
     /// Checkpointing
     template<class S>
     void operator& (S& stream) {
@@ -185,6 +187,16 @@ public:
     /// Number of days in a year; defined as 365 (leap years are not simulated).
     enum { DAYS_IN_YEAR = 365 };
     
+    /** Return this time in time steps modulo some positive integer. */
+    static inline int moduloSteps(SimTime d, int denominator){
+        return util::mod_nn(d / SimData::interval, denominator);
+    }
+    
+    /** Return this time in time steps modulo some positive integer. */
+    static inline int moduloYearSteps(SimTime d){
+        return util::mod_nn(d / SimData::interval, SimData::steps_per_year);
+    }
+
     /** Duration zero and the time at the start of the simulation. */
     static inline SimTime zero(){ return SimTime(0); }
 

--- a/model/sim.h
+++ b/model/sim.h
@@ -38,8 +38,6 @@ namespace scnXml {
 
 namespace OM {
 
-class SimTime;
-
 inline int floorToInt( double x ){
 	return static_cast<int>(std::floor(x));
 }
@@ -52,9 +50,6 @@ class SimData {
     static int interval;        // days per time step
     static size_t steps_per_year;
     static double years_per_step;
-    
-    friend class SimTime;
-    friend class SimTime;
     friend class sim;
 };
 
@@ -81,16 +76,9 @@ class SimTime {
     ///@brief Unparameterised constructors
     //@{
     /** Default construction; same as sim::never(). */
-    SimTime() : d(0) {}
+    SimTime() = default;
     
     // ///@brief Self-modifying arithmatic
-    // //@{
-    // inline void operator+=( const SimTime rhs ) {
-    //     d += rhs.d;
-    // }
-    // //@}
-    
-    /// Checkpointing
     template<class S>
     void operator& (S& stream) {
         using namespace OM::util::checkpoint;

--- a/model/util/AgeGroupInterpolation.cpp
+++ b/model/util/AgeGroupInterpolation.cpp
@@ -40,7 +40,7 @@ namespace OM { namespace util {
         }
         ofstream fstream( (name+".csv").c_str() );
         
-        double max = sim::maxHumanAge().inYears();
+        double max = sim::inYears(sim::maxHumanAge());
         for( double age = 0.0; age < max; age += 0.1 ){
             fstream << age << "," << this->eval( age ) << endl;
         }
@@ -166,7 +166,7 @@ namespace OM { namespace util {
             }
 
             // add a point in middle of last age group (taking upper bound as max-age-years:
-            dataPoints[ 0.5*(greatestLbound + sim::maxHumanAge().inYears()) ] = lastValue;
+            dataPoints[ 0.5*(greatestLbound + sim::inYears(sim::maxHumanAge())) ] = lastValue;
         }
 
         virtual void scale( double factor ){

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -68,7 +68,7 @@ public:
         return 1.0;
     }
     SimTime sampleAgeOfDecay (LocalRng& rng) const{
-        return SimTime::future();        // decay occurs "in the future" (don't use SimTime::never() because that is interpreted as being in the past)
+        return sim::future();        // decay occurs "in the future" (don't use sim::never() because that is interpreted as being in the past)
     }
 };
 
@@ -98,7 +98,7 @@ public:
     }
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const{
-        return SimTime::roundToTSFromDays( 1.0 / invL );
+        return sim::roundToTSFromDays( 1.0 / invL );
     }
     
 private:
@@ -125,7 +125,7 @@ public:
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const{
         // Note: rounds to nearest. Object may decay instantly or at time L.
-        return SimTime::roundToTSFromDays(rng.uniform_01() / invL);
+        return sim::roundToTSFromDays(rng.uniform_01() / invL);
     }
     
 private:
@@ -149,7 +149,7 @@ public:
     }
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const{
-        return SimTime::roundToTSFromDays( -log(rng.uniform_01()) / invLambda );
+        return sim::roundToTSFromDays( -log(rng.uniform_01()) / invLambda );
     }
     
 private:
@@ -176,7 +176,7 @@ public:
     }
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const{
-        return SimTime::roundToTSFromDays( pow( -log(rng.uniform_01()), 1.0/k ) / constOverLambda );
+        return sim::roundToTSFromDays( pow( -log(rng.uniform_01()), 1.0/k ) / constOverLambda );
     }
     
 private:
@@ -200,7 +200,7 @@ public:
     }
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const{
-        return SimTime::roundToTSFromDays( pow( 1.0 / rng.uniform_01() - 1.0, 1.0/k ) / invL );
+        return sim::roundToTSFromDays( pow( 1.0 / rng.uniform_01() - 1.0, 1.0/k ) / invL );
     }
     
 private:
@@ -227,7 +227,7 @@ public:
     }
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const{
-        return SimTime::roundToTSFromDays( sqrt( 1.0 - k / (k - log( rng.uniform_01() )) ) / invL );
+        return sim::roundToTSFromDays( sqrt( 1.0 - k / (k - log( rng.uniform_01() )) ) / invL );
     }
     
 private:

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -96,7 +96,7 @@ public:
      * over this period (from age-1 to age), but difference should be small for
      * interventions being effective for a month or more. */
     inline double eval( SimTime age, DecayFuncHet sample )const{
-        return eval( age.inDays() * sample.getTMult() );
+        return eval( age * sample.getTMult() );
     }
     
     /** Sample a DecayFuncHet value (should be stored per individual).

--- a/model/util/ModelOptions.cpp
+++ b/model/util/ModelOptions.cpp
@@ -263,7 +263,7 @@ namespace OM { namespace util {
             // 1 day TS is also okay
         }else{
             ostringstream msg;
-            msg << "Time step set to " << sim::oneTS().inDays() << " days but only 1 and 5 days are supported.";
+            msg << "Time step set to " << sim::oneTS() << " days but only 1 and 5 days are supported.";
             throw xml_scenario_error (msg.str());
         }
     }

--- a/model/util/ModelOptions.cpp
+++ b/model/util/ModelOptions.cpp
@@ -246,7 +246,7 @@ namespace OM { namespace util {
             options[UPDATE_DENSITY_GAMMA] ) )
             throw xml_scenario_error( "Penny model option used without PENNY_WITHIN_HOST_MODEL option" );
         
-        if( SimTime::oneTS() == SimTime::fromDays(5) ){
+        if( sim::oneTS() == sim::fromDays(5) ){
             // 5 day TS is okay; some tests specific to this TS:
             bitset<NUM_OPTIONS> require1DayTS;
             require1DayTS
@@ -259,11 +259,11 @@ namespace OM { namespace util {
                     throw xml_scenario_error (msg.str());
                 }
             }
-        }else if( SimTime::oneTS() == SimTime::fromDays(1) ){
+        }else if( sim::oneTS() == sim::fromDays(1) ){
             // 1 day TS is also okay
         }else{
             ostringstream msg;
-            msg << "Time step set to " << SimTime::oneTS().inDays() << " days but only 1 and 5 days are supported.";
+            msg << "Time step set to " << sim::oneTS().inDays() << " days but only 1 and 5 days are supported.";
             throw xml_scenario_error (msg.str());
         }
     }

--- a/model/util/SimpleDecayingValue.h
+++ b/model/util/SimpleDecayingValue.h
@@ -39,7 +39,7 @@ public:
     /** Default construction: always return 0. */
     SimpleDecayingValue() :
             initial(0.0),
-            deploy_t(SimTime::never()) {}
+            deploy_t(sim::never()) {}
     
     /** Configure from an XML element. */
     inline void set (double initial_value, const scnXml::DecayFunction& elt, const char* name){

--- a/model/util/SimpleDecayingValue.h
+++ b/model/util/SimpleDecayingValue.h
@@ -87,7 +87,7 @@ private:
     util::DecayFuncHet het;
     
     /** Time of larviciding deployment. */
-    SimTime deploy_t;
+    SimTime deploy_t = sim::never();
 };
 
 } }

--- a/model/util/UnitParse.cpp
+++ b/model/util/UnitParse.cpp
@@ -53,7 +53,7 @@ SimTime readShortDuration( const std::string& str, DefaultUnit defUnit ){
     if( len == str.size() ){
         // no unit given; examine our policy:
         if( v == 0 ){   // don't need a unit in this case
-            return SimTime::zero();
+            return sim::zero();
         }else if( defUnit == NONE ){
             throw util::format_error( "unit required but not given (try e.g. 5d or 12t)" );
         }else{
@@ -61,9 +61,9 @@ SimTime readShortDuration( const std::string& str, DefaultUnit defUnit ){
                 cerr << "Deprecation warning: duration \"" << str << "\" specified without unit; it is recommended to do so (e.g. 5d or 1t)" << endl;
             }
             if( defUnit == DAYS ){
-                return SimTime::roundToTSFromDays( v );
+                return sim::roundToTSFromDays( v );
             }else if( defUnit == STEPS ){
-                return SimTime::fromTS( castToInt(v) );
+                return sim::fromTS( castToInt(v) );
             }else{
                 throw SWITCH_DEFAULT_EXCEPTION;
             }
@@ -72,9 +72,9 @@ SimTime readShortDuration( const std::string& str, DefaultUnit defUnit ){
         // one extra character found; is this a unit?
         char u = str[len];
         if( u == 'd' || u == 'D' ){
-            return SimTime::roundToTSFromDays( v );
+            return sim::roundToTSFromDays( v );
         }else if( u == 't' || u == 'T' ){
-            return SimTime::fromTS( castToInt(v) );
+            return sim::fromTS( castToInt(v) );
         }
         // otherwise, fall through to below
     }
@@ -113,26 +113,26 @@ double parseDurationAndUnit( const std::string& str, DefaultUnit& unit ){
 SimTime readDuration( const std::string& str, DefaultUnit unit ){
     double v = parseDurationAndUnit( str, unit );
     
-    if( unit == YEARS ) return SimTime::fromYearsN( v );
+    if( unit == YEARS ) return sim::fromYearsN( v );
     else if( v != std::floor(v) ){
         throw util::format_error( "fractional values are only allowed when the unit is years (e.g. 0.25y)" );
-    }else if( unit == DAYS ) return SimTime::roundToTSFromDays( v );
-	else if( unit == STEPS ) return SimTime::fromTS( castToInt(v) );
+    }else if( unit == DAYS ) return sim::roundToTSFromDays( v );
+	else if( unit == STEPS ) return sim::fromTS( castToInt(v) );
     else throw SWITCH_DEFAULT_EXCEPTION;
 }
 
 double durationToDays( const std::string& str, DefaultUnit unit ){
     double v = parseDurationAndUnit( str, unit );
     
-    if( unit == YEARS ) return v * SimTime::oneYear().inDays();
+    if( unit == YEARS ) return v * sim::oneYear().inDays();
     else if( unit == DAYS ) return v;
-    else if( unit == STEPS ) return v * SimTime::oneTS().inDays();
+    else if( unit == STEPS ) return v * sim::oneTS().inDays();
     else throw SWITCH_DEFAULT_EXCEPTION;
 }
 
-/** Returns SimDate::never() when it doesn't recognise a date. Throws when it does
+/** Returns sim::never() when it doesn't recognise a date. Throws when it does
  * but encounters definite format errors. */
-SimDate parseDate( const std::string& str ){
+SimTime parseDate( const std::string& str ){
     std::regex dateRx("(\\d{4})-(\\d{1,2})-(\\d{1,2})");
     std::smatch rx_what;
 
@@ -149,18 +149,18 @@ SimDate parseDate( const std::string& str ){
         // Inconsistency: time "zero" is 0000-01-01, not 0001-01-01. Since
         // dates are always relative to another date, the extra year doesn't
         // actually affect anything.
-        return SimDate::origin()
-            + SimTime::fromYearsI(year)
-            + SimTime::roundToTSFromDays(monthStart[month-1] + day - 1);
+        return sim::origin()
+            + sim::fromYearsI(year)
+            + sim::roundToTSFromDays(monthStart[month-1] + day - 1);
     }else{
-        return SimDate::never();
+        return sim::never();
     }
 }
 
-SimDate readDate( const std::string& str, DefaultUnit defUnit ){
-    SimDate date = parseDate( str );
-    if( date != SimDate::never() ){
-        if( date > sim::startDate() + SimTime::fromYearsI(500) ){
+SimTime readDate( const std::string& str, DefaultUnit defUnit ){
+    SimTime date = parseDate( str );
+    if( date != sim::never() ){
+        if( date > sim::startDate() + sim::fromYearsI(500) ){
             cerr << "Warning: date is a long time after start date. Did you forget to set monitoring/startDate?" << endl;
         }else if( date < sim::startDate() ){
             throw util::format_error( "date of event is before the start of monitoring" );

--- a/model/util/UnitParse.cpp
+++ b/model/util/UnitParse.cpp
@@ -124,9 +124,9 @@ SimTime readDuration( const std::string& str, DefaultUnit unit ){
 double durationToDays( const std::string& str, DefaultUnit unit ){
     double v = parseDurationAndUnit( str, unit );
     
-    if( unit == YEARS ) return v * sim::oneYear().inDays();
+    if( unit == YEARS ) return v * sim::oneYear();
     else if( unit == DAYS ) return v;
-    else if( unit == STEPS ) return v * sim::oneTS().inDays();
+    else if( unit == STEPS ) return v * sim::oneTS();
     else throw SWITCH_DEFAULT_EXCEPTION;
 }
 

--- a/model/util/UnitParse.h
+++ b/model/util/UnitParse.h
@@ -70,9 +70,9 @@ namespace UnitParse {
      * Call sim::init() first. */
     double durationToDays( const std::string& str, DefaultUnit defUnit );
     
-    /** Returns SimDate::never() when it doesn't recognise a date. Throws when it does
+    /** Returns sim::never() when it doesn't recognise a date. Throws when it does
      * but encounters definite format errors. */
-    SimDate parseDate( const std::string& str );
+    SimTime parseDate( const std::string& str );
 
     /** Read a date or relative time specifier found in the XML; dates are
      * rebased relative to a starting date so that they work the same as other
@@ -83,7 +83,7 @@ namespace UnitParse {
      * of the intervention period (as readDuration will parse). Returns a time
      * to be compared against sim::intervDate(). Again, the result is rounded to
      * the nearest time step. */
-    SimDate readDate( const std::string& str, DefaultUnit defUnit );
+    SimTime readDate( const std::string& str, DefaultUnit defUnit );
 }
 
 }

--- a/model/util/checkpoint.cpp
+++ b/model/util/checkpoint.cpp
@@ -295,7 +295,7 @@ namespace OM { namespace util { namespace checkpoint {
         auto pos = x.begin ();
         for(size_t i = 0; i < l; ++i) {
             interventions::ComponentId s( stream );
-            SimTime t;
+            SimTime t = sim::never();
             t & stream;
             pos = x.insert (pos, make_pair (s,t));
         }

--- a/unittest/CMDecisionTreeSuite.h
+++ b/unittest/CMDecisionTreeSuite.h
@@ -212,16 +212,16 @@ public:
         dt1.setTreatSimple( treat1 );
         
         TS_ASSERT_EQUALS( propTreatmentsNReps( 1, dt1 ), 1 );
-        TS_ASSERT_EQUALS( whm->lastTimeLiver.inDays(), 0 );
-        TS_ASSERT_EQUALS( whm->lastTimeBlood.inDays(), 1*5 );
+        TS_ASSERT_EQUALS( whm->lastTimeLiver, 0 );
+        TS_ASSERT_EQUALS( whm->lastTimeBlood, 1*5 );
         
         scnXml::DTTreatSimple treat2( "15d", "-1t" );
         scnXml::DecisionTree dt2;
         dt2.setTreatSimple( treat2 );
         
         TS_ASSERT_EQUALS( propTreatmentsNReps( 1, dt2 ), 1 );
-        TS_ASSERT_EQUALS( whm->lastTimeLiver.inDays(), 3*5 );
-        TS_ASSERT_EQUALS( whm->lastTimeBlood.inDays(), -1*5 );
+        TS_ASSERT_EQUALS( whm->lastTimeLiver, 3*5 );
+        TS_ASSERT_EQUALS( whm->lastTimeBlood, -1*5 );
     }
     
     double runAndGetMgPrescribed( scnXml::DecisionTree& dt, double age ){

--- a/unittest/CMDecisionTreeSuite.h
+++ b/unittest/CMDecisionTreeSuite.h
@@ -48,7 +48,7 @@ public:
 
         UnittestUtil::EmpiricalWHM_setup();
 
-        human.reset( UnittestUtil::createHuman(SimTime::zero()).release() );
+        human.reset( UnittestUtil::createHuman(sim::zero()).release() );
         ETS_ASSERT( human.get() != 0 );
         whm = dynamic_cast<WHMock*>(UnittestUtil::setHumanWH( *human,
                 unique_ptr<WithinHost::WHInterface>(new WHMock()) ));
@@ -204,8 +204,8 @@ public:
     }
     
     void testSimpleTreat(){
-        TS_ASSERT_EQUALS( whm->lastTimeLiver, SimTime::never() );
-        TS_ASSERT_EQUALS( whm->lastTimeBlood, SimTime::never() );
+        TS_ASSERT_EQUALS( whm->lastTimeLiver, sim::never() );
+        TS_ASSERT_EQUALS( whm->lastTimeBlood, sim::never() );
         
         scnXml::DTTreatSimple treat1( "0t", "1t" );   // 0 time steps liver, 1 blood (using 1 day TS)
         scnXml::DecisionTree dt1;

--- a/unittest/DecayFunctionSuite.h
+++ b/unittest/DecayFunctionSuite.h
@@ -57,78 +57,78 @@ public:
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         // First test: with a default-constructed DecayFuncHet and positive age, result should be zero
         DecayFuncHet dHet;
-        TS_ASSERT_EQUALS( df->eval( SimTime::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         // Second test: with an appropriately sampled helper value, we should get the results we want
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( SimTime::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(10), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(10), dHet ), 1.0 );
         // Third test: time of decay (age plus now) should always be in the future
-        TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), SimTime::future() );
+        TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), sim::future() );
     }
     
     void testStep () {
         dfElt.setFunction( "step" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFuncHet dHet;
-        TS_ASSERT_EQUALS( df->eval( SimTime::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( SimTime::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(6), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(20), dHet ), 0.0 );
-        TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), SimTime::fromYearsI(10) );
+        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), sim::fromYearsI(10) );
     }
     
     void testLinear () {
         dfElt.setFunction( "linear" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFuncHet dHet;
-        TS_ASSERT_EQUALS( df->eval( SimTime::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( SimTime::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(6), dHet ), 0.4 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(20), dHet ), 0.0 );
+        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.4 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.0 );
     }
     
     void testExponential () {
         dfElt.setFunction( "exponential" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFuncHet dHet;
-        TS_ASSERT_EQUALS( df->eval( SimTime::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( SimTime::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(6), dHet ), 0.65975394736842108 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(20), dHet ), 0.25 );
+        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.65975394736842108 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.25 );
     }
     
     void testWeibull () {
         dfElt.setFunction( "weibull" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFuncHet dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( SimTime::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(6), dHet ), 0.73631084210526321 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(20), dHet ), 0.122306 );
+        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.73631084210526321 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.122306 );
     }
     
     void testHill () {
         dfElt.setFunction( "hill" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFuncHet dHet;
-        TS_ASSERT_EQUALS( df->eval( SimTime::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( SimTime::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(6), dHet ), 0.6936673684210527 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(20), dHet ), 0.24805074736842106 );
+        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.6936673684210527 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.24805074736842106 );
     }
     
     void testSmoothCompact () {
         dfElt.setFunction( "smooth-compact" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFuncHet dHet;
-        TS_ASSERT_EQUALS( df->eval( SimTime::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( SimTime::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(6), dHet ), 0.40656965789473687 );
-        TS_ASSERT_APPROX( df->eval( SimTime::fromYearsI(20), dHet ), 0.0 );
+        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.40656965789473687 );
+        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.0 );
     }
     
 private:

--- a/unittest/DummyInfectionSuite.h
+++ b/unittest/DummyInfectionSuite.h
@@ -43,7 +43,7 @@ public:
         DummyInfection::init();
         // pkpdID (1st value) isn't important since we're not using drug model here:
         infection = CommonWithinHost::createInfection( m_rng, 0xFFFFFFFF );
-        for( SimTime d = sim::ts1(), end = sim::ts1() + sim::fromDays(15); d < end; d += sim::oneDay() ){
+        for( SimTime d = sim::ts1(), end = sim::ts1() + sim::fromDays(15); d < end; d = d + sim::oneDay() ){
             // blood stage starts 15 days after creation
             UnittestUtil::incrTime( sim::oneDay() );
             infection->update( m_rng, 1.0, d, numeric_limits<double>::quiet_NaN() );

--- a/unittest/DummyInfectionSuite.h
+++ b/unittest/DummyInfectionSuite.h
@@ -43,9 +43,9 @@ public:
         DummyInfection::init();
         // pkpdID (1st value) isn't important since we're not using drug model here:
         infection = CommonWithinHost::createInfection( m_rng, 0xFFFFFFFF );
-        for( SimTime d = sim::ts1(), end = sim::ts1() + SimTime::fromDays(15); d < end; d += SimTime::oneDay() ){
+        for( SimTime d = sim::ts1(), end = sim::ts1() + sim::fromDays(15); d < end; d += sim::oneDay() ){
             // blood stage starts 15 days after creation
-            UnittestUtil::incrTime( SimTime::oneDay() );
+            UnittestUtil::incrTime( sim::oneDay() );
             infection->update( m_rng, 1.0, d, numeric_limits<double>::quiet_NaN() );
         }
     }
@@ -58,30 +58,30 @@ public:
     }
 
     void testUpdatedInf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         TS_ASSERT_APPROX (infection->getDensity(), 128.00000008620828820);
     }
     void testUpdated2Inf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         TS_ASSERT_APPROX (infection->getDensity(), 1024.00000082264208600);
     }
 
     void testUpdatedReducedInf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 0.1, sim::ts1(), numeric_limits<double>::quiet_NaN());
         // This is, as expected, 1/10th of that in testUpdated2Inf
         TS_ASSERT_APPROX (infection->getDensity(), 102.40000008226420860);
     }
     void testUpdatedReducedInf2 () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 0.1, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         // This is nearly the same
         TS_ASSERT_APPROX (infection->getDensity(), 102.00000008286288040);

--- a/unittest/EmpiricalInfectionSuite.h
+++ b/unittest/EmpiricalInfectionSuite.h
@@ -46,9 +46,9 @@ public:
         EmpiricalInfection::init();
         // pkpdID (1st value) isn't important since we're not using drug model here:
         infection = CommonWithinHost::createInfection( m_rng, 0xFFFFFFFF );
-        for( SimTime d = sim::ts1(), end = sim::ts1() + SimTime::fromDays(15); d < end; d += SimTime::oneDay() ){
+        for( SimTime d = sim::ts1(), end = sim::ts1() + sim::fromDays(15); d < end; d += sim::oneDay() ){
             // blood stage starts 15 days after creation
-            UnittestUtil::incrTime( SimTime::oneDay() );
+            UnittestUtil::incrTime( sim::oneDay() );
             infection->update( m_rng, 1.0, d, numeric_limits<double>::quiet_NaN() );
         }
     }
@@ -62,61 +62,61 @@ public:
 
     // Parasite growth is stochastic, so there's not a lot we can test, except for reproducability
     void testUpdatedInf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         if (dump_emprical) cout << setprecision(8) << infection->getDensity() << endl;
         TS_ASSERT_APPROX (infection->getDensity(), 2.3427793);
     }
     void testUpdated2Inf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         if (dump_emprical) cout << setprecision(8) << infection->getDensity() << endl;
         TS_ASSERT_APPROX (infection->getDensity(), 0.42220637);
     }
     void testUpdated3Inf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         if (dump_emprical) cout << setprecision(8) << infection->getDensity() << endl;
         TS_ASSERT_APPROX (infection->getDensity(), 1.2290052);
     }
     void testUpdated4Inf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         if (dump_emprical) cout << setprecision(8) << infection->getDensity() << endl;
         TS_ASSERT_APPROX (infection->getDensity(), 0.4272347);
     }
     void testUpdatedInf1 () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         if (dump_emprical) cout << setprecision(8) << infection->getDensity() << endl;
         TS_ASSERT_APPROX (infection->getDensity(), 2.3427793);
     }
 
     void testUpdatedReducedInf () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 0.1, sim::ts1(), numeric_limits<double>::quiet_NaN());
         // This is, as expected, 1/10th of that in testUpdated2Inf
         if (dump_emprical) cout << setprecision(8) << infection->getDensity() << endl;
         TS_ASSERT_APPROX (infection->getDensity(), 0.042220637);
     }
     void testUpdatedReducedInf2 () {
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 0.1, sim::ts1(), numeric_limits<double>::quiet_NaN());
-        UnittestUtil::incrTime( SimTime::oneTS() );
+        UnittestUtil::incrTime( sim::oneTS() );
         infection->update (m_rng, 1.0, sim::ts1(), numeric_limits<double>::quiet_NaN());
         // This is completely different due to stochasitic effects
         if (dump_emprical) cout << setprecision(8) << infection->getDensity() << endl;

--- a/unittest/EmpiricalInfectionSuite.h
+++ b/unittest/EmpiricalInfectionSuite.h
@@ -46,7 +46,7 @@ public:
         EmpiricalInfection::init();
         // pkpdID (1st value) isn't important since we're not using drug model here:
         infection = CommonWithinHost::createInfection( m_rng, 0xFFFFFFFF );
-        for( SimTime d = sim::ts1(), end = sim::ts1() + sim::fromDays(15); d < end; d += sim::oneDay() ){
+        for( SimTime d = sim::ts1(), end = sim::ts1() + sim::fromDays(15); d < end; d = d + sim::oneDay() ){
             // blood stage starts 15 days after creation
             UnittestUtil::incrTime( sim::oneDay() );
             infection->update( m_rng, 1.0, d, numeric_limits<double>::quiet_NaN() );

--- a/unittest/MolineauxInfectionSuite.h
+++ b/unittest/MolineauxInfectionSuite.h
@@ -82,7 +82,7 @@ public:
 //                 out << infection->getDensity() << endl;
                 day += 1;
             }
-            now += sim::oneDay();
+            now = now + sim::oneDay();
         }while(!extinct);
         TS_ASSERT_EQUALS( day, dens.size() );
         delete infection;
@@ -294,7 +294,7 @@ private:
                 
                 while( !infection->update(rng, 1.0 /*no external immunity*/, now, 71.43 /*adult body mass in kg to get 5l blood volume*/) ){
                     dens.push_back( infection->getDensity() );
-                    now += sim::oneDay();
+                    now = now + sim::oneDay();
                 }
                 delete infection;
                 calc( run, dens );

--- a/unittest/MolineauxInfectionSuite.h
+++ b/unittest/MolineauxInfectionSuite.h
@@ -76,13 +76,13 @@ public:
         do{
             extinct = infection->update(m_rng, 1.0 /*no external immunity*/, now, 71.43 /*adult body mass in kg to get 5l blood volume*/);
             SimTime age = now - infection->m_startDate - infection->s_latentP;
-            if( age >= SimTime::zero() ){
+            if( age >= sim::zero() ){
                 ETS_ASSERT_LESS_THAN( day, dens.size() );
                 TS_ASSERT_APPROX( infection->getDensity(), dens[day] );
 //                 out << infection->getDensity() << endl;
                 day += 1;
             }
-            now += SimTime::oneDay();
+            now += sim::oneDay();
         }while(!extinct);
         TS_ASSERT_EQUALS( day, dens.size() );
         delete infection;
@@ -294,7 +294,7 @@ private:
                 
                 while( !infection->update(rng, 1.0 /*no external immunity*/, now, 71.43 /*adult body mass in kg to get 5l blood volume*/) ){
                     dens.push_back( infection->getDensity() );
-                    now += SimTime::oneDay();
+                    now += sim::oneDay();
                 }
                 delete infection;
                 calc( run, dens );

--- a/unittest/PennyInfectionSuite.h
+++ b/unittest/PennyInfectionSuite.h
@@ -83,7 +83,7 @@ public:
         SimTime now = sim::ts0();
         do{
             extinct = infection->update(m_rng, 1.0, now, numeric_limits<double>::quiet_NaN());
-            int ageDays = (now - infection->m_startDate - infection->s_latentP).inDays();
+            int ageDays = (now - infection->m_startDate - infection->s_latentP);
             while( ageDays < 0 ) ageDays += infection->delta_V; // special case encountered by unit test
             ETS_ASSERT_LESS_THAN( iterations, cirDens.size() );
             TS_ASSERT_APPROX( infection->getDensity(), cirDens[iterations] );

--- a/unittest/PennyInfectionSuite.h
+++ b/unittest/PennyInfectionSuite.h
@@ -90,7 +90,7 @@ public:
             TS_ASSERT_APPROX( infection->seqDensity(ageDays), seqDens[iterations] );
 //             outCir << infection->getDensity() << endl;
 //             outSeq << infection->seqDensity(ageDays) << endl;
-            now += sim::oneDay();
+            now = now + sim::oneDay();
             iterations+=1;
         }while(!extinct);
         TS_ASSERT_EQUALS( iterations, cirDens.size() );

--- a/unittest/PennyInfectionSuite.h
+++ b/unittest/PennyInfectionSuite.h
@@ -90,7 +90,7 @@ public:
             TS_ASSERT_APPROX( infection->seqDensity(ageDays), seqDens[iterations] );
 //             outCir << infection->getDensity() << endl;
 //             outSeq << infection->seqDensity(ageDays) << endl;
-            now += SimTime::oneDay();
+            now += sim::oneDay();
             iterations+=1;
         }while(!extinct);
         TS_ASSERT_EQUALS( iterations, cirDens.size() );

--- a/unittest/PkPdComplianceSuite.h
+++ b/unittest/PkPdComplianceSuite.h
@@ -184,7 +184,7 @@ public:
             PCS_VERBOSE(res_Fac[i] = totalFac;)
             
             // update (two parts):
-            UnittestUtil::incrTime(SimTime::oneDay());
+            UnittestUtil::incrTime(sim::oneDay());
             proxy->decayDrugs(bodymass);
             
             // after update:

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -265,7 +265,7 @@ public:
         sim::init( dummyXML::scenario );
         
         // we could just use zero, but we may spot more errors by using some weird number
-        sim::s_t0 = SimTime::fromYearsN(83.2591);
+        sim::s_t0 = sim::fromYearsN(83.2591);
         sim::s_t1 = sim::s_t0;
 #ifndef NDEBUG
         sim::in_update = true;  // may not always be correct but we're more interested in getting around this check than using it in unit tests
@@ -409,7 +409,7 @@ public:
     // For when infection parameters shouldn't be used; enforce by setting to NaNs.
     // But do set latentP.
     static void Infection_init_latentP_and_NaN () {
-	Infection::s_latentP = SimTime::fromDays(15);
+	Infection::s_latentP = sim::fromDays(15);
     }
     
     static void DescriptiveInfection_init () {

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -273,7 +273,7 @@ public:
     }
     static void incrTime(SimTime incr){
         //NOTE: for unit tests, we do not differentiate between s_t0 and s_t1
-        sim::s_t0 += incr;
+        sim::s_t0 = sim::s_t0 + incr;
         sim::s_t1 = sim::s_t0;
     }
     

--- a/unittest/WHMock.cpp
+++ b/unittest/WHMock.cpp
@@ -56,7 +56,7 @@ bool WHMock::treatSimple( Host::Human& human, SimTime timeLiver, SimTime timeBlo
     nTreatments += 1;
     lastTimeLiver = timeLiver;
     lastTimeBlood = timeBlood;
-    return timeBlood != SimTime::zero();
+    return timeBlood != sim::zero();
 }
 
 void WHMock::treatPkPd(size_t schedule, size_t dosages, double age, double delay_d){

--- a/unittest/WHMock.cpp
+++ b/unittest/WHMock.cpp
@@ -29,7 +29,8 @@ namespace UnitTest {
 
 WHMock::WHMock() :
     totalDensity(numeric_limits<double>::quiet_NaN()),
-    nTreatments(0)
+    nTreatments(0),
+    lastTimeLiver(sim::never()), lastTimeBlood(sim::never())
 {}
 WHMock::~WHMock() {}
 

--- a/unittest/WHMock.h
+++ b/unittest/WHMock.h
@@ -67,7 +67,7 @@ public:
     // This mock class counts the number of times treatment() was called. Read/write this as you like.
     int nTreatments;
     
-    // The last treatment time-spans used by the simple treatment model. SimTime::never() if not used.
+    // The last treatment time-spans used by the simple treatment model. sim::never() if not used.
     SimTime lastTimeLiver, lastTimeBlood;
     
     // Lists medications and drugs in the body


### PR DESCRIPTION
Part of a series of updates aiming at simplifying the code to ultimately run on GPUs.

Replace SimTime class by a simple integer definition in model/sim.h.

Most time related loops operate on integers rather than SimTime objects, for example:
`for (SimTime i = sim::zero(); i < sim::oneYear(); i += sim::oneDay())`
will be strictly equivalent (from the compiler's point of view) to:
`for (int i = 0; i < 365; i += 1)`

In addition, model implementations that rely on number of days, such as the transmission model, benefit from not having to constantly convert SimTime to days, since it is already a number of days.

Time conversions are done via static functions defined in the sim class.
`double ageYears1 = age(sim::ts1()).inYears();`
becomes:
`double ageYears1 = sim::inYears(age(sim::ts1()));`

Note that with this new structure, it is possible to go back to a more complex SimTime definition with few changes. For example, replacing the typedef by the following definition will work (but is not necessary anymore and would make the code in general more complex).

```
class SimTime {
    public:
    /** Construct, from a time in days. */
    SimTime( int days ) : d(days) {}
    
    operator int() const { return d; }

    ///@brief Unparameterised constructors
    //@{
    /** Default construction; same as sim::never(). */
    SimTime() = default;
    
    // ///@brief Self-modifying arithmatic
    template<class S>
    void operator& (S& stream) {
        using namespace OM::util::checkpoint;
        d & stream;
    }
    
private:
    int d;      // time in days
};
```