### PR TITLE
update Appveyor token

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ deploy:
   provider: GitHub
   description: "OpenMalaria build for Windows"
   auth_token:
-    secure: ptQ5n7+VWKZB6M8TGGwHovHl0Quwv4fOAuNP2V2wu+snUHS8Fdpj4N8WE9tJLiSe
+    secure: 55I3piJ00R39LqRqJWX+vq7gbt655ZSdBFhJWpcVX5cjTQJ4cPrzgz6TIKMXwXo6
   artifact: openMalaria-windows.zip
   draft: false
   prerelease: false


### PR DESCRIPTION
The old token use for uploading artifacts to github releases has expired.
This updates the token.