### PR TITLE
Add verbose output

### DIFF
--- a/model/Transmission/VectorModel.cpp
+++ b/model/Transmission/VectorModel.cpp
@@ -207,7 +207,7 @@ VectorModel::VectorModel(vector<double> initEIR, int interventionMode, vector<st
         ctsRA, ctsRR;
 
     size_t numSpecies = species.size();
-    cout << "numSpecies " << numSpecies << endl;
+
     // Output in order of species so that (1) we can just iterate through this
     // list when outputting and (2) output is in order specified in XML.
     for (size_t i = 0; i < numSpecies; ++i)

--- a/model/interventions/Deployments.hpp
+++ b/model/interventions/Deployments.hpp
@@ -77,7 +77,7 @@ public:
     }
     virtual void deploy (Population& population, Transmission::TransmissionModel& transmission) {}
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tdummy (no interventions)";
+        out << "Dummy";
     }
 };
 
@@ -93,7 +93,7 @@ public:
         newHS = 0;
     }
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tchange HS";
+        out << "ChangeHS";
     }
     
 private:
@@ -112,7 +112,7 @@ public:
         newEIR = 0;
     }
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tchange EIR";
+        out << "ChangeEIR";
     }
     
 private:
@@ -128,7 +128,7 @@ public:
         transmission.uninfectVectors();
     }
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tuninfect vectors";
+        out << "UninfectVectors";
     }
 };
 
@@ -221,11 +221,11 @@ public:
     }
     
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t"
-            << sim::inYears(minAge) << "y\t" << sim::inYears(maxAge) << "t\t";
-        if( subPop == ComponentId::wholePop() ) out << "(none)";
+        out << "Human:" << endl;
+        out << "\tage: " << sim::inYears(minAge) << "y\tmax age: " << sim::inYears(maxAge) << "y\tsubpop: ";
+        if( subPop == ComponentId::wholePop() ) out << "whole";
         else out << subPop.id;
-        out << '\t' << complement << '\t' << coverage << '\t';
+        out << "\tcomplement: " << complement << "\tcoverage: " << coverage << "\t";
         intervention->print_details( out );
     }
     
@@ -302,7 +302,7 @@ public:
             vectorModel->deployVectorPopInterv(inst);
     }
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tvector";
+        out << "Vector";
     }
     
 private:
@@ -323,7 +323,8 @@ public:
         }
     }
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tvector trap";
+        out << "VectorTrap:" << endl;
+        out << "\tratio: " << ratio << "\tlifespan: " << lifespan; 
     }
     
 private:
@@ -415,7 +416,7 @@ public:
         }
     }
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tnhh";
+        out << "NonHumanHosts(" << intervName << ")";
     }
     
 private:
@@ -484,7 +485,8 @@ public:
         }
     }
     virtual void print_details( std::ostream& out )const{
-        out << date << "\t\t\t\t\tnhh";
+        out << "AddNonHumanHosts(" << intervName << "):" << endl;
+        out << "\tlifespan: " << lifespan;
     }
     
 private:
@@ -557,13 +559,14 @@ public:
     }
     
     inline void print_details( std::ostream& out )const{
-        out << begin << "\t";
+        out << "Human:" << endl;
+        out << "\tbegin: " << begin << "\tend: ";
         if( end == sim::future() ) out << "(none)";
-        else out << end << 't';
-        out << '\t' << sim::inYears(deployAge) << "y\t";
-        if( subPop == ComponentId::wholePop() ) out << "(none)";
+        else out << end;
+        out << "\tdeployAge: " << sim::inYears(deployAge) << "y\tsubpop: ";
+        if( subPop == ComponentId::wholePop() ) out << "whole";
         else out << subPop.id;
-        out << '\t' << complement << '\t' << coverage << '\t';
+        out << "\tcomplement: " << complement << "\tcoverage: " << coverage << "\t";
         intervention->print_details( out );
     }
     

--- a/model/interventions/InterventionManager.cpp
+++ b/model/interventions/InterventionManager.cpp
@@ -542,6 +542,13 @@ void InterventionManager::deploy(Population &population, Transmission::Transmiss
     SimTime now = sim::intervDate();
     while (timed[nextTimed]->date <= now)
     {
+        if (util::CommandLine::option(util::CommandLine::VERBOSE))
+        {
+            cout << "deploy::Timed" << endl;
+            timed[nextTimed]->print_details(cout);
+            cout << endl;
+        }
+
         timed[nextTimed]->deploy(population, transmission);
         nextTimed += 1;
     }
@@ -553,6 +560,12 @@ void InterventionManager::deploy(Population &population, Transmission::Transmiss
         // deploy continuous interventions
         while (nextCtsDist < continuous.size())
         {
+            if (util::CommandLine::option(util::CommandLine::VERBOSE))
+            {
+                cout << "deploy::Continuous" << endl;
+                continuous[nextCtsDist].print_details(cout);
+                cout << endl;
+            }
             if (!continuous[nextCtsDist].filterAndDeploy(*it, population)) break; // deployment (and all remaining) happens in the future
             nextCtsDist = it->incrNextCtsDist();
         }

--- a/model/interventions/InterventionManager.cpp
+++ b/model/interventions/InterventionManager.cpp
@@ -544,7 +544,7 @@ void InterventionManager::deploy(Population &population, Transmission::Transmiss
     {
         if (util::CommandLine::option(util::CommandLine::VERBOSE))
         {
-            cout << "deploy::Timed" << endl;
+            cout << "deploy::" << now << "::Timed";
             timed[nextTimed]->print_details(cout);
             cout << endl;
         }
@@ -562,7 +562,7 @@ void InterventionManager::deploy(Population &population, Transmission::Transmiss
         {
             if (util::CommandLine::option(util::CommandLine::VERBOSE))
             {
-                cout << "deploy::Continuous" << endl;
+                cout << "deploy::" << now << "::Continuous";
                 continuous[nextCtsDist].print_details(cout);
                 cout << endl;
             }

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -74,7 +74,10 @@ void print_errno()
 void loop(const SimTime humanWarmupLength, Population &population, TransmissionModel &transmission, SimTime &endTime, SimTime &estEndTime, int lastPercent)
 {
     while (sim::now() < endTime)
-    {        
+    {
+        if (util::CommandLine::option(util::CommandLine::VERBOSE) && sim::intervDate() > 0)
+            cout << "Time step: " << sim::now() / sim::oneTS() << ", internal days: " << sim::now() << " | " << estEndTime << ", Intervention Date: " << sim::intervDate() << endl;
+
         // Monitoring. sim::now() gives time of end of last step,
         // and is when reporting happens in our time-series.
         Continuous.update( population );
@@ -214,6 +217,8 @@ int main(int argc, char* argv[])
         if(!startedFromCheckpoint)
         {
             endTime = humanWarmupLength;
+            if (util::CommandLine::option(util::CommandLine::VERBOSE))
+                cout << "Warmup..." << endl;
             loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);
         }
 
@@ -227,6 +232,8 @@ int main(int argc, char* argv[])
                 endTime = endTime + iterate;
                 // adjust estimation of final time step: end of current period + length of main phase
                 estEndTime = endTime + (sim::endDate() - sim::startDate()) + sim::oneTS();
+                if (util::CommandLine::option(util::CommandLine::VERBOSE))
+                    cout << "EIR Calibration..." << endl;
                 loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);
                 iterate = transmission->initIterate();
             }
@@ -256,6 +263,8 @@ int main(int argc, char* argv[])
         }
 
         // Main phase loop
+        if (util::CommandLine::option(util::CommandLine::VERBOSE))
+            cout << "Intervention phase..." << endl;
         loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);
        
         cerr << '\r' << flush;  // clean last line of progress-output

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -217,9 +217,9 @@ int main(int argc, char* argv[])
         if(!startedFromCheckpoint)
         {
             endTime = humanWarmupLength;
-            if (util::CommandLine::option(util::CommandLine::VERBOSE))
-                cout << "Warmup..." << endl;
+            if (util::CommandLine::option(util::CommandLine::VERBOSE)) cout << "Starting Warmup..." << endl;
             loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);
+            if (util::CommandLine::option(util::CommandLine::VERBOSE)) cout << "Finishing Warmup..." << endl;
         }
 
         /** Transmission init phase:
@@ -232,9 +232,9 @@ int main(int argc, char* argv[])
                 endTime = endTime + iterate;
                 // adjust estimation of final time step: end of current period + length of main phase
                 estEndTime = endTime + (sim::endDate() - sim::startDate()) + sim::oneTS();
-                if (util::CommandLine::option(util::CommandLine::VERBOSE))
-                    cout << "EIR Calibration..." << endl;
+                if (util::CommandLine::option(util::CommandLine::VERBOSE)) cout << "Starting EIR Calibration..." << endl;
                 loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);
+                if (util::CommandLine::option(util::CommandLine::VERBOSE)) cout << "Finishing EIR Calibration..." << endl;
                 iterate = transmission->initIterate();
             }
         }
@@ -263,9 +263,9 @@ int main(int argc, char* argv[])
         }
 
         // Main phase loop
-        if (util::CommandLine::option(util::CommandLine::VERBOSE))
-            cout << "Intervention phase..." << endl;
+        if (util::CommandLine::option(util::CommandLine::VERBOSE)) cout << "Starting Intervention period..." << endl;
         loop(humanWarmupLength, *population, *transmission, endTime, estEndTime, lastPercent);
+        if (util::CommandLine::option(util::CommandLine::VERBOSE)) cout << "Finishing Intervention period..." << endl;
        
         cerr << '\r' << flush;  // clean last line of progress-output
         

--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -32,273 +32,278 @@
 #include <cassert>
 
 namespace OM { namespace util {
-    bitset<CommandLine::NUM_OPTIONS> CommandLine::options;
-    string CommandLine::resourcePath;
-    string CommandLine::outputName;
-    string CommandLine::ctsoutName;
-    string CommandLine::checkpointFileName;
-    
-    string parseNextArg (int argc, char* argv[], int& i) {
-	++i;
-	if (i >= argc)
-	    throw cmd_exception ("Expected an argument following the last option");
-	return string(argv[i]);
-    }
-    
-    string CommandLine::parse (int argc, char* argv[]) {
-	bool cloHelp = false, cloVersion = false, cloError = false;
-	string scenarioFile = "";
-        outputName = "";
-        ctsoutName = "";
+	bitset<CommandLine::NUM_OPTIONS> CommandLine::options;
+	string CommandLine::resourcePath;
+	string CommandLine::outputName;
+	string CommandLine::ctsoutName;
+	string CommandLine::checkpointFileName;
+
+	string parseNextArg (int argc, char* argv[], int& i) {
+		++i;
+		if (i >= argc)
+			throw cmd_exception ("Expected an argument following the last option");
+		return string(argv[i]);
+	}
+
+	string CommandLine::parse (int argc, char* argv[]) {
+		bool cloHelp = false, cloVersion = false, cloError = false;
+		string scenarioFile = "";
+		outputName = "";
+		ctsoutName = "";
 #	ifdef OM_STREAM_VALIDATOR
-	string sVFile;
+		string sVFile;
 #	endif
-	
+
 	/* Simple command line parser. Seems to work fine.
 	* If an extension is wanted, http://tclap.sourceforge.net/ looks good. */
-	for(int i = 1; i < argc; ++i) {
-	    string clo = argv[i];
-	    
+		for(int i = 1; i < argc; ++i) {
+			string clo = argv[i];
+
 	    // starts "--"
-	    if (clo.size() >= 2 && *clo.data() == '-' && clo.data()[1] == '-') {
-		clo.assign (clo, 2, clo.size()-2);
-		
-		if (clo == "resource-path") {
-		    if (resourcePath.size())
-			throw cmd_exception ("--resource-path (or -p) may only be given once");
-		    resourcePath = parseNextArg (argc, argv, i).append ("/");
-		} else if (clo == "scenario") {
-		    if (scenarioFile != ""){
-			throw cmd_exception ("--scenario argument may only be given once");
-		    }
-		    scenarioFile = parseNextArg (argc, argv, i);
-		} else if (clo == "output") {
-		    if (outputName != ""){
-			throw cmd_exception ("--output argument may only be given once");
-		    }
-		    outputName = parseNextArg (argc, argv, i);
-                } else if (clo == "compress-output") {
-                    options.set (COMPRESS_OUTPUT);
-                } else if (clo == "ctsout") {
-                    if (ctsoutName != ""){
-                        throw cmd_exception ("--ctsout argument may only be given once");
-                    }
-                    ctsoutName = parseNextArg (argc, argv, i);
-                } else if (clo == "name") {
-                    if (ctsoutName != "" || outputName != "" || scenarioFile != ""){
-                        throw cmd_exception ("--name may not be used along with --scenario, --output or --ctsout");
-                    }
-                    string name = parseNextArg (argc, argv, i);
-                    (scenarioFile = "scenario").append(name).append(".xml");
-                    (outputName = "output").append(name).append(".txt");
-                    (ctsoutName = "ctsout").append(name).append(".txt");
-                } else if (clo == "validate-only") {
-                    options.set (SKIP_SIMULATION);
-                } else if (clo == "deprecation-warnings") {
-                    options.set (DEPRECATION_WARNINGS);
-		} else if (clo == "print-model") {
-		    options.set (PRINT_MODEL_OPTIONS);
-                    options.set (SKIP_SIMULATION);
-		} else if (clo == "print-EIR") {
-		    options.set (PRINT_ANNUAL_EIR);
-                    options.set (SKIP_SIMULATION);
-                } else if (clo == "print-interventions") {
-                    options.set (PRINT_INTERVENTIONS);
-                    options.set (SKIP_SIMULATION);
-                } else if (clo == "print-survey-times") {
-                    options.set (PRINT_SURVEY_TIMES);
-                    options.set (SKIP_SIMULATION);
-                } else if (clo == "print-genotypes") {
-                    options.set (PRINT_GENOTYPES);
-                    options.set (SKIP_SIMULATION);
-		} else if (clo == "sample-interpolations") {
-		    options.set (SAMPLE_INTERPOLATIONS);
-		    options.set (SKIP_SIMULATION);
-		} else if (clo == "checkpoint") {
-		    options.set (CHECKPOINT);
-                } else if (clo == "checkpoint-file") {
-                    if (checkpointFileName != ""){
-                        throw cmd_exception ("--checkpoint-file argument may only be given once");
-                    }
-                    options.set (CHECKPOINT);
-                    checkpointFileName = parseNextArg (argc, argv, i);
-                } else if (clo == "checkpoint-stop") {
-		    		options.set (CHECKPOINT);
-                    options.set (CHECKPOINT_STOP);
-                } else if (clo == "debug-vector-fitting") {
-                    options.set (DEBUG_VECTOR_FITTING);
+			if (clo.size() >= 2 && *clo.data() == '-' && clo.data()[1] == '-') {
+				clo.assign (clo, 2, clo.size()-2);
+				if (clo == "verbose") {
+					options.set (VERBOSE);
+				}
+				if (clo == "resource-path") {
+					if (resourcePath.size())
+						throw cmd_exception ("--resource-path (or -p) may only be given once");
+					resourcePath = parseNextArg (argc, argv, i).append ("/");
+				} else if (clo == "scenario") {
+					if (scenarioFile != ""){
+						throw cmd_exception ("--scenario argument may only be given once");
+					}
+					scenarioFile = parseNextArg (argc, argv, i);
+				} else if (clo == "output") {
+					if (outputName != ""){
+						throw cmd_exception ("--output argument may only be given once");
+					}
+					outputName = parseNextArg (argc, argv, i);
+				} else if (clo == "compress-output") {
+					options.set (COMPRESS_OUTPUT);
+				} else if (clo == "ctsout") {
+					if (ctsoutName != ""){
+						throw cmd_exception ("--ctsout argument may only be given once");
+					}
+					ctsoutName = parseNextArg (argc, argv, i);
+				} else if (clo == "name") {
+					if (ctsoutName != "" || outputName != "" || scenarioFile != ""){
+						throw cmd_exception ("--name may not be used along with --scenario, --output or --ctsout");
+					}
+					string name = parseNextArg (argc, argv, i);
+					(scenarioFile = "scenario").append(name).append(".xml");
+					(outputName = "output").append(name).append(".txt");
+					(ctsoutName = "ctsout").append(name).append(".txt");
+				} else if (clo == "validate-only") {
+					options.set (SKIP_SIMULATION);
+				} else if (clo == "deprecation-warnings") {
+					options.set (DEPRECATION_WARNINGS);
+				} else if (clo == "print-model") {
+					options.set (PRINT_MODEL_OPTIONS);
+					options.set (SKIP_SIMULATION);
+				} else if (clo == "print-EIR") {
+					options.set (PRINT_ANNUAL_EIR);
+					options.set (SKIP_SIMULATION);
+				} else if (clo == "print-interventions") {
+					options.set (PRINT_INTERVENTIONS);
+					options.set (SKIP_SIMULATION);
+				} else if (clo == "print-survey-times") {
+					options.set (PRINT_SURVEY_TIMES);
+					options.set (SKIP_SIMULATION);
+				} else if (clo == "print-genotypes") {
+					options.set (PRINT_GENOTYPES);
+					options.set (SKIP_SIMULATION);
+				} else if (clo == "sample-interpolations") {
+					options.set (SAMPLE_INTERPOLATIONS);
+					options.set (SKIP_SIMULATION);
+				} else if (clo == "checkpoint") {
+					options.set (CHECKPOINT);
+				} else if (clo == "checkpoint-file") {
+					if (checkpointFileName != ""){
+						throw cmd_exception ("--checkpoint-file argument may only be given once");
+					}
+					options.set (CHECKPOINT);
+					checkpointFileName = parseNextArg (argc, argv, i);
+				} else if (clo == "checkpoint-stop") {
+					options.set (CHECKPOINT);
+					options.set (CHECKPOINT_STOP);
+				} else if (clo == "debug-vector-fitting") {
+					options.set (DEBUG_VECTOR_FITTING);
 #	ifdef OM_STREAM_VALIDATOR
-		} else if (clo == "stream-validator") {
-		    if (sVFile.size())
-			throw cmd_exception ("--stream-validator may only be given once");
-		    sVFile = parseNextArg (argc, argv, i);
+				} else if (clo == "stream-validator") {
+					if (sVFile.size())
+						throw cmd_exception ("--stream-validator may only be given once");
+					sVFile = parseNextArg (argc, argv, i);
 #	endif
-                } else if (clo == "version") {
-                    cloVersion = true;
-                } else if (clo == "help") {
-                    cloHelp = true;
-		} else {
-		    cerr << "Unrecognised command-line option: --" << clo << endl;
-		    cloError = true;
-		}
+				} else if (clo == "version") {
+					cloVersion = true;
+				} else if (clo == "help") {
+					cloHelp = true;
+				} else {
+					cerr << "Unrecognised command-line option: --" << clo << endl;
+					cloError = true;
+				}
 	    } else if (clo.size() >= 1 && *clo.data() == '-') {	// single - (not --)
-		for(size_t j = 1; j < clo.size(); ++j) {
-		    if (clo[j] == 'p') {
-			if (j + 1 != clo.size())
-			    throw cmd_exception ("a path must be given as next argument after -p");
-			if (resourcePath.size())
-			    throw cmd_exception ("--resource-path (or -p) may only be given once");
-			resourcePath = parseNextArg (argc, argv, i).append ("/");
-		    } else if (clo[j] == 'm') {
-			options.set (PRINT_MODEL_OPTIONS);
-			options.set (SKIP_SIMULATION);
-		    } else if (clo[j] == 's') {
-			if (scenarioFile != ""){
-			    throw cmd_exception ("-s argument may only be given once");
-			}
-			scenarioFile = parseNextArg (argc, argv, i);
-		    } else if (clo[j] == 'o') {
-			if (outputName != ""){
-			    throw cmd_exception ("-o argument may only be given once");
-			}
-			outputName = parseNextArg (argc, argv, i);
-                    } else if (clo[j] == 'n') {
-                        if (ctsoutName != "" || outputName != "" || scenarioFile != ""){
-                            throw cmd_exception ("--name may not be used along with --scenario, --output or --ctsout");
-                        }
-                        string name = parseNextArg (argc, argv, i);
-                        (scenarioFile = "scenario").append(name).append(".xml");
-                        (outputName = "output").append(name).append(".txt");
-                        (ctsoutName = "ctsout").append(name).append(".txt");
-		    } else if (clo[j] == 'c') {
-			options.set (CHECKPOINT);
-                    } else if (clo[j] == 'v') {
-                        cloVersion = true;
-                    } else if (clo[j] == 'z') {
-                        options.set (COMPRESS_OUTPUT);
-                    } else if (clo[j] == 'h') {
-                        cloHelp = true;
-		    } else {
-		    cerr << "Unrecognised command-line option: -" << clo[j] << endl;
-		    cloError = true;
-		    }
-		}
+	    	for(size_t j = 1; j < clo.size(); ++j) {
+	    		if (clo[j] == 'V') {
+	    			options.set (VERBOSE);
+	    		} else if (clo[j] == 'p') {
+	    			if (j + 1 != clo.size())
+	    				throw cmd_exception ("a path must be given as next argument after -p");
+	    			if (resourcePath.size())
+	    				throw cmd_exception ("--resource-path (or -p) may only be given once");
+	    			resourcePath = parseNextArg (argc, argv, i).append ("/");
+	    		} else if (clo[j] == 'm') {
+	    			options.set (PRINT_MODEL_OPTIONS);
+	    			options.set (SKIP_SIMULATION);
+	    		} else if (clo[j] == 's') {
+	    			if (scenarioFile != ""){
+	    				throw cmd_exception ("-s argument may only be given once");
+	    			}
+	    			scenarioFile = parseNextArg (argc, argv, i);
+	    		} else if (clo[j] == 'o') {
+	    			if (outputName != ""){
+	    				throw cmd_exception ("-o argument may only be given once");
+	    			}
+	    			outputName = parseNextArg (argc, argv, i);
+	    		} else if (clo[j] == 'n') {
+	    			if (ctsoutName != "" || outputName != "" || scenarioFile != ""){
+	    				throw cmd_exception ("--name may not be used along with --scenario, --output or --ctsout");
+	    			}
+	    			string name = parseNextArg (argc, argv, i);
+	    			(scenarioFile = "scenario").append(name).append(".xml");
+	    			(outputName = "output").append(name).append(".txt");
+	    			(ctsoutName = "ctsout").append(name).append(".txt");
+	    		} else if (clo[j] == 'c') {
+	    			options.set (CHECKPOINT);
+	    		} else if (clo[j] == 'v') {
+	    			cloVersion = true;
+	    		} else if (clo[j] == 'z') {
+	    			options.set (COMPRESS_OUTPUT);
+	    		} else if (clo[j] == 'h') {
+	    			cloHelp = true;
+	    		} else {
+	    			cerr << "Unrecognised command-line option: -" << clo[j] << endl;
+	    			cloError = true;
+	    		}
+	    	}
 	    } else {
-		cerr << "Unexpected parameter: " << clo << endl << endl;
-		cloError = true;
+	    	cerr << "Unexpected parameter: " << clo << endl << endl;
+	    	cloError = true;
 	    }
 	}
 	
 	if (cloVersion || cloHelp){
-            cerr<<"OpenMalaria simulator of malaria epidemiology and control."<<endl<< endl
-                  <<"For more information, see https://github.com/SwissTPH/openmalaria/wiki"<<endl<<endl
-                  <<"\tschema version: \t"   <<DocumentLoader::SCHEMA_VERSION<<endl
-                  <<"\tprogram version:\t" << util::semantic_version <<endl<<endl
-                  <<"OpenMalaria is copyright © 2005-2015 Swiss Tropical Institute"<<endl
-                  <<"and Liverpool School Of Tropical Medicine."<<endl
-                  <<"OpenMalaria comes with ABSOLUTELY NO WARRANTY. This is free software, and you"<<endl<<endl
-                  <<"are welcome to redistribute it under certain conditions. See the file COPYING"<<endl
-                  <<"or http://www.gnu.org/licenses/gpl-2.0.html for details of warranty or terms of"<<endl
-                  <<"redistribution."<<endl<<endl;
-        }
+		cerr<<"OpenMalaria simulator of malaria epidemiology and control."<<endl<< endl
+		<<"For more information, see https://github.com/SwissTPH/openmalaria/wiki"<<endl<<endl
+		<<"\tschema version: \t"   <<DocumentLoader::SCHEMA_VERSION<<endl
+		<<"\tprogram version:\t" << util::semantic_version <<endl<<endl
+		<<"OpenMalaria is copyright © 2005-2015 Swiss Tropical Institute"<<endl
+		<<"and Liverpool School Of Tropical Medicine."<<endl
+		<<"OpenMalaria comes with ABSOLUTELY NO WARRANTY. This is free software, and you"<<endl<<endl
+		<<"are welcome to redistribute it under certain conditions. See the file COPYING"<<endl
+		<<"or http://www.gnu.org/licenses/gpl-2.0.html for details of warranty or terms of"<<endl
+		<<"redistribution."<<endl<<endl;
+	}
 	if (cloHelp || cloError) {
-	    cerr << "Usage: " << argv[0] << " [options]" << endl << endl
-	    << "Options:"<<endl
-	    << " -p --resource-path	Path to look up input resources with relative URLs (defaults to"<<endl
-	    << "			working directory). Not used for output files."<<endl
-	    << " -s --scenario file.xml	Uses file.xml as the scenario. If not given, scenario.xml is used." << endl
-	    << "			If path is relative (doesn't start '/'), --resource-path is used."<<endl
-	    << " -o --output file.txt	Uses file.txt as output file name. If not given, output.txt is used." << endl
-	    << "    --ctsout file.txt	Uses file.txt as ctsout file name. If not given, ctsout.txt is used." << endl
-	    << " -n --name NAME		Equivalent to --scenario scenarioNAME.xml --output outputNAME.txt \\"<<endl
-	    << "			--ctsout ctsoutNAME.txt" <<endl
-	    << " -z --compress-output	Compress output with gzip (writes output.txt.gz)." << endl
-	    << "    --validate-only	Initialise and validate scenario, but don't run simulation." << endl
-	    << "    --deprecation-warnings" << endl
-	    << "			Warn about the use of features deemed error-prone and where" << endl
-	    << "			more flexible alternatives are available." << endl
-	    << endl
-	    << "Debugging options:"<<endl
-	    << " -m --print-model	Print all model options with a non-default value and exit." << endl
-	    << "    --print-EIR		Print the annual EIR (of each species in vector mode) and exit." << endl
-	    << "    --print-interventions" << endl
-	    << "			Print intervention deployment details and exit." << endl
-	    << "    --print-survey-times" << endl
-	    << "			Print out the times of all surveys and exit." << endl
-            << "    --print-genotypes" << endl
-            << "                        Print out genotype ids and exit." << endl
-	    << "    --sample-interpolations" <<endl
-	    << "			Output samples of all used age-group data according to active"<<endl
-	    << "			interpolation method and exit."<<endl
-	    << " -c --checkpoint	Write a checkpoint just before starting the main phase."<<endl
-	    << "			This may be used to skip redundant computation when multiple"<<endl
-	    << "			simulations differ only during the intervention phase."<<endl
-	    << "    --checkpoint-file file	Checkpoint as above. Uses file as checkpoint file name. If not given, checkpoint is used." << endl
-	    << "    --checkpoint-stop	Checkpoint as above, then stop immediately afterwards. Can be used with --checkpoint-file."<<endl
-	    << "    --debug-vector-fitting"<<endl
-	    << "			Show details of vector-parameter fitting. The fitting methods used" <<endl
-	    << "			aren't guaranteed to work. If they don't, this output should help"<<endl
-	    << "			work out why."<<endl
+		cerr << "Usage: " << argv[0] << " [options]" << endl << endl
+		<< "Options:"<<endl
+		<< " -V --verbose		Verbose output" <<endl
+		<< " -p --resource-path	Path to look up input resources with relative URLs (defaults to"<<endl
+		<< "			working directory). Not used for output files."<<endl
+		<< " -s --scenario file.xml	Uses file.xml as the scenario. If not given, scenario.xml is used." << endl
+		<< "			If path is relative (doesn't start '/'), --resource-path is used."<<endl
+		<< " -o --output file.txt	Uses file.txt as output file name. If not given, output.txt is used." << endl
+		<< "    --ctsout file.txt	Uses file.txt as ctsout file name. If not given, ctsout.txt is used." << endl
+		<< " -n --name NAME		Equivalent to --scenario scenarioNAME.xml --output outputNAME.txt \\"<<endl
+		<< "			--ctsout ctsoutNAME.txt" <<endl
+		<< " -z --compress-output	Compress output with gzip (writes output.txt.gz)." << endl
+		<< "    --validate-only	Initialise and validate scenario, but don't run simulation." << endl
+		<< "    --deprecation-warnings" << endl
+		<< "			Warn about the use of features deemed error-prone and where" << endl
+		<< "			more flexible alternatives are available." << endl
+		<< endl
+		<< "Debugging options:"<<endl
+		<< " -m --print-model	Print all model options with a non-default value and exit." << endl
+		<< "    --print-EIR		Print the annual EIR (of each species in vector mode) and exit." << endl
+		<< "    --print-interventions" << endl
+		<< "			Print intervention deployment details and exit." << endl
+		<< "    --print-survey-times" << endl
+		<< "			Print out the times of all surveys and exit." << endl
+		<< "    --print-genotypes" << endl
+		<< "                        Print out genotype ids and exit." << endl
+		<< "    --sample-interpolations" <<endl
+		<< "			Output samples of all used age-group data according to active"<<endl
+		<< "			interpolation method and exit."<<endl
+		<< " -c --checkpoint	Write a checkpoint just before starting the main phase."<<endl
+		<< "			This may be used to skip redundant computation when multiple"<<endl
+		<< "			simulations differ only during the intervention phase."<<endl
+		<< "    --checkpoint-file file	Checkpoint as above. Uses file as checkpoint file name. If not given, checkpoint is used." << endl
+		<< "    --checkpoint-stop	Checkpoint as above, then stop immediately afterwards. Can be used with --checkpoint-file."<<endl
+		<< "    --debug-vector-fitting"<<endl
+		<< "			Show details of vector-parameter fitting. The fitting methods used" <<endl
+		<< "			aren't guaranteed to work. If they don't, this output should help"<<endl
+		<< "			work out why."<<endl
 #	ifdef OM_STREAM_VALIDATOR
-	    << "    --stream-validator PATH" <<endl
-	    << "			Use StreamValidator to validate against reference file PATH." <<endl
-	    << "			(note: PATH must be absolute or relative to resource path)." <<endl
+		<< "    --stream-validator PATH" <<endl
+		<< "			Use StreamValidator to validate against reference file PATH." <<endl
+		<< "			(note: PATH must be absolute or relative to resource path)." <<endl
 #	endif
-	    << " -v --version           Display the current schema version of OpenMalaria." << endl
-	    << " -h --help              Print this message." << endl<<endl
-	    ;
-	    if( cloError )
-		throw cmd_exception( "bad argument" );
+		<< " -v --version           Display the current schema version of OpenMalaria." << endl
+		<< " -h --help              Print this message." << endl<<endl
+		;
+		if( cloError )
+			throw cmd_exception( "bad argument" );
 	}
 	if( cloVersion || cloHelp ){
-            throw cmd_exception("Printed help",Error::None);
-        }
+		throw cmd_exception("Printed help",Error::None);
+	}
 	
 #	ifdef OM_STREAM_VALIDATOR
 	if( sVFile.size() )
-	    StreamValidator.loadStream( sVFile );
+		StreamValidator.loadStream( sVFile );
 #	endif
 	
-        if (scenarioFile == ""){
-            scenarioFile = "scenario.xml";
-        }
+	if (scenarioFile == ""){
+		scenarioFile = "scenario.xml";
+	}
 	if (outputName == ""){
-	    outputName = "output.txt";
+		outputName = "output.txt";
 	}
 	if (ctsoutName == ""){
-            ctsoutName = "ctsout.txt";
-        }
+		ctsoutName = "ctsout.txt";
+	}
 
 	return scenarioFile;
-    }
-    
-    string CommandLine::lookupResource (const string& path) {
+}
+
+string CommandLine::lookupResource (const string& path) {
 	string ret;
 	if (path.size() >= 1 && path[0] == '/') {
 	    // UNIX absolute path
 	} else if (path.size() >= 3 && path[1] == ':'
-	    && (path[2] == '\\' || path[2] == '/')) {
+		&& (path[2] == '\\' || path[2] == '/')) {
 	    // Windows absolute path.. at least probably
 	} else {	// relative
-	    ret = resourcePath;
+		ret = resourcePath;
 	}
 	ret.append (path);
 	return ret;
-    }
-    
+}
+
     /* These check parameters are as expected. They only really serve to make
      * sure important command-line parameters didn't change (and only in DEBUG mode)! */
-    void CommandLine::staticCheckpoint (istream& stream) {
+void CommandLine::staticCheckpoint (istream& stream) {
 	string tOpt;
 	string tResPath;
 	tOpt & stream;
 	tResPath & stream;
 	assert (tOpt == options.to_string());
 	assert (tResPath == resourcePath);
-    }
-    void CommandLine::staticCheckpoint (ostream& stream) {
+}
+void CommandLine::staticCheckpoint (ostream& stream) {
 	options.to_string() & stream;
 	resourcePath & stream;
-    }
-    
+}
+
 } }

--- a/model/util/CommandLine.h
+++ b/model/util/CommandLine.h
@@ -31,63 +31,65 @@ using namespace std;
 
 namespace OM { namespace util {
     /// Command line options and processing
-    class CommandLine {
-    public:
+	class CommandLine {
+	public:
 	/// Boolean command-line options
-	enum Options {
+		enum Options {
 	    /** Outputs non-default "ModelOptions" values in a human-readable form. */
-	    PRINT_MODEL_OPTIONS = 0,
+			PRINT_MODEL_OPTIONS = 0,
+	    /// Verbose output
+			VERBOSE,
 	    /// Forces checkpointing just before starting the main phase.
-	    CHECKPOINT,
+			CHECKPOINT,
 	    /// Exit after writing checkpoint
-            CHECKPOINT_STOP,
+			CHECKPOINT_STOP,
 	    /** Do initialisation and error checks, but don't run simulation. */
-	    SKIP_SIMULATION,
+			SKIP_SIMULATION,
             /** Compress output.txt file. */
-            COMPRESS_OUTPUT,
+			COMPRESS_OUTPUT,
 	    /** Print the annual EIR. */
-	    PRINT_ANNUAL_EIR,
+			PRINT_ANNUAL_EIR,
             /** Outputs samples from the active interpolation methods of all
              * age-group data suitible for graphing. */
-            SAMPLE_INTERPOLATIONS,
+			SAMPLE_INTERPOLATIONS,
             /** Show details of vector-parameter fitting.
              * 
              * The fitting methods used aren't guaranteed to work. If they don't, this output should help work out why. */
-            DEBUG_VECTOR_FITTING,
+			DEBUG_VECTOR_FITTING,
             /** Print out details about interventions. */
-            PRINT_INTERVENTIONS,
+			PRINT_INTERVENTIONS,
             /** Warn on use of deprecated features; that is recommend the use
              * of replacement features. */
-            DEPRECATION_WARNINGS,
+			DEPRECATION_WARNINGS,
             /** Print times of all surveys. */
-            PRINT_SURVEY_TIMES,
-            PRINT_GENOTYPES,
-	    NUM_OPTIONS
-	};
-	
+			PRINT_SURVEY_TIMES,
+			PRINT_GENOTYPES,
+			NUM_OPTIONS
+		};
+
 	/** Return true if given option (from CommandLine::Options) is active. */
-	static inline bool option(size_t code) {
-	    return options.test(code);
-	}
-	
+		static inline bool option(size_t code) {
+			return options.test(code);
+		}
+
 	/** If path is relative, prepend it with clResourcePath. */
-	static string lookupResource (const string& path);
-	
+		static string lookupResource (const string& path);
+
         /** Get the name of the output file. */
-	static inline string getOutputName (){
-	    return outputName;
-	}
-	
+		static inline string getOutputName (){
+			return outputName;
+		}
+
     /** Get the name of the ctsout file. */
-    static inline string getCtsoutName (){
-        return ctsoutName;
-    }
+		static inline string getCtsoutName (){
+			return ctsoutName;
+		}
 
      /** Get the name of the checkpoint file. */
-    static inline string getCheckpointName (){
-        return checkpointFileName;
-    }
-        
+		static inline string getCheckpointName (){
+			return checkpointFileName;
+		}
+
 	/** Looks through all command line options.
 	*
 	* @returns The name of the scenario XML file to use.
@@ -97,23 +99,23 @@ namespace OM { namespace util {
 	* 
 	* In other cases command-line parameters cause variables to be set in Global
 	* to achieve the desired result. */
-	static string parse (int argc, char* argv[]);
-	
+		static string parse (int argc, char* argv[]);
+
 	/** @brief Checkpointing.
 	*
 	* Not really required; more to confirm things are expected. */
-	static void staticCheckpoint (istream& stream);
+		static void staticCheckpoint (istream& stream);
 	static void staticCheckpoint (ostream& stream);	///< ditto
 	
-    private:
+private:
 	// Static parameters: don't require checkpointing (set by parse())
 	static bitset<NUM_OPTIONS> options;	// boolean options
 	static string resourcePath;
 	
 	//Output filename (for main output file "output.txt")
 	static string outputName;
-    static string ctsoutName;
-    static string checkpointFileName;
-    };
+	static string ctsoutName;
+	static string checkpointFileName;
+};
 } }
 #endif


### PR DESCRIPTION
Add a rudimentary verbose output with the option `-V` or `--verbose`

```
Starting Warmup...
92%	Finishing Warmup...
Starting EIR Calibration...
94%	Finishing EIR Calibration...
Starting EIR Calibration...
94%	Finishing EIR Calibration...
Starting EIR Calibration...
94%	Finishing EIR Calibration...
Starting EIR Calibration...
94%	Finishing EIR Calibration...
Starting EIR Calibration...
95%	Finishing EIR Calibration...
Starting EIR Calibration...
95%	Finishing EIR Calibration...
Starting EIR Calibration...
95%	Finishing EIR Calibration...
Starting Intervention period...
95%	Time step: 46356, internal days: 46356 | 48546, Intervention Date: 1
95%	Time step: 46357, internal days: 46357 | 48546, Intervention Date: 2
95%	Time step: 46358, internal days: 46358 | 48546, Intervention Date: 3
95%	Time step: 46359, internal days: 46359 | 48546, Intervention Date: 4
95%	Time step: 46360, internal days: 46360 | 48546, Intervention Date: 5
95%	Time step: 46361, internal days: 46361 | 48546, Intervention Date: 6
...
99%	Time step: 48202, internal days: 48202 | 48546, Intervention Date: 1847
99%	Time step: 48203, internal days: 48203 | 48546, Intervention Date: 1848
99%	Time step: 48204, internal days: 48204 | 48546, Intervention Date: 1849
deploy::1849::TimedHuman:
	age: 0y	max age: 2.94176e+06y	subpop: whole	complement: 0	coverage: 0.85	human:	0
99%	Time step: 48205, internal days: 48205 | 48546, Intervention Date: 1850
```