### PR TITLE
Updat gh-pages action to deploy on main instead of master

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/generated/book


### PR DESCRIPTION
- The master branch has been renamed to main
- The default branch is now the main branch
- The develop branch will be removed shortly

This updates the gh-pages github action to now deploy the schema doc when a push is done on the main branch, rather than on the master branch. 