### PR TITLE
Fix error when totalDensity is 0 in sumlogDens survey

### DIFF
--- a/model/Host/WithinHost/CommonWithinHost.cpp
+++ b/model/Host/WithinHost/CommonWithinHost.cpp
@@ -308,7 +308,10 @@ bool CommonWithinHost::summarize( Host::Human& human )const{
     // totalDensity > 0. Here we report the last calculated density.
     if( diagnostics::monitoringDiagnostic().isPositive(human.rng(), totalDensity, std::numeric_limits<double>::quiet_NaN()) ){
         mon::reportStatMHI( mon::MHR_PATENT_HOSTS, human, 1 );
-        mon::reportStatMHF( mon::MHF_LOG_DENSITY, human, log(totalDensity) );
+        if(totalDensity == 0.0)
+            mon::reportStatMHF( mon::MHF_LOG_DENSITY, human, 0.0);
+        else
+            mon::reportStatMHF( mon::MHF_LOG_DENSITY, human, log(totalDensity) );
         return true;    // patent
     }
     return false;       // not patent


### PR DESCRIPTION
If the diagnostic specificity is less than 1.0, then there will be false positives, which is expected.

However, OpenMalaria will try to report the sum of the log of the totalDensity values for each host, even when "sumlogDens" is false in the survey optons.

Computing log(totalDensity) when totalDensity is 0 is not valid and raises an errno error, which is then reported in the main().

With this commit, OM will not compute the log if totalDensity is 0.