### PR TITLE
remove MacOS10.15 because it is now obsolete in github Actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -54,8 +54,6 @@ jobs:
           - os: macos-11
             compiler: clang
           
-          - os: macos-10.15
-            compiler: clang
     steps:
       - uses: actions/checkout@v2
       


### PR DESCRIPTION
Remove MacOS10.15 from CI.
MacOS10.15 has been marked obsolete by github actions and since then errors occur during the build.