### PR TITLE
Add c++17 flag when using intel compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 # -----  Compile options  -----
 
+set(CMAKE_CXX_STANDARD 17)
+
+set (OM_STD_LIBS)
+
 # -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR
 # auto_ptr has been removed from c++17
 # This extension is needed because XSD still use auto_ptr in its headers
@@ -27,8 +31,6 @@ if (NOT MSVC)
   # We almost always want optimisations enabled:
   set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
 endif (NOT MSVC)
-
-set (OM_STD_LIBS )
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fp-model source")


### PR DESCRIPTION
Add C++17 flag when using Intel compilers.