### PR TITLE
Show deprecation warnings

### DIFF
--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -54,6 +54,9 @@ namespace OM { namespace util {
 		string sVFile;
 #	endif
 
+		// Set DEPRECATION_WARNINGS to ON by default
+		options.set (DEPRECATION_WARNINGS);
+
 	/* Simple command line parser. Seems to work fine.
 	* If an extension is wanted, http://tclap.sourceforge.net/ looks good. */
 		for(int i = 1; i < argc; ++i) {
@@ -95,8 +98,8 @@ namespace OM { namespace util {
 					(ctsoutName = "ctsout").append(name).append(".txt");
 				} else if (clo == "validate-only") {
 					options.set (SKIP_SIMULATION);
-				} else if (clo == "deprecation-warnings") {
-					options.set (DEPRECATION_WARNINGS);
+				} else if (clo == "no-deprecation-warnings") {
+					options.reset (DEPRECATION_WARNINGS);
 				} else if (clo == "print-model") {
 					options.set (PRINT_MODEL_OPTIONS);
 					options.set (SKIP_SIMULATION);
@@ -218,9 +221,9 @@ namespace OM { namespace util {
 		<< "			--ctsout ctsoutNAME.txt" <<endl
 		<< " -z --compress-output	Compress output with gzip (writes output.txt.gz)." << endl
 		<< "    --validate-only	Initialise and validate scenario, but don't run simulation." << endl
-		<< "    --deprecation-warnings" << endl
-		<< "			Warn about the use of features deemed error-prone and where" << endl
-		<< "			more flexible alternatives are available." << endl
+		<< "    --no-deprecation-warnings" << endl
+		<< "			OpenMalaria warn about the use of features deemed error-prone and where" << endl
+		<< "			more flexible alternatives are available. Use this option to silence it." << endl
 		<< endl
 		<< "Debugging options:"<<endl
 		<< " -m --print-model	Print all model options with a non-default value and exit." << endl

--- a/test/run.py
+++ b/test/run.py
@@ -136,7 +136,7 @@ def runScenario(options,omOptions,name):
             print("\033[0;32m  "+(" ".join(cmd))+"\033[0;00m")
         return subprocess.call (cmd,cwd=testBuildDir)
     
-    cmd=options.wrapArgs+[openMalariaExec,"--deprecation-warnings","--resource-path",os.path.abspath(testSrcDir),"--scenario",scenarioSrc]+omOptions
+    cmd=options.wrapArgs+[openMalariaExec,"--resource-path",os.path.abspath(testSrcDir),"--scenario",scenarioSrc]+omOptions
     
     if not options.run:
         print("\033[0;32m  "+(" ".join(cmd))+"\033[0;00m")

--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -1,309 +1,335 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_44" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Scenario" schemaVersion="44" xsi:schemaLocation="http://openmalaria.org/schema/scenario_44 scenario_44.xsd">
-  <demography maximumAgeYrs="90" name="Ifakara" popSize="1000">
-    <ageGroup lowerbound="0">
-      <group poppercent="3.474714994" upperbound="1"/>
-      <group poppercent="12.76004028" upperbound="5"/>
-      <group poppercent="14.52151394" upperbound="10"/>
-      <group poppercent="12.75565434" upperbound="15"/>
-      <group poppercent="10.83632374" upperbound="20"/>
-      <group poppercent="8.393312454" upperbound="25"/>
-      <group poppercent="7.001421452" upperbound="30"/>
-      <group poppercent="5.800587654" upperbound="35"/>
-      <group poppercent="5.102136612" upperbound="40"/>
-      <group poppercent="4.182561874" upperbound="45"/>
-      <group poppercent="3.339409351" upperbound="50"/>
-      <group poppercent="2.986112356" upperbound="55"/>
-      <group poppercent="2.555766582" upperbound="60"/>
-      <group poppercent="2.332763433" upperbound="65"/>
-      <group poppercent="1.77400255" upperbound="70"/>
-      <group poppercent="1.008525491" upperbound="75"/>
-      <group poppercent="0.74167341" upperbound="80"/>
-      <group poppercent="0.271863401" upperbound="85"/>
-      <group poppercent="0.161614642" upperbound="90"/>
-    </ageGroup>
-  </demography>
-  <monitoring name="Quarterly Surveys" startDate="2000-01-1">
-    <continuous period="1">
-      <option name="input EIR" value="true"/>
-      <option name="simulated EIR" value="true"/>
-      <option name="human infectiousness" value="true"/>
-      <option name="N_v0" value="true"/>
-      <option name="immunity h" value="true"/>
-      <option name="immunity Y" value="true"/>
-      <option name="new infections" value="true"/>
-      <option name="num transmitting humans" value="true"/>
-      <option name="ITN coverage"/>
-      <option name="GVI coverage"/>
-      <!-- <option name="mean hole index"/>
-      <option name="mean insecticide content"/>-->
-      <option name="alpha" value="true"/>
-      <option name="P_B" value="false"/>
-      <option name="P_C*P_D" value="false"/>
-    </continuous>
-    <SurveyOptions>
-      <option name="nHost" value="true"/>
-      <option name="nPatent" value="true"/>
-      <option name="nUncomp" value="true"/>
-      <option name="nSevere" value="true"/>
-      <option name="nDirDeaths" value="false"/>
-      <option name="inputEIR" value="true"/>
-      <option name="simulatedEIR" value="true"/>
-    </SurveyOptions>
-    <surveys detectionLimit="40">
-      <surveyTime repeatStep="1y" repeatEnd="20.027y">1t</surveyTime>
-      <surveyTime repeatStep="1y" repeatEnd="20.027y">19t</surveyTime>
-      <surveyTime repeatStep="1y" repeatEnd="20.027y">37t</surveyTime>
-      <surveyTime repeatStep="1y" repeatEnd="20.027y">55t</surveyTime>
-    </surveys>
-    <ageGroup lowerbound="0">
-      <group upperbound="5"/>
-      <group upperbound="90"/>
-    </ageGroup>
-  </monitoring>
-  <interventions name="test">
-    <human>
-      <component id="GVI" name="DDT test">
-        <GVI>
-          <decay L="0.5" function="exponential"/>
-          <anophelesParams mosquito="gambiae_ss" propActive="1">
-            <deterrency value="0.56"/>
-            <preprandialKillingEffect value="0"/>
-            <postprandialKillingEffect value="0.24"/>
-          </anophelesParams>
-        </GVI>
-      </component>
-      <deployment name="DDT test">
-        <component id="GVI"/>
-        <timed>
-          <deploy coverage="0.9" time="10y"/>
-        </timed>
-      </deployment>
-    </human>
-  </interventions>
-  <healthSystem>
-    <ImmediateOutcomes name="Tanzania ACT">
-      <drugRegimen firstLine="ACT" inpatient="QN" secondLine="ACT"/>
-      <initialACR>
-        <ACT value="0.85"/>
-        <QN value="0.998"/>
-        <selfTreatment value="0.63"/>
-      </initialACR>
-      <compliance>
-        <ACT value="0.9"/>
-        <selfTreatment value="0.85"/>
-      </compliance>
-      <nonCompliersEffective>
-        <ACT value="0"/>
-        <selfTreatment value="0"/>
-      </nonCompliersEffective>
-      <treatmentActions>
-        <ACT name="clear blood-stage infections">
-          <clearInfections stage="blood" timesteps="1"/>
-        </ACT>
-        <QN name="clear blood-stage infections">
-          <clearInfections stage="blood" timesteps="1"/>
-        </QN>
-      </treatmentActions>
-      <pSeekOfficialCareUncomplicated1 value="0.04"/>
-      <pSelfTreatUncomplicated value="0.01"/>
-      <pSeekOfficialCareUncomplicated2 value="0.04"/>
-      <pSeekOfficialCareSevere value="0.48"/>
-    </ImmediateOutcomes>
-    <CFR>
-      <group lowerbound="0" value="0.09189"/>
-      <group lowerbound="0.25" value="0.0810811"/>
-      <group lowerbound="0.75" value="0.0648649"/>
-      <group lowerbound="1.5" value="0.0689189"/>
-      <group lowerbound="2.5" value="0.0675676"/>
-      <group lowerbound="3.5" value="0.0297297"/>
-      <group lowerbound="4.5" value="0.0459459"/>
-      <group lowerbound="7.5" value="0.0945946"/>
-      <group lowerbound="12.5" value="0.1243243"/>
-      <group lowerbound="15" value="0.1378378"/>
-    </CFR>
-    <pSequelaeInpatient interpolation="none">
-      <group lowerbound="0.0" value="0.0132"/>
-      <group lowerbound="5.0" value="0.005"/>
-    </pSequelaeInpatient>
-  </healthSystem>
-  <entomology mode="dynamic" name="Namawala">
-    <vector>
-      <anopheles mosquito="gambiae_ss" propInfected="0.078" propInfectious="0.021">
-        <seasonality annualEIR="16" input="EIR">
-          <fourierSeries EIRRotateAngle="0">
-            <coeffic a="0.8968" b="2.678"/>
-            <coeffic a="-0.4551" b="2.599"/>
-          </fourierSeries>
-        </seasonality>
-        <mosq minInfectedThreshold="0.001">
-          <mosqRestDuration value="3"/>
-          <extrinsicIncubationPeriod value="11"/>
-          <mosqLaidEggsSameDayProportion value="0.313"/>
-          <mosqSeekingDuration value="0.33"/>
-          <mosqSurvivalFeedingCycleProbability value="0.623"/>
-          <availability distr="const"/>
-          <mosqProbBiting mean="0.95" variance="0"/>
-          <mosqProbFindRestSite mean="0.95" variance="0"/>
-          <mosqProbResting mean="0.99" variance="0"/>
-          <mosqProbOvipositing value="0.88"/>
-          <mosqHumanBloodIndex value="0.939"/>
-        </mosq>
-        <nonHumanHosts name="unprotectedAnimals">
-          <mosqRelativeEntoAvailability value="1.0"/>
-          <mosqProbBiting value="0.95"/>
-          <mosqProbFindRestSite value="0.95"/>
-          <mosqProbResting value="0.99"/>
-        </nonHumanHosts>
-      </anopheles>
-      <nonHumanHosts name="unprotectedAnimals" number="1.0"/>
-    </vector>
-  </entomology>
-  <model>
-    <ModelOptions>
-      <option name="LOGNORMAL_MASS_ACTION" value="true"/>
-      <option name="NO_PRE_ERYTHROCYTIC" value="true"/>
-      <option name="INNATE_MAX_DENS" value="false"/>
-      <option name="INDIRECT_MORTALITY_FIX" value="false"/>
-      <option name="NON_MALARIA_FEVERS" value="true"/>
-    </ModelOptions>
-    <clinical healthSystemMemory="6">
-      <NonMalariaFevers>
-        <incidence>
-          <group lowerbound="0" value="0.322769924518357"/>
-          <group lowerbound="0" value="0.308520194304172"/>
-          <group lowerbound="1" value="0.279441774808493"/>
-          <group lowerbound="2" value="0.250431781111273"/>
-          <group lowerbound="3" value="0.223285859756841"/>
-          <group lowerbound="4" value="0.199298352451799"/>
-          <group lowerbound="5" value="0.179376872365614"/>
-          <group lowerbound="6" value="0.163623659390782"/>
-          <group lowerbound="7" value="0.152227726923469"/>
-          <group lowerbound="8" value="0.145022785567758"/>
-          <group lowerbound="9" value="0.141493087461765"/>
-          <group lowerbound="10" value="0.140473293219353"/>
-          <group lowerbound="11" value="0.141109775159515"/>
-          <group lowerbound="12" value="0.142644475217328"/>
-          <group lowerbound="13" value="0.144335079395766"/>
-          <group lowerbound="14" value="0.145964032924869"/>
-          <group lowerbound="15" value="0.147708915135714"/>
-          <group lowerbound="16" value="0.149731543445568"/>
-          <group lowerbound="17" value="0.151887428568276"/>
-          <group lowerbound="18" value="0.154060663485195"/>
-          <group lowerbound="19" value="0.156179169710494"/>
-          <group lowerbound="20" value="0.158135015380583"/>
-          <group lowerbound="21" value="0.159704766482219"/>
-          <group lowerbound="22" value="0.160807788387655"/>
-          <group lowerbound="23" value="0.161427976448279"/>
-          <group lowerbound="24" value="0.161620429119137"/>
-          <group lowerbound="25" value="0.16144021875986"/>
-          <group lowerbound="26" value="0.160943264630612"/>
-          <group lowerbound="27" value="0.160217573697398"/>
-          <group lowerbound="28" value="0.159422614374451"/>
-          <group lowerbound="29" value="0.158542519631641"/>
-          <group lowerbound="30" value="0.157501217628248"/>
-          <group lowerbound="31" value="0.156175160594841"/>
-          <group lowerbound="32" value="0.154402302191411"/>
-          <group lowerbound="33" value="0.152102040636481"/>
-          <group lowerbound="34" value="0.14921450014676"/>
-          <group lowerbound="35" value="0.145714433541659"/>
-          <group lowerbound="36" value="0.141800502067518"/>
-          <group lowerbound="37" value="0.137916853907569"/>
-          <group lowerbound="38" value="0.134503529382102"/>
-          <group lowerbound="39" value="0.131746276580642"/>
-          <group lowerbound="40" value="0.12969902537497"/>
-          <group lowerbound="41" value="0.128398077347679"/>
-          <group lowerbound="42" value="0.127864136551891"/>
-          <group lowerbound="43" value="0.12804497197004"/>
-          <group lowerbound="44" value="0.128894055047661"/>
-          <group lowerbound="45" value="0.130350838992718"/>
-          <group lowerbound="46" value="0.132286605622701"/>
-          <group lowerbound="47" value="0.134599921072495"/>
-          <group lowerbound="48" value="0.137212726976988"/>
-          <group lowerbound="49" value="0.140035253913284"/>
-          <group lowerbound="50" value="0.142934573453621"/>
-          <group lowerbound="51" value="0.145830221511879"/>
-          <group lowerbound="52" value="0.148674810561069"/>
-          <group lowerbound="53" value="0.151497963594518"/>
-          <group lowerbound="54" value="0.15438856687865"/>
-          <group lowerbound="55" value="0.157403790093505"/>
-          <group lowerbound="56" value="0.16059513222516"/>
-          <group lowerbound="57" value="0.16402433342886"/>
-          <group lowerbound="58" value="0.16770481415944"/>
-          <group lowerbound="59" value="0.171626873047865"/>
-          <group lowerbound="60" value="0.175748327054247"/>
-          <group lowerbound="61" value="0.180030857856799"/>
-          <group lowerbound="62" value="0.184411365583771"/>
-          <group lowerbound="63" value="0.188816421789366"/>
-          <group lowerbound="64" value="0.19316997803338"/>
-          <group lowerbound="65" value="0.197435603275487"/>
-          <group lowerbound="66" value="0.201578808813379"/>
-          <group lowerbound="67" value="0.205556806881398"/>
-          <group lowerbound="68" value="0.209307183457343"/>
-          <group lowerbound="69" value="0.212783260344084"/>
-          <group lowerbound="70" value="0.215944154621391"/>
-          <group lowerbound="71" value="0.218749275266548"/>
-          <group lowerbound="72" value="0.221187990639016"/>
-          <group lowerbound="73" value="0.223361260399378"/>
-          <group lowerbound="74" value="0.225363436789592"/>
-          <group lowerbound="75" value="0.227254280093211"/>
-          <group lowerbound="76" value="0.229084576349576"/>
-          <group lowerbound="77" value="0.230891971097789"/>
-          <group lowerbound="78" value="0.232690225166173"/>
-          <group lowerbound="79" value="0.234484973338876"/>
-          <group lowerbound="80" value="0.236276361586796"/>
-          <group lowerbound="81" value="0.238064394629696"/>
-          <group lowerbound="82" value="0.239849077182917"/>
-          <group lowerbound="83" value="0.241630413957381"/>
-          <group lowerbound="84" value="0.243408409659591"/>
-          <group lowerbound="85" value="0.245183068991633"/>
-          <group lowerbound="86" value="0.246954396651183"/>
-          <group lowerbound="87" value="0.248722397331501"/>
-          <group lowerbound="88" value="0.250487075721441"/>
-          <group lowerbound="89" value="0.252248436505447"/>
-          <group lowerbound="90" value="0.253127874257909"/>
-        </incidence>
-      </NonMalariaFevers>
-    </clinical>
-    <human>
-      <availabilityToMosquitoes>
-        <group lowerbound="0" value="0.7076"/>
-        <group lowerbound="0" value="0.8538"/>
-        <group lowerbound="5" value="1.0"/>
-        <group lowerbound="5" value="1.0"/>
-      </availabilityToMosquitoes>
-    </human>
-    <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
-    </parameters>
-  </model>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_44" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="R0068" schemaVersion="44" xsi:schemaLocation="http://openmalaria.org/schema/scenario_44 scenario_44.xsd">
+    <!-- This is an example scenario.
+    More information is available in the official documentation: https://swisstph.github.io/openmalaria/schema-latest.html
+    And in the wiki: https://github.com/SwissTPH/openmalaria/wiki 
+    For on overview of xml parameters, see: https://github.com/SwissTPH/openmalaria/wiki/ScenarioDesign -->
+    
+    <!-- The following block describes the demography of the population -->
+    <demography maximumAgeYrs="90" name="Ifakara" popSize="2000">
+        <ageGroup lowerbound="0">
+            <group poppercent="3.474714994" upperbound="1"/>
+            <group poppercent="12.76004028" upperbound="5"/>
+            <group poppercent="14.52151394" upperbound="10"/>
+            <group poppercent="12.75565434" upperbound="15"/>
+            <group poppercent="10.836323739" upperbound="20"/>
+            <group poppercent="8.393312454" upperbound="25"/>
+            <group poppercent="7.001421452" upperbound="30"/>
+            <group poppercent="5.800587654" upperbound="35"/>
+            <group poppercent="5.102136612" upperbound="40"/>
+            <group poppercent="4.182561874" upperbound="45"/>
+            <group poppercent="3.339409351" upperbound="50"/>
+            <group poppercent="2.986112356" upperbound="55"/>
+            <group poppercent="2.555766582" upperbound="60"/>
+            <group poppercent="2.332763433" upperbound="65"/>
+            <group poppercent="1.77400255" upperbound="70"/>
+            <group poppercent="1.008525491" upperbound="75"/>
+            <group poppercent="0.74167341" upperbound="80"/>
+            <group poppercent="0.271863401" upperbound="85"/>
+            <group poppercent="0.161614642" upperbound="90"/>
+        </ageGroup>
+    </demography>
+
+    <!-- The monitoring block is where you define the output of the simulation.
+    The startDate will be the beginning of the monitoring period.
+    Interventions can only be deployed AFTER the startDate/ -->
+    <monitoring name="monthly surveys" startDate="1970-01-01">
+        <!-- Specify the desired outputs here, the full list is available at:
+        https://github.com/SwissTPH/openmalaria/wiki/MonitoringOptions#survey-measures -->
+        <SurveyOptions onlyNewEpisode="true">
+            <option name="nHost"/>          <!-- id 0 -->
+            <option name="nInfect"/>        <!-- id 1 -->
+            <option name="nPatent"/>        <!-- id 3 -->
+            <option name="totalInfs"/>      <!-- id 6 -->
+            <option name="totalPatentInf"/> <!-- id 8 -->
+            <option name="nTreatments1"/>   <!-- id 11 -->
+            <option name="nTreatments2"/>   <!-- id 12 -->
+            <option name="nTreatments3"/>   <!-- id 13 -->
+            <option name="nUncomp"/>        <!-- id 14 -->
+            <option name="nSevere"/>        <!-- id 15 -->
+            <option name="nSevereWithoutComorbidities"/> <!-- id 80 -->
+            <option name="nSeq"/>           <!-- id 16 -->
+            <option name="nIndDeaths"/>     <!-- id 18 -->
+            <option name="nDirDeaths"/>     <!-- id 19 -->
+            <option name="inputEIR"/>       <!-- id 35 -->
+            <option name="simulatedEIR"/>   <!-- id 36 -->
+            <option name="expectedDirectDeaths"/>   <!-- id 74 -->
+            <option name="expectedIndirectDeaths"/> <!-- id 76 -->
+        </SurveyOptions>
+
+        <!-- OpenMalaria will only provide outputs at the specified survey times.
+        You can indicate the actual survey time (for example here it is 2000-01-01)
+        and additionally you can repeat it every repeatStep for some repeatEnd period. 
+        The diagnostic option is used for the 'nPatent' output and the diagnostic is specified
+        in the <diagnostic></diagnostic> bloc at the of this file.
+        More information on the wiki: https://github.com/SwissTPH/openmalaria/wiki/Monitoring -->
+        <surveys diagnostic="deterministic">
+            <surveyTime repeatStep="5d" repeatEnd="2020-01-01">2000-01-01</surveyTime> 
+        </surveys>
+        <!-- The following age groups will be used in the output. By default, all the 
+        specified SurveyOptions specified above that support age groups will use them.
+        OpenMalaria will output one more line per age group.
+        To interpret the txt output, see: https://github.com/SwissTPH/openmalaria/wiki/MonitoringOutput -->
+        <ageGroup lowerbound="0">
+            <group upperbound="0.5"/>
+            <group upperbound="1"/>
+            <group upperbound="2"/>
+            <group upperbound="5"/>
+            <group upperbound="10"/>
+            <group upperbound="15"/>
+            <group upperbound="20"/>
+            <group upperbound="100"/>
+        </ageGroup>
+    </monitoring>
+
+    <!-- Deploy interventions here, see: https://github.com/SwissTPH/openmalaria/wiki/ModelInterventions -->
+    <interventions name="GVI example">
+        <human>
+            <!-- Example deployment of a GVI intervention that models a deterrency postprandialKilling effects (to model 
+            a insecticide treated net for example). -->
+            <component id="GVI_example">
+                <GVI>
+                    <!-- Exponential decay with a half-life of 3 years, see: https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions -->
+                    <decay function="exponential" L="3y"/>
+                    <anophelesParams mosquito="gambiae_ss">
+                        <deterrency value="0.7696"/>
+                        <postprandialKillingEffect value="0.0544"/>
+                    </anophelesParams>
+                    <anophelesParams mosquito="funestus">
+                        <deterrency value="0.7696"/>
+                        <postprandialKillingEffect value="0.0544"/>
+                    </anophelesParams>
+                    <anophelesParams mosquito="arabiensis">
+                        <deterrency value="0.7696"/>
+                        <postprandialKillingEffect value="0.0544"/>
+                    </anophelesParams>
+                </GVI>
+            </component>
+            <deployment name="GVI_example">
+                <component id="GVI_example"/>
+                <timed>
+                    <deploy coverage="0.7" maxAge="95" minAge="0" time="2005-01-01"/> 
+                </timed>
+            </deployment>
+        </human>
+    </interventions>
+
+    <!-- Specify health system parameters here, see: https://github.com/SwissTPH/openmalaria/wiki/ScenarioHealthSystem -->
+    <healthSystem>
+        <!-- The more flexible DecisionTree5Day replaces the older ImmediateOutcomes. 
+        The probabilities below are greatly affected by the presence (or the absence) of a clinic or hospital on site -->
+        <DecisionTree5Day name="example name">
+            <pSeekOfficialCareUncomplicated1 value="0.04"/><!-- 5-day probability that a patient uncomplicated case seeks official care -->
+            <pSelfTreatUncomplicated value="0.0"/><!-- 5-day probability that a patient with uncomplicated case will self-treat -->
+            <pSeekOfficialCareUncomplicated2 value="0.04"/><!-- 5-day probability that a patient with recurrence seeks official care -->
+            <pSeekOfficialCareSevere value="0.48"/><!-- 5-day probability that a patient with severe case seeks official care -->
+            <treeUCOfficial>
+                <treatSimple durationLiver="0" durationBlood="1t"/>
+            </treeUCOfficial>
+            <treeUCSelfTreat>
+                <noTreatment/>
+            </treeUCSelfTreat>
+            <cureRateSevere value="1.0"/>
+            <treatmentSevere>
+                <clearInfections stage="blood" timesteps="1t"/>
+            </treatmentSevere>
+        </DecisionTree5Day>
+        <CFR>
+            <group lowerbound="0" value="0.09189"/>
+            <group lowerbound="0.25" value="0.0810811"/>
+            <group lowerbound="0.75" value="0.0648649"/>
+            <group lowerbound="1.5" value="0.0689189"/>
+            <group lowerbound="2.5" value="0.0675676"/>
+            <group lowerbound="3.5" value="0.0297297"/>
+            <group lowerbound="4.5" value="0.0459459"/>
+            <group lowerbound="7.5" value="0.0945946"/>
+            <group lowerbound="12.5" value="0.1243243"/>
+            <group lowerbound="15" value="0.1378378"/>
+        </CFR>
+        <pSequelaeInpatient interpolation="none">
+            <group lowerbound="0.0" value="0.0132"/>
+            <group lowerbound="5.0" value="0.005"/>
+        </pSequelaeInpatient>
+    </healthSystem>
+
+    <!-- Mosquito parameters.
+    It is possible to specify multiple species and different EIR and parameters per species.
+    A global EIR can be specified immediately below using the 'scaledAnnualEIR' parameter. 
+    If so, the EIR of the species will be scaled so that the total EIR is equal to the scaledAnualEIR.
+    mode can be "dynamic" or "forced". 
+        dynamic: the EIR will be simulated and it will be affected by interventions, changes in immunity,
+            infectivity of hosts and mosquitoes, and other parameters. 
+            forced: the EIR will always be equal to the scaledAnnualEIR. -->
+            <entomology mode="dynamic" name="Namawala" scaledAnnualEIR="20">
+                <vector>
+                    <anopheles mosquito="gambiae_ss" propInfected="0.078" propInfectious="0.021">
+                <!-- Seasonality can be passed as fourier coefficients or monthly values.
+                Note that if monthly values are used, OpenMalaria will anyway smooth the values
+                using fourier coefficients. -->
+                <seasonality annualEIR="24.826144381650714" input="EIR">
+                    <fourierSeries EIRRotateAngle="0">
+                        <coeffic a="-0.2072" b="0.8461"/>
+                        <coeffic a="0.0906" b="-0.0425"/>
+                    </fourierSeries>
+                </seasonality>
+                <mosq minInfectedThreshold="0.001">
+                    <mosqRestDuration value="3"/>
+                    <extrinsicIncubationPeriod value="11"/>
+                    <mosqLaidEggsSameDayProportion value="0.313"/>
+                    <mosqSeekingDuration value="0.33"/>
+                    <mosqSurvivalFeedingCycleProbability value="0.623"/>
+                    <availability/>
+                    <mosqProbBiting mean="0.95" variance="0"/>
+                    <mosqProbFindRestSite mean="0.95" variance="0"/>
+                    <mosqProbResting mean="0.99" variance="0"/>
+                    <mosqProbOvipositing value="0.88"/>
+                    <mosqHumanBloodIndex value="0.939"/>
+                </mosq>
+                <nonHumanHosts name="unprotectedAnimals">
+                    <mosqRelativeEntoAvailability value="1.0"/>
+                    <mosqProbBiting value="0.95"/>
+                    <mosqProbFindRestSite value="0.95"/>
+                    <mosqProbResting value="0.99"/>
+                </nonHumanHosts>
+            </anopheles>
+
+            <anopheles mosquito="funestus" propInfected="0.078" propInfectious="0.021">
+                <seasonality annualEIR="77.00628873180102" input="EIR">
+                    <fourierSeries EIRRotateAngle="0">
+                        <coeffic a="0.4943" b="0.6127"/>
+                        <coeffic a="-0.2386" b="-0.2851"/>
+                    </fourierSeries>
+                </seasonality>
+                <mosq minInfectedThreshold="0.001">
+                    <mosqRestDuration value="3"/>
+                    <extrinsicIncubationPeriod value="11"/>
+                    <mosqLaidEggsSameDayProportion value="0.616"/>
+                    <mosqSeekingDuration value="0.33"/>
+                    <mosqSurvivalFeedingCycleProbability value="0.611"/>
+                    <availability/>
+                    <mosqProbBiting mean="0.95" variance="0"/>
+                    <mosqProbFindRestSite mean="0.95" variance="0"/>
+                    <mosqProbResting mean="0.99" variance="0"/>
+                    <mosqProbOvipositing value="0.88"/>
+                    <mosqHumanBloodIndex value="0.98"/>
+                </mosq>
+                <nonHumanHosts name="unprotectedAnimals">
+                    <mosqRelativeEntoAvailability value="1.0"/>
+                    <mosqProbBiting value="0.95"/>
+                    <mosqProbFindRestSite value="0.95"/>
+                    <mosqProbResting value="0.99"/>
+                </nonHumanHosts>
+            </anopheles>
+
+            <anopheles mosquito="arabiensis" propInfected="0.078" propInfectious="0.021">
+                <seasonality annualEIR="223.38512656454782" input="EIR">
+                    <fourierSeries EIRRotateAngle="0">
+                        <coeffic a="-0.2072" b="0.8461"/>
+                        <coeffic a="0.0906" b="-0.0425"/>
+                    </fourierSeries>
+                </seasonality>
+                <mosq minInfectedThreshold="0.001">
+                    <mosqRestDuration value="3"/>
+                    <extrinsicIncubationPeriod value="11"/>
+                    <mosqLaidEggsSameDayProportion value="0.313"/>
+                    <mosqSeekingDuration value="0.33"/>
+                    <mosqSurvivalFeedingCycleProbability value="0.623"/>
+                    <availability/>
+                    <mosqProbBiting mean="0.95" variance="0"/>
+                    <mosqProbFindRestSite mean="0.95" variance="0"/>
+                    <mosqProbResting mean="0.99" variance="0"/>
+                    <mosqProbOvipositing value="0.88"/>
+                    <mosqHumanBloodIndex value="0.871"/>
+                </mosq>
+                <nonHumanHosts name="unprotectedAnimals">
+                    <mosqRelativeEntoAvailability value="1.0"/>
+                    <mosqProbBiting value="0.95"/>
+                    <mosqProbFindRestSite value="0.95"/>
+                    <mosqProbResting value="0.99"/>
+                </nonHumanHosts>
+            </anopheles>
+            <nonHumanHosts name="unprotectedAnimals" number="1.0"/>
+        </vector>
+    </entomology>
+
+    <!-- This diagnostic object can be used in several places, including in the monitoring section and in the NeoNatalMortality model.
+    It is also possible to specify stochastic diagnostics, see: https://github.com/SwissTPH/openmalaria/wiki/Diagnostics -->
+    <diagnostics>
+        <diagnostic name="deterministic">
+            <deterministic minDensity="40"/>
+        </diagnostic>
+    </diagnostics>
+
+    <!-- Here you can specify additional model parameters, or model variants. -->
+    <model>
+        <ModelOptions>
+            <option name="INNATE_MAX_DENS" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
+            <option name="INDIRECT_MORTALITY_FIX" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
+        </ModelOptions>
+
+        <!-- Clinical model parameters.
+        The healthSystemMemory is often overlooked. It corresponds to the follow-up period during which a recurrence is considered to be a treatment failure and is not counted as new clinical case. A recurrence after this period will be counted as new clinical case. --> 
+        <clinical healthSystemMemory="30d">
+            <NeonatalMortality diagnostic="deterministic"/>
+        </clinical>
+
+        <!-- The following affects effective EIR by age group. This is under the assumption that the number of bites 
+        is proportional to age and/or body-surface area. This should not be change unless you have a trustworthy source. -->
+        <human>
+            <availabilityToMosquitoes>
+                <group lowerbound="0.0" value="0.225940909648"/>
+                <group lowerbound="1.0" value="0.286173633441"/>
+                <group lowerbound="2.0" value="0.336898395722"/>
+                <group lowerbound="3.0" value="0.370989854675"/>
+                <group lowerbound="4.0" value="0.403114915112"/>
+                <group lowerbound="5.0" value="0.442585112522"/>
+                <group lowerbound="6.0" value="0.473839351511"/>
+                <group lowerbound="7.0" value="0.512630464378"/>
+                <group lowerbound="8.0" value="0.54487872702"/>
+                <group lowerbound="9.0" value="0.581527755812"/>
+                <group lowerbound="10.0" value="0.630257580698"/>
+                <group lowerbound="11.0" value="0.663063362714"/>
+                <group lowerbound="12.0" value="0.702417432755"/>
+                <group lowerbound="13.0" value="0.734605377277"/>
+                <group lowerbound="14.0" value="0.788908765653"/>
+                <group lowerbound="15.0" value="0.839587932303"/>
+                <group lowerbound="20.0" value="1.0"/>
+                <group lowerbound="20.0" value="1.0"/>
+            </availabilityToMosquitoes>
+        </human>
+
+        <!-- DO NOT CHANGE THE MODEL PARAMETERS BELOW -->
+        <parameters interval="5" iseed="1" latentp="3d">
+         <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+         <parameter include="0" name="Estar" number="2" value="0.03247"/>
+         <parameter include="0" name="Simm" number="3" value="0.138161050830301"/>
+         <parameter include="0" name="Xstar_p" number="4" value="1514.385853233699891"/>
+         <parameter include="0" name="gamma_p" number="5" value="2.03692533424484"/>
+         <parameter include="0" name="sigma2i" number="6" value="10.173598698525799"/>
+         <parameter include="0" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+         <parameter include="0" name="CumulativeHstar" number="8" value="97.334652723897705"/>
+         <parameter include="0" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+         <parameter include="0" name="decay_m" number="10" value="2.53106547375805"/>
+         <parameter include="0" name="sigma2_0" number="11" value="0.655747311168152"/>
+         <parameter include="0" name="Xstar_v" number="12" value="0.916181104713054"/>
+         <parameter include="0" name="Ystar2" number="13" value="6502.26335600001039"/>
+         <parameter include="0" name="alpha" number="14" value="142601.912520000012591"/>
+         <parameter include="0" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+         <parameter include="0" name=" sigma2 " number="16" value="1.0"/>
+         <parameter include="0" name="log oddsr CF community" number="17" value="0.736202"/>
+         <parameter include="0" name="Indirect risk cofactor" number="18" value="0.018777338"/>
+         <parameter include="0" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+         <parameter include="0" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+         <parameter include="0" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+         <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
+         <parameter include="0" name="Immune effector decay" number="23" value="0"/>
+         <parameter include="0" name="comorbidity intercept" number="24" value="0.0968"/>
+         <parameter include="0" name="Ystar half life" number="25" value="0.275437402"/>
+         <parameter include="0" name="Ystar1" number="26" value="0.596539864"/>
+         <parameter include="0" name="Asexual immunity decay" number="27" value="0"/>
+         <parameter include="0" name="Ystar0" number="28" value="296.302437899999973"/>
+         <parameter include="0" name="Idete multiplier" number="29" value="2.797523626"/>
+         <parameter include="0" name="critical age for comorbidity" number="30" value="0.117383"/>
+     </parameters>
+ </model>
 </om:scenario>

--- a/util/example/plot.py
+++ b/util/example/plot.py
@@ -1,11 +1,7 @@
-import os
-from math import *
-import numpy as np
 from matplotlib import pyplot as plt
-import matplotlib
 import pandas as pd
 
-names = {
+mm = {
 	0: 'nHost',
 	1: 'nInfect',
 	2: 'nExpectd',
@@ -41,8 +37,8 @@ names = {
 	32: 'Vector_Nv',
 	33: 'Vector_Ov',
 	34: 'Vector_Sv',
-	35: 'Vector_EIR_Input',
-	36: 'Vector_EIR_Simulated',
+    35: 'InputEIR',
+    36: 'SimulatedEIR',
 	39: 'Clinical_RDTs',
 	40: 'Clinical_DrugUsage',
 	41: 'Clinical_FirstDayDeaths',
@@ -83,122 +79,39 @@ names = {
 	76:	'expectedIndirectDeaths',
 	77:	'expectedSequelae',
 	78:	'expectedSevere',
-	79:	'innoculationsPerVector'	
+	79:	'innoculationsPerVector',
+	80:	'nSevereWithoutComorbidities',
+	81:	'expectedSevereWithoutComorbidities'	
 }
 
-def load(scenario):
-	df = pd.read_csv(scenario, sep="\t", header=None)
-	df.columns = ['survey', 'group', 'code', 'value']
-	return df
+mmi = {v: k for k, v in mm.items()}
 
-def extract(df, surveys, groups, code):
-	data = []
+df = pd.read_csv(f'output.txt', sep="\t", header=1)
+df.columns = ['survey', 'age-group', 'measure', 'value']
 
-	# use only survey 2 (post intervention)
-	for survey in surveys:
-		y = np.array(len(groups), dtype=float)
-		for group in groups:
-			v = df[(df['survey'] == survey) & (df['group'] == group) & (df['code'] == code)]['value'].values
-			if len(v) > 1:
-				print('Too many values found for survey', survey, ' code ', code, ' and group ', group)
-			elif len(v) == 0:
-				print('No values found for survey', survey, ' code ', code, ' and group ', group)
-			else:
-				y += v[0]
-		data.append(y)
+nHosts = df[(df["measure"] == mmi['nHost'])].groupby(['survey', 'measure']).sum().value[1:].reset_index()#.values
+inputEIR = df[(df["measure"] == mmi['InputEIR'])].groupby(['survey', 'measure']).sum().value[1:].reset_index()
+simulatedEIR = df[(df["measure"] == mmi['SimulatedEIR'])].groupby(['survey', 'measure']).sum().value[1:].reset_index()
+innoculations = df[(df["measure"] == mmi['innoculationsPerAgeGroup'])].groupby(['survey', 'measure']).sum().value[1:].reset_index()#.values
+nPatent = df[(df["measure"] == mmi['nPatent'])].groupby(['survey', 'measure']).sum().value[1:].reset_index()#.values
+nUncomp = df[(df["measure"] == mmi['nUncomp'])].groupby(['survey', 'measure']).sum().value[1:].reset_index()#.values
 
-	return np.array(data)
+fig = plt.figure()
+ax = fig.add_subplot(1,1,1)
+ax.plot(inputEIR.index, inputEIR.value, marker="v", markersize=1, label=f"inputEIR")
+ax.plot(simulatedEIR.index, simulatedEIR.value, marker="v", markersize=1, label=f"simulatedEIR")
+ax.legend(loc="upper left")
 
-def plot(df, codes, groups, labels, title, norm_code=None):
-	fig = plt.figure(figsize=(6,4))
-	ax = fig.add_subplot(1,1,1)
+fig = plt.figure()
+ax = fig.add_subplot(1,1,1)
+prevalence = nPatent / nHosts
+ax.plot(prevalence.index, prevalence.value, marker="v", markersize=1, label=f"Prevalence")
+ax.legend(loc="upper left")
 
-	for i in range(len(codes)):
-		surveys = np.arange(max(df['survey']))+1
-		data = extract(df, surveys, groups, codes[i])
-
-		if norm_code is not None:
-			nHost = extract(df, surveys, groups, norm_code)
-			data /= nHost
-
-		ax.plot(surveys, data, marker='o', linewidth=1, markersize=4, label=labels[i])
-		
-	ax.set_title(title)
-	ax.set_xlabel("time steps")
-	ax.set_ylabel(title)
-	ax.legend(loc="upper left")
-	plt.tight_layout()
-
-df = load(f'output.txt')
-
-def plot_by_group(df, codes, groups, labels, title, norm_code=None):
-	fig = plt.figure(figsize=(6,4))
-	ax = fig.add_subplot(1,1,1)
-
-	for i in range(len(codes)):
-		surveys = np.arange(max(df['survey']))+1
-		for j in range(len(groups)):
-			data = extract(df, surveys, [groups[j]], codes[i])
-
-			if norm_code is not None:
-				nHost = extract(df, surveys, [groups[j]], norm_code)
-				data /= nHost
-
-			ax.plot(surveys, data, marker='o', linewidth=1, markersize=4, label=labels[i][j])
-		
-	ax.set_title(title)
-	ax.set_xlabel("time steps")
-	ax.set_ylabel(title)
-	ax.legend(loc="upper left")
-	plt.tight_layout()
-
-def plot_cts(df, field, label):
-	fig = plt.figure(figsize=(6,4))
-	ax = fig.add_subplot(1,1,1)
-
-	data = df[field].values
-	ax.plot(np.arange(len(data)), data, marker='o', markersize=2, label=label)
-
-	ax.set_title(field)
-	ax.set_xlabel("time steps")
-	ax.set_ylabel(field)
-	ax.legend(loc="upper right")
-
-# Normal output 
-# =============
-
-# The file is organized in 4 columns:
-# survey, group, code, value
-# There is one value per survey, group and code
-# Groups are typically age groups (specified in xml)
-# Note 1: some outputs do not have groups
-# Note 2: sometimes instead of age, groups will indicate phenotype or other things depending on the output code (see wiki)
-
-# Example scenario has 4 surveys per year and 2 age groups (< 5y and < 90y).
-# Monitoring period is 20 years. A GVI interventions is deployed after 10 years
-# The transmission is seasonal and you can observe a peak every year
-# Simulated EIR, new infections, Malaria episodes and others are expected to decrease after the intervention is deployed
-# Note: increase population size and run multiple seeds for better results
-df = load(f'output.txt')
-
-# Entomological Innoculation Rate (input and simulated), no age groups
-plot(df, codes=[35,36], groups=[0], labels=['Input EIR', 'Simulated EIR'], title="EIR")
-
-# Number of Severe Episodes per person (divided by number of hosts, which is code 0)
-plot(df, codes=[15], groups=[1,2], labels=['Severe Epiosdes'], title="Severe Episodes per person per survey", norm_code=0)
-
-# Number of Uncomplicated Episodes per person and by age group
-plot_by_group(df, codes=[14], groups=[1,2], labels=[['age < 5', 'age < 90']], title="Unomplicated Episodes per person per survey", norm_code=0)
-
-# Continous output
-# ================
-
-# The file contains one column per output (specified in the xml file)
-
-df = pd.read_csv(f'ctsout.txt', sep="\t", header=1)
-
-plot_cts(df, ["immunity Y"], label="immunity Y")
-plot_cts(df, ["immunity h"], label="immunity h")
-plot_cts(df, ["new infections"], label="new infections")
+fig = plt.figure()
+ax = fig.add_subplot(1,1,1)
+ci = nUncomp / nHosts
+ax.plot(ci.index, ci.value, marker="v", markersize=1, label=f"Clinical Incidence")
+ax.legend(loc="upper left")
 
 plt.show()


### PR DESCRIPTION
Deprecation warnings are now displayed by default.

The `--deprecation-warnings` command-line option has been removed.
A new `--no-deprecation-warnings` command line option has been added to hide the warnings.