### PR TITLE
Update appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
   - C:\cygwin64\bin\bash -lc "echo $HOME"
   - C:\cygwin64\bin\bash -lc "appveyor DownloadFile http://rawgit.com/transcode-open/apt-cyg/master/apt-cyg -FileName apt-cyg"
   - C:\cygwin64\bin\bash -lc "install apt-cyg /bin"
-  - C:\cygwin64\bin\bash -lc "apt-cyg update"
+  # - C:\cygwin64\bin\bash -lc "apt-cyg update"
   - C:\cygwin64\bin\bash -lc "apt-cyg install wget grep"
   - C:\cygwin64\bin\bash -lc "apt-cyg install zlib-devel make python3 cmake libgsl-devel xsd libxerces-c-devel"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 cache:
     - 'C:\cygwin64\var\cache\setup'
 
-os: Visual Studio 2019
+os: Visual Studio 2022
 
 configuration: Release
 


### PR DESCRIPTION
Disable 'apt-cyg update' during Cygwin installation because this causes errors while installing / updating packages.