### PR TITLE
Add macos 12 ubuntu 22.04, Remove macos 10.15

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,6 +43,10 @@ jobs:
       matrix:
         # os: [] #for testing with act
         include:
+          - os: ubuntu-22.04
+            compiler: g++
+            target: Linux
+
           - os: ubuntu-20.04
             compiler: g++
             target: Linux
@@ -50,6 +54,9 @@ jobs:
           - os: ubuntu-18.04
             compiler: g++
             target: Linux
+
+          - os: macos-12
+            compiler: clang
           
           - os: macos-11
             compiler: clang

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -54,8 +54,6 @@ jobs:
           - os: macos-11
             compiler: clang
           
-          - os: macos-10.15
-            compiler: clang
     steps:
       - uses: actions/checkout@v2
       


### PR DESCRIPTION
This adds MacOS 12 and Ubuntu 22.04 to the continous integration pipeline.

Releases will also be available shortly.