### PR TITLE
Update GitHub action workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,10 +51,6 @@ jobs:
             compiler: g++
             target: Linux
           
-          - os: ubuntu-18.04
-            compiler: g++
-            target: Linux
-
           - os: macos-12
             compiler: clang
           

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -62,7 +62,7 @@ jobs:
             compiler: clang
           
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       
       - name: Install - Ubuntu
         if: startsWith(matrix.os,'ubuntu')


### PR DESCRIPTION
- Update the the action checkout to version 3 to avoid a warning
- Remove Ubuntu 18.04 as it is now obsolete