### PR TITLE
Fix error when mean is 0 in LogNormalSampler

### DIFF
--- a/model/util/sampler.cpp
+++ b/model/util/sampler.cpp
@@ -83,7 +83,11 @@ void LognormalSampler::setParams( double mean, const scnXml::SampledValueCV& elt
         if( elt.getCV().present() && elt.getCV().get() != 0.0 ){
             throw util::xml_scenario_error( "attribute CV must be zero or omitted when distr=\"const\" or is omitted" );
         }
-        mu = log(mean);
+        if( mean == 0.0 ){
+            mu = -numeric_limits<double>::infinity();
+        } else {
+            mu = log(mean);
+        }
         sigma = 0.0;
         return;
     }


### PR DESCRIPTION
During the initialization of the LogNormalSampler, mu is set as log(mean), which will raise an error when the mean is 0.

This commit sets mu to -infinity directly when mean is 0, without computing the log first.