### PR TITLE
Change default branch in build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ OMGIT=openmalaria
 
 # Clone from
 RELEASE=openMalaria
-BRANCH=master
+BRANCH=main
 SWITCHBRANCH=0
 
 # options


### PR DESCRIPTION
Change the default branch to from `master` to `main` in the build.sh script.