### PR TITLE
add new severe measures excluding comorbidities

### DIFF
--- a/model/Clinical/Episode.cpp
+++ b/model/Clinical/Episode.cpp
@@ -61,6 +61,9 @@ void Episode::report () {
         // Malarial fevers: report bout
         if (state & Episode::COMPLICATED) {
             mon::reportMSACI( mon::MHE_SEVERE_EPISODES, surveyPeriod, ageGroup, cohortSet, 1 );
+            if (state & Episode::SEVERE) {
+                mon::reportMSACI( mon::MHE_SEVERE_EPISODES_WITHOUT_COMORBIDITIES, surveyPeriod, ageGroup, cohortSet, 1 );
+            }
         } else { // UC or UC2
             mon::reportMSACI( mon::MHE_UNCOMPLICATED_EPISODES, surveyPeriod, ageGroup, cohortSet, 1 );
         }

--- a/model/Clinical/Episode.h
+++ b/model/Clinical/Episode.h
@@ -61,6 +61,8 @@ public:
         MALARIA             = WithinHost::Pathogenesis::MALARIA,          ///< Malaria sickness
         /// Used by ClinicalEventScheduler to indicate a second bout of malarial sickness within the same episode (roughly)
         SECOND_CASE         = 0x10,
+        SEVERE              = 0x8,      ///< Severe malaria case
+        COINFECTION         = 0x4,      ///< Malaria with a coinfection
         COMPLICATED         = WithinHost::Pathogenesis::COMPLICATED,         ///< Flag used to indicate SEVERE and/or COINFECTION
         
         //NEED_ANTIBIOTIC     = 0x40,         ///< Flag indicates a non-malaria fever requires (antibiotic) treatment

--- a/model/Host/WithinHost/Pathogenesis/PathogenesisModel.cpp
+++ b/model/Host/WithinHost/Pathogenesis/PathogenesisModel.cpp
@@ -117,6 +117,7 @@ Pathogenesis::StatePair PathogenesisModel::determineState(Host::Human& human,
         // Expectation of a severe bout:
         const double exSevere = prSevereEpisode + (1.0 - prSevereEpisode) * pCoinfection;
         mon::reportStatMHF( mon::MHF_EXPECTED_SEVERE, human, exSevere );
+        mon::reportStatMHF( mon::MHF_EXPECTED_SEVERE_WITHOUT_COMORBIDITIES, human, prSevereEpisode );
         
         if( human.rng().bernoulli( prSevereEpisode ) )
             result.state = STATE_SEVERE;

--- a/model/mon/OutputMeasures.h
+++ b/model/mon/OutputMeasures.h
@@ -455,12 +455,20 @@ void defineOutMeasures(){
      * the reporting period. */
     namedOutMeasures["innoculationsPerVector"] =
         OutMeasure::species( 79, MVF_INOCS, false );
-    
+    /// Similar to nSevere. Number of severe episodes WITHOUT coinfection
+    namedOutMeasures["nSevereWithoutComorbidities"] =
+        OutMeasure::humanAC( 80, MHE_SEVERE_EPISODES_WITHOUT_COMORBIDITIES, false );
+    /** Similar to 'expectedSevere'.
+     * Expected number of severe bouts of malaria WITHOUT "complications due 
+     * to coinfection" (the same as the `nSevereWithoutComorbidities` output). */
+    namedOutMeasures["expectedSevereWithoutComorbidities"] =
+        OutMeasure::humanAC( 81, MHF_EXPECTED_SEVERE_WITHOUT_COMORBIDITIES, true );
     // Now initialise valid condition measures:
     for( const NamedMeasureMapT::value_type& v : namedOutMeasures ){
         Measure m = v.second.m;
         // Not the following:
         if( m == mon::MHE_SEVERE_EPISODES ||
+            m == mon::MHE_SEVERE_EPISODES_WITHOUT_COMORBIDITIES ||
             m == mon::MHE_UNCOMPLICATED_EPISODES ||
             m == mon::MHO_DIRECT_DEATHS ||
             m == mon::MHO_HOSPITAL_DEATHS ||

--- a/model/mon/reporting.h
+++ b/model/mon/reporting.h
@@ -84,6 +84,8 @@ enum Measure{
     MHE_UNCOMPLICATED_EPISODES,
     // Number of severe fever episodes in humans. Units: cases
     MHE_SEVERE_EPISODES,
+    // Number of severe fever episodes without counting episodes due to comorbidities in humans. Units: cases
+    MHE_SEVERE_EPISODES_WITHOUT_COMORBIDITIES,
     // Number of fever episodes in humans not due to malaria. Units: cases
     MHE_NON_MALARIA_FEVERS,
     
@@ -162,6 +164,8 @@ enum Measure{
     MHF_EXPECTED_SEQUELAE,
     // Expected severe bouts
     MHF_EXPECTED_SEVERE,
+    // Expected severe bouts without counting expected episodes due to comorbidites
+    MHF_EXPECTED_SEVERE_WITHOUT_COMORBIDITIES,
     
     // ———  MVF: vector (transmission) measures (doubles)  ———
     // Infectiousness of human population to mosquitoes


### PR DESCRIPTION
Add two new measures:

- nSevereWithoutComorbidities (81)
- expectedSevereWithoutComborbidities (82)

which are the same as 'nSevere' and 'expectedSevere', respectively, but without counting cases caused by comorbidities. 

Note that 'nSevere' and 'expectedSevere' are unchanged.