### PR TITLE
add increasing decay functions with complement=true option

### DIFF
--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -34,7 +34,9 @@ namespace util {
 class BaseHetDecayFunction : public DecayFunction {
     LognormalSampler het;
 public:
-    BaseHetDecayFunction( const scnXml::DecayFunction& elt ){
+    BaseHetDecayFunction( const scnXml::DecayFunction& elt ) :
+        DecayFunction( elt )
+    {
         het.setMeanCV( 1.0, elt.getCV() );
     }
     
@@ -50,6 +52,10 @@ public:
 
 class ConstantDecayFunction : public DecayFunction {
 public:
+    ConstantDecayFunction( const scnXml::DecayFunction& elt ) :
+        DecayFunction( elt )
+    {}
+
     DecayFuncHet hetSample (LocalRng& rng) const{
         DecayFuncHet ret;
         ret.tMult = 1.0;
@@ -244,7 +250,7 @@ unique_ptr<DecayFunction> DecayFunction::makeObject(
     // Type mostly equivalent to a std::string:
     const scnXml::Function& func = elt.getFunction();
     if( func == "constant" ){
-        return unique_ptr<DecayFunction>(new ConstantDecayFunction);
+        return unique_ptr<DecayFunction>(new ConstantDecayFunction( elt ));
     }else if( func == "step" ){
         return unique_ptr<DecayFunction>(new StepDecayFunction( elt ));
     }else if( func == "linear" ){
@@ -261,9 +267,5 @@ unique_ptr<DecayFunction> DecayFunction::makeObject(
         throw util::xml_scenario_error("decay function type " + string(func) + " of " + string(eltName) + " unrecognized");
     }
 }
-unique_ptr<DecayFunction> DecayFunction::makeConstantObject(){
-    return unique_ptr<DecayFunction>(new ConstantDecayFunction);
-}
-
 
 } }

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -72,6 +72,10 @@ public:
 class DecayFunction
 {
 public:
+    DecayFunction(const scnXml::DecayFunction& elt) :
+        complement(elt.getComplement())
+    {}
+
     virtual ~DecayFunction() {}
     
     /** Return a new decay function, constructed from an XML element.
@@ -82,9 +86,7 @@ public:
     static unique_ptr<DecayFunction> makeObject(
         const scnXml::DecayFunction& elt, const char* eltName
     );
-    /** Return an object representing no decay (useful default). */
-    static unique_ptr<DecayFunction> makeConstantObject();
-    
+
     /** Return a value in the range [0,1] describing remaining effectiveness of
      * the intervention.
      * 
@@ -97,7 +99,10 @@ public:
      * over this period (from age-1 to age), but difference should be small for
      * interventions being effective for a month or more. */
     inline double eval( SimTime age, DecayFuncHet sample )const{
-        return eval( age * sample.getTMult() );
+        if(complement)
+            return 1.0 - eval( age * sample.getTMult() );
+        else
+            return eval( age * sample.getTMult() );
     }
     
     /** Sample a DecayFuncHet value (should be stored per individual).
@@ -125,6 +130,9 @@ protected:
     // Protected version. Note that the het sample parameter is needed even
     // when heterogeneity is not used so don't try calling this without that.
     virtual double eval(double ageDays) const =0;
+
+private:
+    bool complement;
 };
 
 } }

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -3,30 +3,28 @@
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
 <!-- standard types used -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_44"
-           xmlns:om="http://openmalaria.org/schema/scenario_44"
-           xmlns:xs="http://www.w3.org/2001/XMLSchema">
-  <!-- Component and TriggeredDeployments would be in interventions.xsd, except
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_44" xmlns:om="http://openmalaria.org/schema/scenario_44" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+ <!-- Component and TriggeredDeployments would be in interventions.xsd, except
     that they are needed from healthSystem.xsd -->
-  <xs:complexType name="Component">
-    <xs:annotation>
-      <xs:documentation>
+ <xs:complexType name="Component">
+  <xs:annotation>
+   <xs:documentation>
         The list of components deployed to eligible humans.
       </xs:documentation>
-    <xs:appinfo>name:Component to be deployed;</xs:appinfo>
-    </xs:annotation>
-    <xs:attribute name="id" type="xs:string" use="required">
-      <xs:annotation>
-        <xs:documentation>
+   <xs:appinfo>name:Component to be deployed;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="id" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
           The identifier (short name) of a component.
         </xs:documentation>
-        <xs:appinfo>name:Identifier;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="TriggeredDeployments">
-    <xs:annotation>
-      <xs:documentation>
+    <xs:appinfo>name:Identifier;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="TriggeredDeployments">
+  <xs:annotation>
+   <xs:documentation>
         Lists intervention components which are deployed according to some
         external trigger (for example, screening with a negative patency
         outcome or health-system treatment).
@@ -36,89 +34,89 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
         met by the human host and a random sample with the given probability of
         a positive outcome is positive.
       </xs:documentation>
-      <xs:appinfo>name:Triggered intervention deployment;</xs:appinfo>
-    </xs:annotation>
-    <xs:sequence>
-      <xs:element name="deploy" minOccurs="0" maxOccurs="unbounded">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="component" maxOccurs="unbounded" type="om:Component"/>
-          </xs:sequence>
-          <xs:attribute name="maxAge" type="xs:double" use="optional">
-            <xs:annotation>
-              <xs:documentation>
+   <xs:appinfo>name:Triggered intervention deployment;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="deploy" minOccurs="0" maxOccurs="unbounded">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="component" maxOccurs="unbounded" type="om:Component"/>
+     </xs:sequence>
+     <xs:attribute name="maxAge" type="xs:double" use="optional">
+      <xs:annotation>
+       <xs:documentation>
                 Maximum age of eligible humans (defaults to no limit).
                 
                 Input is rounded to the nearest time step.
               </xs:documentation>
-              <xs:appinfo>units:Years;min:0;name:Maximum age of eligible humans;</xs:appinfo>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="minAge" type="xs:double" default="0">
-            <xs:annotation>
-              <xs:documentation>
+       <xs:appinfo>units:Years;min:0;name:Maximum age of eligible humans;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="minAge" type="xs:double" default="0">
+      <xs:annotation>
+       <xs:documentation>
                 Minimum age of eligible humans (defaults to 0).
                 
                 Input is rounded to the nearest time step.
               </xs:documentation>
-              <xs:appinfo>units:Years;min:0;name:Minimum age of eligible humans;</xs:appinfo>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="p" type="xs:double" default="1">
-            <xs:annotation>
-              <xs:documentation>
+       <xs:appinfo>units:Years;min:0;name:Minimum age of eligible humans;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="p" type="xs:double" default="1">
+      <xs:annotation>
+       <xs:documentation>
                 Probability of this list of components being deployed, given
                 that other constraints are met.
               </xs:documentation>
-              <xs:appinfo>units:dimensionless;min:0;max:1;name:Probability of delivery to eligible humans;</xs:appinfo>
-            </xs:annotation>
-          </xs:attribute>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="OptionSet">
-    <xs:sequence>
-      <xs:element name="option" type="om:Option" minOccurs="0" maxOccurs="unbounded"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="Option">
-    <xs:attribute name="name" type="xs:string" use="required">
-      <xs:annotation>
-        <xs:documentation>
+       <xs:appinfo>units:dimensionless;min:0;max:1;name:Probability of delivery to eligible humans;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="OptionSet">
+  <xs:sequence>
+   <xs:element name="option" type="om:Option" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="Option">
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
           Name of an option (monitoring measure or model option).
         </xs:documentation>
-        <xs:appinfo>name:Option name;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="value" type="xs:boolean" default="true">
-      <xs:annotation>
-        <xs:documentation>
-          Option on/off switch (true/false). Specifying value="true" is
-          the same as not specifying a value; specifying value="false"
+    <xs:appinfo>name:Option name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="value" type="xs:boolean" default="true">
+   <xs:annotation>
+    <xs:documentation>
+          Option on/off switch (true/false). Specifying value=&quot;true&quot; is
+          the same as not specifying a value; specifying value=&quot;false&quot;
           explicitly turns the option off. If an option is not mentioned
           at all, it is left at its default value (normally off, but
           in a few cases, such as some bug-fix options, on).
         </xs:documentation>
-      <xs:appinfo>name:Indicator of whether option is required;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="DoubleList">
-    <xs:sequence>
-      <xs:element name="item" maxOccurs="unbounded" type="xs:double" />
-    </xs:sequence>
-  </xs:complexType>
-  <xs:complexType name="DecayFunction">
-    <xs:annotation>
-      <xs:documentation>
+    <xs:appinfo>name:Indicator of whether option is required;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DoubleList">
+  <xs:sequence>
+   <xs:element name="item" maxOccurs="unbounded" type="xs:double"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="DecayFunction">
+  <xs:annotation>
+   <xs:documentation>
         Specification of decay or survival of a parameter.
       </xs:documentation>
-      <xs:appinfo>name:Decay or survival of a parameter</xs:appinfo>
-    </xs:annotation>
-    <xs:attribute name="function" use="required">
-      <xs:annotation>
-        <xs:documentation>
+   <xs:appinfo>name:Decay or survival of a parameter</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="function" use="required">
+   <xs:annotation>
+    <xs:documentation>
           Determines which decay function to use. Available decay functions,
           for age t in years:
           
@@ -136,27 +134,27 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
           
           smooth-compact: exp( k - k / (1 - (t/L)^2) ) for t less than L, otherwise 0
         </xs:documentation>
-        <xs:appinfo>units:None;min:0;max:1;name:function;</xs:appinfo>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="constant" />
-          <xs:enumeration value="step" />
-          <xs:enumeration value="linear" />
-          <xs:enumeration value="exponential" />
-          <xs:enumeration value="weibull" />
-          <xs:enumeration value="hill" />
-          <xs:enumeration value="smooth-compact" />
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:attribute>
-    <xs:attribute name="L" type="xs:string" use="optional">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>units:None;min:0;max:1;name:function;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="constant"/>
+     <xs:enumeration value="step"/>
+     <xs:enumeration value="linear"/>
+     <xs:enumeration value="exponential"/>
+     <xs:enumeration value="weibull"/>
+     <xs:enumeration value="hill"/>
+     <xs:enumeration value="smooth-compact"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="L" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
           (Time) scale parameter of distribution: this is either the age of
           complete decay (smooth-compact, step and linear functions) or the age
           at which the parameter has decayed to half its original value
-          (exponential, weibull and hill). Not used when function="constant"
+          (exponential, weibull and hill). Not used when function=&quot;constant&quot;
           (i.e. no decay).
           
           This value can be specified in years, days or steps (e.g. 2y, 180d or
@@ -164,21 +162,21 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
           used without rounding except when sampling an age of decay, when the
           rounding happens as late as possible.
         </xs:documentation>
-        <xs:appinfo>units:User-defined (defaults to years);min:0;name:L;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="k" type="xs:double" default="1.0">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to years);min:0;name:L;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="k" type="xs:double" default="1.0">
+   <xs:annotation>
+    <xs:documentation>
           Shape parameter of distribution. If not specified, default value of
           1 is used. Meaning depends on function; not used in some cases.
         </xs:documentation>
-        <xs:appinfo>min:0;name:k;units:none;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="CV" type="xs:double" default="0">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>min:0;name:k;units:none;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="CV" type="xs:double" default="0">
+   <xs:annotation>
+    <xs:documentation>
         If CV is non-zero, heterogeneity of decay is introduced via a random
         variable sampled from the log-normal distribution. This distribution is
         parameterised with mean=1 and CV as given.
@@ -187,256 +185,267 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
         (for decay functions with a half-life, this is equivalent to dividing
         the half-life by the variable).
         </xs:documentation>
-        <xs:appinfo>min:0;name:Coefficient of Variation;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="SampledValueN">
-    <xs:annotation>
-      <xs:documentation>
+    <xs:appinfo>min:0;name:Coefficient of Variation;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="complement" type="xs:boolean" default="false">
+   <xs:annotation>
+    <xs:documentation>
+          (Boolean) If True, this tells OpenMalaria to use the complement of the
+          DecayFunction defined as 1-f(x). This is useful to model increasing
+          functions that will &quot;decay&quot; to 1. This only works if f(x) is contained
+          between 0 and 1.
+</xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to years);min:0;name:L;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="SampledValueN">
+  <xs:annotation>
+   <xs:documentation>
         A parameter with optional heterogeneity.
         
-        Optionally, a distribution ("distr") and standard of deviation ("SD") may be specified.
+        Optionally, a distribution (&quot;distr&quot;) and standard of deviation (&quot;SD&quot;) may be specified.
       </xs:documentation>
-      <xs:appinfo>name:Sampled value (normal);</xs:appinfo>
-    </xs:annotation>
-    <xs:attribute name="mean" type="xs:double" use="required">
-      <xs:annotation>
-        <xs:documentation>
+   <xs:appinfo>name:Sampled value (normal);</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="mean" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
           The mean value.
         </xs:documentation>
-        <xs:appinfo>name:mean;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="SD" type="xs:double" use="optional">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>name:mean;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="SD" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
           The standard deviation of variates.
         </xs:documentation>
-        <xs:appinfo>name:standard deviation;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="distr" use="optional" default="const">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>name:standard deviation;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="distr" use="optional" default="const">
+   <xs:annotation>
+    <xs:documentation>
           To allow heterogeneity, a distribution must be specified.
           
           Valid options are as follows.
           
-          "const": no variation or sampling. Specifying distr="const" has the
+          &quot;const&quot;: no variation or sampling. Specifying distr=&quot;const&quot; has the
           same effect as not specifying distr at all.
           
-          "normal": the parameter is sampled from a normal distribution.
+          &quot;normal&quot;: the parameter is sampled from a normal distribution.
         </xs:documentation>
-        <xs:appinfo>name:Distribution;</xs:appinfo>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="const" />
-          <xs:enumeration value="normal" />
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="BetaMeanSample">
-    <xs:annotation>
-      <xs:documentation>
+    <xs:appinfo>name:Distribution;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="const"/>
+     <xs:enumeration value="normal"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="BetaMeanSample">
+  <xs:annotation>
+   <xs:documentation>
         Parameters of a normal distribution, provided as mean and variance.
         
         Variates are sampled from Be(α,β) where α and β are determined from the
         mean and variance as follows: let v be the variance and c=mean/(1-mean).
         Then we set α=cβ and β=((c+1)²v - c)/((c+1)³v).
       </xs:documentation>
-      <xs:appinfo>name:Log-normal parameters;</xs:appinfo>
-    </xs:annotation>
-    <xs:attribute name="mean" type="xs:double" use="required">
-      <xs:annotation>
-        <xs:documentation>
+   <xs:appinfo>name:Log-normal parameters;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="mean" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
           The mean of the beta distribution (must be in the open range (0,1)).
         </xs:documentation>
-        <xs:appinfo>units:none;name:mean;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="variance" type="xs:double" use="required">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>units:none;name:mean;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="variance" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
           The standard deviation of variates.
         </xs:documentation>
-        <xs:appinfo>units:none;name:variance;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="SampledValueCV">
-    <xs:annotation>
-      <xs:documentation>
+    <xs:appinfo>units:none;name:variance;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="SampledValueCV">
+  <xs:annotation>
+   <xs:documentation>
         A parameter with optional heterogeneity.
         
         The mean cannot be specified (unless this type is extended).
-        Optionally, a distribution ("distr") and coefficient of variation ("CV") may be specified.
+        Optionally, a distribution (&quot;distr&quot;) and coefficient of variation (&quot;CV&quot;) may be specified.
       </xs:documentation>
-      <xs:appinfo>name:Sampled value (log normal);</xs:appinfo>
-    </xs:annotation>
-    <xs:attribute name="CV" type="xs:double" use="optional">
-      <xs:annotation>
-        <xs:documentation>
+   <xs:appinfo>name:Sampled value (log normal);</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="CV" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
           The (linear) coefficient of variation.
           
           This value must be specified when a (non-constant) distribution is used.
           
-          Note that specifying CV="0" has the same effect as distr="const" and
-          disables sampling of this parameter, even if distr is not "const". 
+          Note that specifying CV=&quot;0&quot; has the same effect as distr=&quot;const&quot; and
+          disables sampling of this parameter, even if distr is not &quot;const&quot;. 
         </xs:documentation>
-        <xs:appinfo>name:Coefficient of variation;units:unitless;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="distr" use="optional" default="const">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>name:Coefficient of variation;units:unitless;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="distr" use="optional" default="const">
+   <xs:annotation>
+    <xs:documentation>
           To allow heterogeneity, a distribution must be specified.
           
           Valid options are as follows.
           
-          "const": no variation or sampling. Specifying distr="const" has the
+          &quot;const&quot;: no variation or sampling. Specifying distr=&quot;const&quot; has the
           same effect as not specifying distr at all.
           
-          "lognormal": the parameter is sampled from a log-normal distribution.
-          Note that the "mean" and "CV" values are linear (arithmetic) properties
+          &quot;lognormal&quot;: the parameter is sampled from a log-normal distribution.
+          Note that the &quot;mean&quot; and &quot;CV&quot; values are linear (arithmetic) properties
           of the distribution and not log-space properties.
         </xs:documentation>
-        <xs:appinfo>name:Distribution;</xs:appinfo>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="const" />
-          <xs:enumeration value="lognormal" />
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="SampledValueLN">
-    <xs:annotation>
-      <xs:documentation>
+    <xs:appinfo>name:Distribution;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="const"/>
+     <xs:enumeration value="lognormal"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="SampledValueLN">
+  <xs:annotation>
+   <xs:documentation>
         A parameter with optional log-normal heterogeneity.
         
-        The mean value must be specified. Optionally, a distribution ("distr")
-        and coefficient of variation ("CV") may be specified.
+        The mean value must be specified. Optionally, a distribution (&quot;distr&quot;)
+        and coefficient of variation (&quot;CV&quot;) may be specified.
       </xs:documentation>
-      <xs:appinfo>name:Sampled value;</xs:appinfo>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="om:SampledValueCV">
-        <xs:attribute name="mean" type="xs:double" use="required">
-          <xs:annotation>
-            <xs:documentation>
+   <xs:appinfo>name:Sampled value;</xs:appinfo>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:extension base="om:SampledValueCV">
+    <xs:attribute name="mean" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:documentation>
               The (linear) mean value.
             </xs:documentation>
-            <xs:appinfo>name:mean;</xs:appinfo>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-  <xs:complexType name="WeibullSample">
-    <xs:annotation>
-      <xs:documentation>
+      <xs:appinfo>name:mean;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <xs:complexType name="WeibullSample">
+  <xs:annotation>
+   <xs:documentation>
         Parameters of a Weibull distribution.
       </xs:documentation>
-      <xs:appinfo>name:Weibull parameters;</xs:appinfo>
-    </xs:annotation>
-    <xs:attribute name="scale" type="xs:double" use="required">
-      <xs:annotation>
-        <xs:documentation>
+   <xs:appinfo>name:Weibull parameters;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="scale" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
           The Weibull scale parameter (λ).
         </xs:documentation>
-        <xs:appinfo>name:Scale;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="shape" type="xs:double" use="required">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>name:Scale;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="shape" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
           The Weibull shape parameter (k).
         </xs:documentation>
-        <xs:appinfo>name:shape;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="distr" use="required">
-      <xs:annotation>
-        <xs:documentation>
+    <xs:appinfo>name:shape;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="distr" use="required">
+   <xs:annotation>
+    <xs:documentation>
           To allow heterogeneity, a distribution must be specified.
-          In this case, only "weibull" is allowed.
+          In this case, only &quot;weibull&quot; is allowed.
         </xs:documentation>
-        <xs:appinfo>name:Distribution;</xs:appinfo>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="weibull" />
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="DoubleValue">
-    <xs:attribute name="value" type="xs:double" use="required">
-      <xs:annotation>
-        <xs:documentation>A double-precision floating-point value.</xs:documentation>
-        <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="IntValue">
-    <xs:attribute name="value" type="xs:int" use="required">
-      <xs:annotation>
-        <xs:documentation>An integer value.</xs:documentation>
-        <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="BooleanValue">
-    <xs:attribute name="value" type="xs:boolean" use="required">
-      <xs:annotation>
-        <xs:documentation>A boolean value.</xs:documentation>
-        <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-  <xs:complexType name="AgeGroupValues">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" name="group">
-        <xs:annotation>
-          <xs:documentation>
+    <xs:appinfo>name:Distribution;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="weibull"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DoubleValue">
+  <xs:attribute name="value" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>A double-precision floating-point value.</xs:documentation>
+    <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="IntValue">
+  <xs:attribute name="value" type="xs:int" use="required">
+   <xs:annotation>
+    <xs:documentation>An integer value.</xs:documentation>
+    <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="BooleanValue">
+  <xs:attribute name="value" type="xs:boolean" use="required">
+   <xs:annotation>
+    <xs:documentation>A boolean value.</xs:documentation>
+    <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="AgeGroupValues">
+  <xs:sequence>
+   <xs:element maxOccurs="unbounded" name="group">
+    <xs:annotation>
+     <xs:documentation>
             A series of values according to age groups, each specified with
             a lower-bound and a value. The first lower-bound specified must be
             zero; a final upper-bound of infinity is added to complete the last
             age group. At least one age group is required. Normally these are
             interpolated by a continuous function (see interpolation attribute).
           </xs:documentation>
-          <xs:appinfo>name:age group;</xs:appinfo>
-        </xs:annotation>
-        <xs:complexType>
-          <xs:complexContent>
-            <xs:extension base="om:DoubleValue">
-              <xs:attribute name="lowerbound" type="xs:double" use="required">
-                <xs:annotation>
-                  <xs:documentation>
+     <xs:appinfo>name:age group;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:complexContent>
+      <xs:extension base="om:DoubleValue">
+       <xs:attribute name="lowerbound" type="xs:double" use="required">
+        <xs:annotation>
+         <xs:documentation>
                     Lower bound of age group
                   </xs:documentation>
-                  <xs:appinfo>units:Years;min:0;max:100;name:Lower bound;</xs:appinfo>
-                </xs:annotation>
-            </xs:attribute>
-            </xs:extension>
-          </xs:complexContent>
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-    <!-- NOTE: would specify default="linear" except for a possible bug in Code
+         <xs:appinfo>units:Years;min:0;max:100;name:Lower bound;</xs:appinfo>
+        </xs:annotation>
+       </xs:attribute>
+      </xs:extension>
+     </xs:complexContent>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <!-- NOTE: would specify default="linear" except for a possible bug in Code
     Synthesis' XSD associated with creating blank AgeGroupValues elements -->
-    <xs:attribute name="interpolation" use="optional">
-      <xs:annotation>
-        <xs:documentation>
+  <xs:attribute name="interpolation" use="optional">
+   <xs:annotation>
+    <xs:documentation>
           Interpolation algorithm. Normally it is desirable for age-based
           values to be continuous w.r.t. age. By default linear interpolation
           is used.
           
-          With all algorithms except "none", the age groups are converted to a
+          With all algorithms except &quot;none&quot;, the age groups are converted to a
           set of points centred within each age range. Extra
           points are added at each end (zero and infinity) to keep value
           constant at both ends of the function. A zero-length age group may
@@ -452,14 +461,14 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
           2. linear: straight lines (on an age vs. value graph) are used to
           interpolate data points.
         </xs:documentation>
-        <xs:appinfo>name:interpolation;</xs:appinfo>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="none" />
-          <xs:enumeration value="linear" />
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:attribute>
-  </xs:complexType>
+    <xs:appinfo>name:interpolation;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="none"/>
+     <xs:enumeration value="linear"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+ </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Add a "complement" parameter to DecayFunction, which will make the decay function return 1-f(x) instead. Since DecayFunctions assume 0 <= f(x) <= 1.0, this is enough to get an increasing effect where the function will "decay" to 1.0 and instead of 0.0.