### PR TITLE
fix Windows builds with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,15 @@ clone_folder: c:\projects\openmalaria
 
 # Run install scripts
 install:
-  - C:\cygwin64\bin\bash -lc "echo $HOME"
-  - C:\cygwin64\bin\bash -lc "appveyor DownloadFile http://rawgit.com/transcode-open/apt-cyg/master/apt-cyg -FileName apt-cyg"
-  - C:\cygwin64\bin\bash -lc "install apt-cyg /bin"
+  # Workaround (update CygWin)
+  - appveyor DownloadFile "http://www.cygwin.com/setup-x86_64.exe" -FileName C:\cygwin64\setup-x86_64.exe
+  - C:\cygwin64\setup-x86_64.exe -q --no-desktop --no-shortcuts --no-startmenu --upgrade-also -P cmake,make,python3,zlib-devel,libgsl-devel,xsd,libxerces-c-devel
+  # - C:\cygwin64\bin\bash -lc "echo $HOME"
+  # - C:\cygwin64\bin\bash -lc "appveyor DownloadFile http://rawgit.com/transcode-open/apt-cyg/master/apt-cyg -FileName apt-cyg"
+  # - C:\cygwin64\bin\bash -lc "install apt-cyg /bin"
   # - C:\cygwin64\bin\bash -lc "apt-cyg update"
-  - C:\cygwin64\bin\bash -lc "apt-cyg install wget grep"
-  - C:\cygwin64\bin\bash -lc "apt-cyg install zlib-devel make python3 cmake libgsl-devel xsd libxerces-c-devel"
+  # - C:\cygwin64\bin\bash -lc "apt-cyg install wget grep"
+  # - C:\cygwin64\bin\bash -lc "apt-cyg install zlib-devel make python3 cmake libgsl-devel xsd libxerces-c-devel"
 
 build_script:
   - C:\cygwin64\bin\bash -lc "git config --global --add safe.directory /cygdrive/c/projects/openmalaria"


### PR DESCRIPTION
cmake is broken in Cygwin: https://github.com/appveyor/ci/issues/3508 and cannot be updated without also upgrading the entire cygwin distribution.

This fix forces a cygwin upgrade and pulls cmake from the official package list instead of updating the cmake package alone.