### PR TITLE
add ProbDeathSeeking to VectorPop intervention

### DIFF
--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -31,6 +31,109 @@
 
 #include <cmath>
 
+#include <stdio.h>
+#include <gsl/gsl_errno.h>
+#include <gsl/gsl_math.h>
+#include <gsl/gsl_roots.h>
+
+struct quadratic_params
+{
+    double ah; // The availability rate of host h. Time-1
+    double an; // The availability rate of host n. Time-1
+    double Nh; // Population size of hosts of type h. Animals.
+    double Nn; // Population size of hosts of type n. Humans.
+    double mu_v_interv; // Mosquito mortality rate while host-seeking. Time-1
+    double theta_d; // Proportion of the night that the mosquito spends host-seeking. Time.
+    double PAt_wanted; // PAt is the daily probability of a mosquito feeding on an ATSB
+};
+
+double quadratic_f (double x, void *params)
+{
+    struct quadratic_params *p = (struct quadratic_params *) params;
+
+    double ah = p->ah;
+    double an = p->an;
+    double Nh = p->Nh;
+    double Nn = p->Nn;
+    double mu_v_interv = p->mu_v_interv;
+    double theta_d = p->theta_d;
+    double PAt_wanted = p->PAt_wanted;
+    
+    double tmp = (x + Nh*ah + Nn*an + mu_v_interv);
+
+    return (1.0 - exp(-tmp * theta_d)) * x / tmp - PAt_wanted;
+}
+
+double quadratic_df (double x, void *params)
+{
+    struct quadratic_params *p = (struct quadratic_params *) params;
+
+    double ah = p->ah;
+    double an = p->an;
+    double Nh = p->Nh;
+    double Nn = p->Nn;
+    double mu_v_interv = p->mu_v_interv;
+    double theta_d = p->theta_d;
+    // double PAt_wanted = p->PAt_wanted;
+
+    double tmp = (x + Nh*ah + Nn*an + mu_v_interv);
+
+    double a = (1.0 - exp(-tmp * theta_d)) * x / (tmp * tmp);
+    double b = (1.0 - exp(-tmp * theta_d)) / tmp;
+    double c = exp(-tmp * theta_d) * x * theta_d / tmp;
+
+    return -a + b + c;
+}
+
+void quadratic_fdf (double x, void *params, double *y, double *dy)
+{
+    struct quadratic_params *p = (struct quadratic_params *) params;
+
+    double ah = p->ah;
+    double an = p->an;
+    double Nh = p->Nh;
+    double Nn = p->Nn;
+    double mu_v_interv = p->mu_v_interv;
+    double theta_d = p->theta_d;
+    double PAt_wanted = p->PAt_wanted;
+
+    double tmp = (x + Nh*ah + Nn*an + mu_v_interv);
+
+    double a = (1.0 - exp(-tmp)) * x / (tmp * tmp);
+    double b = (1.0 - exp(-tmp)) / tmp;
+    double c = exp(-tmp * theta_d) * x * theta_d / tmp;
+
+    *y = (1.0 - exp(-tmp * theta_d)) * x / tmp - PAt_wanted;
+    *dy = -a + b + c;
+}
+
+#define USE_DERIVATIVE
+
+#ifdef USE_DERIVATIVE
+    using gsl_root_solver_type = gsl_root_fdfsolver_type;
+    using gsl_root_solver = gsl_root_fdfsolver;
+    auto gsl_root_solver_alloc = gsl_root_fdfsolver_alloc;
+    auto gsl_root_solver_free = gsl_root_fdfsolver_free;
+    auto gsl_root_solver_name = gsl_root_fdfsolver_name;
+    auto gsl_root_solver_iterate = gsl_root_fdfsolver_iterate;
+    auto gsl_root_solver_root = gsl_root_fdfsolver_root;
+    // auto gsl_root_solver_method = gsl_root_fdfsolver_newton;
+    auto gsl_root_solver_method = gsl_root_fdfsolver_secant;
+    // auto gsl_root_solver_method = gsl_root_fdfsolver_steffenson;
+#else
+    using gsl_root_solver_type = gsl_root_fsolver_type;
+    using gsl_root_solver = gsl_root_fsolver;
+    auto gsl_root_solver_alloc = gsl_root_fsolver_alloc;
+    auto gsl_root_solver_free = gsl_root_fsolver_free;
+    auto gsl_root_solver_name = gsl_root_fsolver_name;
+    auto gsl_root_solver_iterate = gsl_root_fsolver_iterate;
+    auto gsl_root_solver_root = gsl_root_fsolver_root;
+    // auto gsl_root_solver_method = gsl_root_fsolver_brent;
+    auto gsl_root_solver_method = gsl_root_fsolver_bisection;
+    // auto gsl_root_solver_method = gsl_root_fsolver_falsepos;
+#endif
+
+
 namespace OM
 {
 namespace Transmission
@@ -403,6 +506,8 @@ void AnophelesModel::advancePeriod(double sum_avail, double sigma_df, vector<dou
     {
         leaveRate *= 1.0 + increase.current_value(sim::ts0());
     }
+    double mu_v_interv = leaveRate;
+    printf("don't forget to remove\n");
     leaveRate += sum_avail;
 
     // NON-HUMAN HOSTS INTERVENTIONS
@@ -495,6 +600,103 @@ void AnophelesModel::advancePeriod(double sum_avail, double sigma_df, vector<dou
         it++;
     }
 
+    printf("sum_avail: %f\n", sum_avail);
+    printf("modified_nhh_avail: %f\n", modified_nhh_avail);
+
+    // Calculate alpha_t for ATSB interventions with fixed target PA
+    // =============================================================
+    printf("check if multiple fixed PA ATSB interventions at the same time\n");
+    printf("%d %d\n", sim::intervDate()-sim::startDate(), sim::ts0());
+    // if ((sim::intervDate()-sim::startDate() > 22*365) && (sim::intervDate()-sim::startDate() < 25*365))
+    // {
+    //     int status;
+    //     int iter = 0, max_iter = 20;
+
+    //     double x0, x = 0.5;
+
+    //     double ah = sum_avail;//0.0001; // The availability rate of host h. Time-1
+    //     double an = modified_nhh_avail;//0.0072; // The availability rate of host n. Time-1
+    //     double Nh = 1.0;//10000; // Population size of hosts of type h. Animals.
+    //     double Nn = 1.0; // Population size of hosts of type n. Humans.
+    //     // double mu_v_interv = mu_v_interv; // Mosquito mortality rate while host-seeking. Time-1
+    //     double theta_d = mosq.seekingDuration; // Proportion of the night that the mosquito spends host-seeking. Time.
+    //     double PAt_wanted = 0.015; // PAt is the daily probability of a mosquito feeding on an ATSB
+
+    //     struct quadratic_params params = { ah, an, Nh, Nn, mu_v_interv, theta_d, PAt_wanted};
+
+    //     const gsl_root_solver_type *T = gsl_root_solver_method;
+    //     gsl_root_solver *s = gsl_root_solver_alloc(T);
+
+    //     #ifdef USE_DERIVATIVE
+    //         gsl_function_fdf FDF;
+    //         FDF.f = &quadratic_f;
+    //         FDF.df = &quadratic_df;
+    //         FDF.fdf = &quadratic_fdf;
+    //         FDF.params = &params;
+
+    //         gsl_root_fdfsolver_set (s, &FDF, x);
+    //     #else
+    //         gsl_function F;
+    //         F.function = &quadratic_f;
+    //         F.params = &params;
+
+    //         gsl_root_fsolver_set (s, &F, 0.0, 1.0);
+    //     #endif
+
+    //     printf("Checks:\n");
+    //     printf("f(0) = %f\n", quadratic_f(0, &params));
+    //     printf("df(0) = %f\n", quadratic_df(0, &params));
+
+    //     printf ("using %s method\n", gsl_root_solver_name (s));
+    //     printf ("%-5s %10s %10s\n", "iter", "root", "err(est)");
+
+    //     do
+    //     {
+    //         iter++;
+    //         status = gsl_root_solver_iterate (s);
+    //         x0 = x;
+    //         x = gsl_root_solver_root (s);
+
+    //         status = gsl_root_test_delta (x, x0, 0, 1e-4);
+
+    //         if (status == GSL_SUCCESS)
+    //             printf ("Converged:\n");
+
+
+    //         printf ("%5d %10.7f %10.7f\n", iter, x, x - x0);
+    //     }
+    //     while (status == GSL_CONTINUE && iter < max_iter);
+
+    //     gsl_root_solver_free (s);
+
+    //     double a_t = x;
+    //     printf("a_t: %f\n", a_t);
+    //     printf("a_h * N_h: %f\n", sum_avail);
+    //     printf("a_n * N_n: %f\n", modified_nhh_avail);
+    //     printf("leaveRate (a_h * N_h + a_n * N_n + mu_v_interv): %f\n", leaveRate);
+    //     printf("seekingDuration: %f\n", mosq.seekingDuration);
+    //     printf("seekingDeathRate: %f\n", mu_v_interv);
+    //     printf("seekingDeathRateIncrease: %f\n", a_t / mu_v_interv);
+    //     printf("newSeekingDeathRate: %f\n", mu_v_interv * (1.0 + (a_t / mu_v_interv)));
+    //     // printf("newSeekingDeathRate: %f\n", mosq.seekingDeathRate + (a_t / mosq.seekingDeathRate));
+        
+    //     double tmp = (Nh*ah + Nn*an + mu_v_interv);
+    //     double PAmu = (1.0 - exp(-theta_d * tmp)) * mu_v_interv / tmp;
+    //     printf("PAmu_Before: %f\n", PAmu);
+
+    //     mu_v_interv = mu_v_interv * (1.0 + (a_t / mu_v_interv));
+    //     // double mu = mosq.seekingDeathRate + (a_t / mosq.seekingDeathRate);
+        
+    //     tmp = (a_t + Nh*ah + Nn*an + mu_v_interv);
+    //     PAmu = (1.0 - exp(-theta_d * tmp)) * mu_v_interv / tmp;
+    //     printf("PAmu_After: %f\n", PAmu);
+    //     printf("PA_t(a_t): %f\n", (1.0 - exp(-theta_d * tmp)) * a_t / tmp);
+
+    //     // Forward
+    //     leaveRate += a_t;
+    //     // mosq.seekingDeathRate = mu_v_interv * (1.0 + (a_t / mu_v_interv));
+    // }
+    // =============================================================
     // Probability of a mosquito not finding a host this day:
     double tsP_A = exp(-leaveRate * mosq.seekingDuration);
     double availDivisor = (1.0 - tsP_A) / leaveRate; // α_d

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -408,15 +408,15 @@ void AnophelesModel::initVectorInterv(const scnXml::VectorSpeciesIntervention &e
         if (elt2.getInitial() > 1.0) throw util::xml_scenario_error("emergenceReduction intervention: initial effect must be ≤ 1");
         emergenceReduction[instance].set(elt2.getInitial(), elt2.getDecay(), "emergenceReduction");
     }
-    if (probDeathSeekingIntervs.size() <= instance) probDeathSeekingIntervs.resize(instance + 1);
+    if (probAdditionalDeathSugarFeedingIntervs.size() <= instance) probAdditionalDeathSugarFeedingIntervs.resize(instance + 1);
     if (seekingDeathRateIntervs.size() <= instance) seekingDeathRateIntervs.resize(instance + 1);
     if (probDeathOvipositingIntervs.size() <= instance) probDeathOvipositingIntervs.resize(instance + 1);
 
-    if (elt.getProbDeathSeeking().present())
+    if (elt.getProbAdditionalDeathSugarFeeding().present())
     {
-        const scnXml::ProbDeathSeeking &elt2 = elt.getProbDeathSeeking().get();
-        if (elt2.getInitial() < -1.0) throw util::xml_scenario_error("probDeathSeeking intervention: initial effect must be ≥ -1");
-        probDeathSeekingIntervs[instance].set(elt2.getInitial(), elt2.getDecay(), "seekingDeathRateIncrease");
+        const scnXml::ProbAdditionalDeathSugarFeeding &elt2 = elt.getProbAdditionalDeathSugarFeeding().get();
+        if (elt2.getInitial() < -1.0) throw util::xml_scenario_error("probAdditionalDeathSugarFeeding intervention: initial effect must be ≥ -1");
+        probAdditionalDeathSugarFeedingIntervs[instance].set(elt2.getInitial(), elt2.getDecay(), "seekingDeathRateIncrease");
     }
     if (elt.getSeekingDeathRateIncrease().present())
     {
@@ -447,7 +447,7 @@ void AnophelesModel::deployVectorPopInterv(LocalRng &rng, size_t instance)
     emergenceReduction[instance].deploy(rng, sim::now());
     // do same as in above function (of EmergenceModel)
     assert(instance < seekingDeathRateIntervs.size() && instance < probDeathOvipositingIntervs.size());
-    probDeathSeekingIntervs[instance].deploy(rng, sim::now());
+    probAdditionalDeathSugarFeedingIntervs[instance].deploy(rng, sim::now());
     seekingDeathRateIntervs[instance].deploy(rng, sim::now());
     probDeathOvipositingIntervs[instance].deploy(rng, sim::now());
 }
@@ -601,7 +601,7 @@ void AnophelesModel::advancePeriod(double sum_avail, double sigma_df, vector<dou
     // Calculate alpha_t for ATSB interventions with fixed target PA
     // =============================================================
     double pDeathSeeking = 0.0;
-    for (const util::SimpleDecayingValue &pDeath : probDeathSeekingIntervs)
+    for (const util::SimpleDecayingValue &pDeath : probAdditionalDeathSugarFeedingIntervs)
         pDeathSeeking += pDeath.current_value(sim::ts0());
 
     if(pDeathSeeking > 1.0)

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -590,6 +590,9 @@ public:
     /** Parameters for trap interventions. Doesn't need checkpointing. */
     vector<TrapParams> trapParams;
 
+    /** Interventions affecting death rate while seeking (parameters + state) based on a given probability */
+    vector<util::SimpleDecayingValue> probDeathSeekingIntervs;
+
     /** Interventions affecting death rate while seeking (parameters + state) */
     vector<util::SimpleDecayingValue> seekingDeathRateIntervs;
 

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -591,7 +591,7 @@ public:
     vector<TrapParams> trapParams;
 
     /** Interventions affecting death rate while seeking (parameters + state) based on a given probability */
-    vector<util::SimpleDecayingValue> probDeathSeekingIntervs;
+    vector<util::SimpleDecayingValue> probAdditionalDeathSugarFeedingIntervs;
 
     /** Interventions affecting death rate while seeking (parameters + state) */
     vector<util::SimpleDecayingValue> seekingDeathRateIntervs;

--- a/schema/interventions.xsd
+++ b/schema/interventions.xsd
@@ -2052,11 +2052,17 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
             Describe an effect on the increase in the death rate while host
             seeking (mu_vA) due to this intervention.
             
-            Enter the rate increase (i.e. if rate increases to 120% of normal,
-            give 0.2). New death rate while seeking is old × (1 + increase)
-            where increase is this factor given. Must have increas ≥ -1.
-          </xs:documentation>
-     <xs:appinfo>units:dimensionless;name:Proportional increase in deaths while host searching;</xs:appinfo>
+            Enter the probability of dying while host seeking due to this 
+            intervention. If multiple interventions overlap, the cumulative 
+            probability will be used. Note that it cannot exceed 1, and 
+            OpenMalaria will return an error during the simulation if this
+            ever happens.
+
+            OpenMalaria will dynamically compute the necessary increase 
+            in mu_vA based on the given probability. Note that this is done 
+            by solving an equation numerically every timestep, which can 
+            cause a small drop in performance.</xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Probability of death while host searching (used to dynamically adjust mu_vA);</xs:appinfo>
     </xs:annotation>
     <xs:complexType>
      <xs:sequence>

--- a/schema/interventions.xsd
+++ b/schema/interventions.xsd
@@ -2046,11 +2046,17 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
      </xs:attribute>
     </xs:complexType>
    </xs:element>
-   <xs:element name="probDeathSeeking" minOccurs="0">
+   <xs:element name="probAdditionalDeathSugarFeeding" minOccurs="0">
     <xs:annotation>
      <xs:documentation>
             Describe an effect on the increase in the death rate while host
-            seeking (mu_vA) due to this intervention.
+            seeking (mu_vA) due to this intervention. This works like 
+            adding an non-human host with its own availability. The
+            difference is that biting this sugar bait is associated with a 
+            probability of dying of 1: all mosquitoes biting the sugar bait
+            will die. OpenMalaria will automatically compute the 
+            availability for this host so that the probability of biting this
+            'host' (and thus dying) is equal to the input parameter.
             
             Enter the probability of dying while host seeking due to this 
             intervention. If multiple interventions overlap, the cumulative 
@@ -2062,7 +2068,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
             in mu_vA based on the given probability. Note that this is done 
             by solving an equation numerically every timestep, which can 
             cause a small drop in performance.</xs:documentation>
-     <xs:appinfo>units:dimensionless;name:Probability of death while host searching (used to dynamically adjust mu_vA);</xs:appinfo>
+     <xs:appinfo>units:dimensionless;name:Probability of death while host searching as a result of feeding on a sugar bait (used to dynamically adjust mu_vA);</xs:appinfo>
     </xs:annotation>
     <xs:complexType>
      <xs:sequence>

--- a/schema/interventions.xsd
+++ b/schema/interventions.xsd
@@ -2046,6 +2046,29 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
      </xs:attribute>
     </xs:complexType>
    </xs:element>
+   <xs:element name="probDeathSeeking" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Describe an effect on the increase in the death rate while host
+            seeking (mu_vA) due to this intervention.
+            
+            Enter the rate increase (i.e. if rate increases to 120% of normal,
+            give 0.2). New death rate while seeking is old × (1 + increase)
+            where increase is this factor given. Must have increas ≥ -1.
+          </xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Proportional increase in deaths while host searching;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="decay" type="om:DecayFunction"/>
+     </xs:sequence>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
   </xs:all>
   <xs:attribute name="mosquito" type="xs:string" use="required">
    <xs:annotation>


### PR DESCRIPTION
Add `probDeathSeeking' parameter effect to the VectorPop intervention. This parameter must be specified as a decay function and allows the user to fix the probability of dying while host seeking.

It can be used as follows:
```
<probDeathSeeking initial="0.01">
        <decay L="3" function="step"/>
</probDeathSeeking>
```

When using this effect, OpenMalaria will dynamically compute the corresponding increase in death rate while host seeking (mu_vA). This is done by internally solving an equation numerically every timestep, and as such a small drop in performance must be expected.

If multiple VectorPop interventions overlap, the cumulative probability will be used. Note that it cannot exceed 1, and OpenMalaria will return an error during the simulation if it ever happens.