### PR TITLE
fix --verbose command line option not working

### DIFF
--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -64,8 +64,7 @@ namespace OM { namespace util {
 				clo.assign (clo, 2, clo.size()-2);
 				if (clo == "verbose") {
 					options.set (VERBOSE);
-				}
-				if (clo == "resource-path") {
+				} else if (clo == "resource-path") {
 					if (resourcePath.size())
 						throw cmd_exception ("--resource-path (or -p) may only be given once");
 					resourcePath = parseNextArg (argc, argv, i).append ("/");


### PR DESCRIPTION
Since version 43.1, a verbose option can be enabled by passing -V or --verbose to openMalaria.

--verbose was not working and is fixed with this patch.