### PR TITLE
remove onlyNewEpisode from example_scenario

### DIFF
--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -36,7 +36,7 @@
     <monitoring name="monthly surveys" startDate="1970-01-01">
         <!-- Specify the desired outputs here, the full list is available at:
         https://github.com/SwissTPH/openmalaria/wiki/MonitoringOptions#survey-measures -->
-        <SurveyOptions onlyNewEpisode="true">
+        <SurveyOptions>
             <option name="nHost"/>          <!-- id 0 -->
             <option name="nInfect"/>        <!-- id 1 -->
             <option name="nPatent"/>        <!-- id 3 -->


### PR DESCRIPTION
This removes the onlyNewEpisode="true" SurveyOptions from the example_scenario.

This option comes from older scenarios and it does not make sense to have it in a default scenario.