### PR TITLE
change minimum monthly input EIR value from 0.1% to 1% of total EIR

### DIFF
--- a/model/Transmission/transmission.h
+++ b/model/Transmission/transmission.h
@@ -149,7 +149,7 @@ inline Anopheles::AnophelesModel *createAnophelesModel(size_t i, const scnXml::A
             sum += months[i];
         }
         // arbitrary minimum we allow (cannot have zeros since we take the logarithm)
-        double min = sum / 1000.0;
+        double min = sum / 100.0;
         for (size_t i = 0; i < N_m; ++i)
         {
             if (months[i] < min) months[i] = min;

--- a/util/fourier.html
+++ b/util/fourier.html
@@ -241,12 +241,21 @@ function plot(){
   var timeseries = textarea.value.split("\n");
   var size = timeseries.length;
 
+  var sum = 0;
   for(var i=0; i<size; i++) {
     var v = parseFloat(timeseries[i]);
-    if(v != 0)
-      v = Math.log(v);
+    sum = sum + v;
+    timeseries[i] = v;
+  }
 
-     timeseries[i] = v;
+  minimum = sum / 100.0
+
+  for(var i=0; i<size; i++) {
+    var v = parseFloat(timeseries[i]);
+    if (v == 0)
+      v = minimum;
+    v = Math.log(v);
+    timeseries[i] = v;
   }
 
   const data = new ComplexArray(size).map((value, i, n) => {


### PR DESCRIPTION
When monthly EIR values are used in the xml with the Fourier smoothing method, the resulting smoothed EIR season might be to short compared to the original input. This is more noticeable when many months have an EIR of '0'.

OpenMalaria automatically replaces '0' values by a minimum value, which used to be 0.1% of the total annual EIR (the sum of the 12 monthly values, not the scaled annual EIR value).

This changes the minimum value to 1%, which helps conserving the original length of the season better after smoothing.