### PR TITLE
Fix OpenMalaria spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Open Malaria
+OpenMalaria
 ============
 
 This git-repository contains source-code for OpenMalaria, a simulator program


### PR DESCRIPTION
- corrected "Open Malaria" -> "OpenMalaria" in the README title