### PR TITLE
Add advanced decay functions

### DIFF
--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -588,7 +588,7 @@ void AnophelesModel::advancePeriod(double sum_avail, double sigma_df, vector<dou
             continue;
         }
         SimTime age = sim::ts0() - it->deployTime;
-        double decayCoeff = it->availHet.eval(age);
+        double decayCoeff = it->availHet->eval(age);
         leaveRate += it->initialAvail * decayCoeff;
         // sigma_df doesn't change: mosquitoes do not survive traps
         it++;

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -588,7 +588,7 @@ void AnophelesModel::advancePeriod(double sum_avail, double sigma_df, vector<dou
             continue;
         }
         SimTime age = sim::ts0() - it->deployTime;
-        double decayCoeff = trapParams[it->instance].availDecay->eval(age, it->availHet);
+        double decayCoeff = it->availHet.eval(age);
         leaveRate += it->initialAvail * decayCoeff;
         // sigma_df doesn't change: mosquitoes do not survive traps
         it++;
@@ -815,7 +815,7 @@ void AnophelesModel::update(SimTime d0, double tsP_A, double tsP_Amu, double tsP
 // -----  Summary and intervention functions  -----
 void AnophelesModel::changeEIRIntervention(const scnXml::NonVector &nonVectorData)
 {
-    assert(nonVectorData.getEIRDaily().present()); // XML loading code should enforce this
+    // assert(nonVectorData.getEIRDaily().present()); // XML loading code should enforce this
     const scnXml::NonVector::EIRDailySequence &daily = nonVectorData.getEIRDaily();
 
     // const scnXml::DailyValues &seasM = seasonality.getDailyValues().get();

--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -457,7 +457,7 @@ void AnophelesModel::deployVectorTrap(LocalRng &rng, size_t species, size_t inst
     data.availHet = trapParams[instance].availDecay->hetSample(rng);
     data.deployTime = sim::now();
     data.expiry = sim::now() + lifespan;
-    baitedTraps.push_back(data);
+    baitedTraps.push_back(move(data));
 }
 
 // Every sim::oneTS() days:

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -168,7 +168,7 @@ struct TrapParams {
 struct TrapData {
     size_t instance; // index in trapParams
     double initialAvail; // initial availability (avail per trap * num traps)
-    DecayFuncHet availHet; // parameter for decay of availability
+    DecayFunctionHet availHet; // parameter for decay of availability
     SimTime deployTime = sim::never(); // deploy time (for decay function)
     SimTime expiry = sim::never(); // date at which this intervention should be deleted
 };

--- a/model/Transmission/Anopheles/AnophelesModel.h
+++ b/model/Transmission/Anopheles/AnophelesModel.h
@@ -168,7 +168,7 @@ struct TrapParams {
 struct TrapData {
     size_t instance; // index in trapParams
     double initialAvail; // initial availability (avail per trap * num traps)
-    DecayFunctionHet availHet; // parameter for decay of availability
+    unique_ptr<DecayFunction> availHet; // parameter for decay of availability
     SimTime deployTime = sim::never(); // deploy time (for decay function)
     SimTime expiry = sim::never(); // date at which this intervention should be deleted
 };

--- a/model/Transmission/PerHost.h
+++ b/model/Transmission/PerHost.h
@@ -36,7 +36,7 @@ using Anopheles::PerHostAnophParams;
 using Anopheles::PerHostAnoph;
 using util::AgeGroupInterpolator;
 using util::DecayFunction;
-using util::DecayFuncHet;
+using util::DecayFunctionHet;
 using util::LocalRng;
 
 class HumanVectorInterventionComponent;

--- a/model/Transmission/PerHost.h
+++ b/model/Transmission/PerHost.h
@@ -36,7 +36,6 @@ using Anopheles::PerHostAnophParams;
 using Anopheles::PerHostAnoph;
 using util::AgeGroupInterpolator;
 using util::DecayFunction;
-using util::DecayFunctionHet;
 using util::LocalRng;
 
 class HumanVectorInterventionComponent;

--- a/model/interventions/GVI.h
+++ b/model/interventions/GVI.h
@@ -30,7 +30,7 @@
 
 namespace OM { namespace interventions {
     using util::DecayFunction;
-    using util::DecayFuncHet;
+    using util::DecayFunctionHet;
     using util::LognormalSampler;
     using util::LocalRng;
     using Transmission::PerHostInterventionData;
@@ -130,7 +130,7 @@ protected:
     
 private:
     // this parameter is sampled on first deployment, but never resampled for the same human:
-    DecayFuncHet decayHet;
+    DecayFunctionHet decayHet;
 };
 
 } }

--- a/model/interventions/GVI.h
+++ b/model/interventions/GVI.h
@@ -30,7 +30,6 @@
 
 namespace OM { namespace interventions {
     using util::DecayFunction;
-    using util::DecayFunctionHet;
     using util::LognormalSampler;
     using util::LocalRng;
     using Transmission::PerHostInterventionData;
@@ -109,7 +108,7 @@ public:
     /** This is the survival factor of the effect. */
     inline double getEffectSurvival(const GVIComponent& params)const{
         SimTime age = sim::nowOrTs1() - deployTime;  // implies age 1 TS on first use
-        return decayHet.eval( age );
+        return decayHet->eval( age );
     }
     
     virtual void update(Host::Human& human);
@@ -130,7 +129,7 @@ protected:
     
 private:
     // this parameter is sampled on first deployment, but never resampled for the same human:
-    DecayFunctionHet decayHet;
+    unique_ptr<DecayFunction> decayHet;
 };
 
 } }

--- a/model/interventions/GVI.h
+++ b/model/interventions/GVI.h
@@ -109,7 +109,7 @@ public:
     /** This is the survival factor of the effect. */
     inline double getEffectSurvival(const GVIComponent& params)const{
         SimTime age = sim::nowOrTs1() - deployTime;  // implies age 1 TS on first use
-        return params.decay->eval( age, decayHet );
+        return decayHet.eval( age );
     }
     
     virtual void update(Host::Human& human);

--- a/model/interventions/HumanComponents.h
+++ b/model/interventions/HumanComponents.h
@@ -97,7 +97,7 @@ private:
     SimTime timeLastDeployment = sim::never();
     /// Efficacy at last deployment (undecayed)
     vector<double> perGenotypeInitialEfficacy;
-    util::DecayFunctionHet hetSample;
+    unique_ptr<util::DecayFunction> hetSample;
     
     friend class PerHumanVaccine;
 };

--- a/model/interventions/HumanComponents.h
+++ b/model/interventions/HumanComponents.h
@@ -97,7 +97,7 @@ private:
     SimTime timeLastDeployment = sim::never();
     /// Efficacy at last deployment (undecayed)
     vector<double> perGenotypeInitialEfficacy;
-    util::DecayFuncHet hetSample;
+    util::DecayFunctionHet hetSample;
     
     friend class PerHumanVaccine;
 };

--- a/model/interventions/IRS.h
+++ b/model/interventions/IRS.h
@@ -29,7 +29,7 @@
 namespace OM {
 namespace interventions {
     using util::DecayFunction;
-    using util::DecayFuncHet;
+    using util::DecayFunctionHet;
     using util::NormalSampler;
     using util::LognormalSampler;
     using util::LocalRng;
@@ -195,7 +195,7 @@ private:
     double initialInsecticide;	// units: mg/m²
     
     // this parameter is sampled on first deployment, but never resampled for the same human:
-    DecayFuncHet insecticideDecayHet;
+    DecayFunctionHet insecticideDecayHet;
 };
 
 } }

--- a/model/interventions/IRS.h
+++ b/model/interventions/IRS.h
@@ -29,7 +29,6 @@
 namespace OM {
 namespace interventions {
     using util::DecayFunction;
-    using util::DecayFunctionHet;
     using util::NormalSampler;
     using util::LognormalSampler;
     using util::LocalRng;
@@ -167,7 +166,7 @@ public:
     /// Get remaining insecticide content based on initial amount and decay.
     inline double getInsecticideContent(const IRSComponent& params)const{
         SimTime age = sim::nowOrTs1() - deployTime;  // implies age 1 TS on first use
-        double effectSurvival = insecticideDecayHet.eval( age );
+        double effectSurvival = insecticideDecayHet->eval( age );
         return initialInsecticide * effectSurvival;
     }
     
@@ -194,7 +193,7 @@ private:
     double initialInsecticide;	// units: mg/m²
     
     // this parameter is sampled on first deployment, but never resampled for the same human:
-    DecayFunctionHet insecticideDecayHet;
+    unique_ptr<DecayFunction> insecticideDecayHet;
 };
 
 } }

--- a/model/interventions/IRS.h
+++ b/model/interventions/IRS.h
@@ -167,8 +167,7 @@ public:
     /// Get remaining insecticide content based on initial amount and decay.
     inline double getInsecticideContent(const IRSComponent& params)const{
         SimTime age = sim::nowOrTs1() - deployTime;  // implies age 1 TS on first use
-        double effectSurvival = params.insecticideDecay->eval( age,
-                                              insecticideDecayHet );
+        double effectSurvival = insecticideDecayHet.eval( age );
         return initialInsecticide * effectSurvival;
     }
     

--- a/model/interventions/ITN.h
+++ b/model/interventions/ITN.h
@@ -30,7 +30,6 @@
 namespace OM {
 namespace interventions {
     using util::DecayFunction;
-    using util::DecayFunctionHet;
     using util::NormalSampler;
     using util::LognormalSampler;
     using util::LocalRng;
@@ -239,7 +238,7 @@ public:
     }
     inline double getInsecticideContent(const ITNComponent& params)const{
             SimTime age = sim::nowOrTs1() - deployTime;  // implies age 1 TS on first use
-        double effectSurvival = insecticideDecayHet.eval( age );
+        double effectSurvival = insecticideDecayHet->eval( age );
         return initialInsecticide * effectSurvival;
     }
     
@@ -270,7 +269,8 @@ private:
     // these parameters are sampled from log-normal per net, but thereafter constant:
     double holeRate;	// rate at which new holes are created (holes/time-step)
     double ripRate;		// rate at which holes are enlarged (rips/hole/time-step)
-    DecayFunctionHet insecticideDecayHet;
+    unique_ptr<DecayFunction> insecticideDecayHet;
+
 };
 
 } }

--- a/model/interventions/ITN.h
+++ b/model/interventions/ITN.h
@@ -30,7 +30,7 @@
 namespace OM {
 namespace interventions {
     using util::DecayFunction;
-    using util::DecayFuncHet;
+    using util::DecayFunctionHet;
     using util::NormalSampler;
     using util::LognormalSampler;
     using util::LocalRng;
@@ -271,7 +271,7 @@ private:
     // these parameters are sampled from log-normal per net, but thereafter constant:
     double holeRate;	// rate at which new holes are created (holes/time-step)
     double ripRate;		// rate at which holes are enlarged (rips/hole/time-step)
-    DecayFuncHet insecticideDecayHet;
+    DecayFunctionHet insecticideDecayHet;
 };
 
 } }

--- a/model/interventions/ITN.h
+++ b/model/interventions/ITN.h
@@ -239,8 +239,7 @@ public:
     }
     inline double getInsecticideContent(const ITNComponent& params)const{
             SimTime age = sim::nowOrTs1() - deployTime;  // implies age 1 TS on first use
-        double effectSurvival = params.insecticideDecay->eval( age,
-                                              insecticideDecayHet );
+        double effectSurvival = insecticideDecayHet.eval( age );
         return initialInsecticide * effectSurvival;
     }
     

--- a/model/interventions/Vaccine.cpp
+++ b/model/interventions/Vaccine.cpp
@@ -214,7 +214,7 @@ double PerHumanVaccine::getFactor( Vaccine::Types type, uint32_t genotype) const
     for( EffectList::const_iterator effect = effects.begin(); effect != effects.end(); ++effect ){
         if( VaccineComponent::getParams(effect->component).type == type ){
             SimTime age = sim::ts1() - effect->timeLastDeployment;  // implies age 1 TS on first use
-            double decayFactor = effect->hetSample.eval( age );
+            double decayFactor = effect->hetSample->eval( age );
             factor *= 1.0 - effect->perGenotypeInitialEfficacy[genotype] * decayFactor;
         }
     }

--- a/model/interventions/Vaccine.cpp
+++ b/model/interventions/Vaccine.cpp
@@ -214,8 +214,7 @@ double PerHumanVaccine::getFactor( Vaccine::Types type, uint32_t genotype) const
     for( EffectList::const_iterator effect = effects.begin(); effect != effects.end(); ++effect ){
         if( VaccineComponent::getParams(effect->component).type == type ){
             SimTime age = sim::ts1() - effect->timeLastDeployment;  // implies age 1 TS on first use
-            double decayFactor = VaccineComponent::getParams(effect->component)
-                .decayFunc->eval( age, effect->hetSample );
+            double decayFactor = effect->hetSample.eval( age );
             factor *= 1.0 - effect->perGenotypeInitialEfficacy[genotype] * decayFactor;
         }
     }

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -35,7 +35,7 @@ class BaseHetDecayFunction : public DecayFunction {
     LognormalSampler het;
 public:
     BaseHetDecayFunction( double timeFactorHet, const scnXml::DecayFunction& elt ) :
-        DecayFunction( elt.getComplement() )
+        DecayFunction( elt.getIncreasing() )
     {
         het.setMeanCV( 1.0, elt.getCV() );
     }
@@ -43,11 +43,9 @@ public:
     virtual unique_ptr<DecayFunction> _sample(double hetFactor) const =0;
 
     unique_ptr<DecayFunction> hetSample (LocalRng& rng) const{
-        //return DecayFunction(het.sample(rng) * getBaseTimeFactorHet());
         return _sample(het.sample(rng));
     }
     unique_ptr<DecayFunction> hetSample (NormalSample sample) const{
-        //return DecayFunction(het.sample(sample) * getBaseTimeFactorHet());
         return _sample(het.sample(sample));
     }
 };

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -50,21 +50,14 @@ public:
     }
 };
 
-class ConstantDecayFunction : public DecayFunction {
+class ConstantDecayFunction : public BaseHetDecayFunction {
 public:
     ConstantDecayFunction( const scnXml::DecayFunction& elt ) :
-        DecayFunction( elt )
+        BaseHetDecayFunction( elt )
     {}
 
-    DecayFunctionHet hetSample (LocalRng& rng) const{
-        DecayFunctionHet ret;
-        ret.timeFactorHet = 1.0;
-        return ret;
-    }
-    DecayFunctionHet hetSample (NormalSample sample) const{
-        DecayFunctionHet ret;
-        ret.timeFactorHet = 1.0;
-        return ret;
+    double getBaseTimeFactorHet() const{
+        return 1.0;
     }
     
     double eval(double effectiveAge) const{

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -262,7 +262,7 @@ public:
         f1(move(f1)), f2(move(f2)) {}
 
     double compute(double effectiveAge) const {
-        return min(op(f1->eval(effectiveAge), f2->eval(effectiveAge)), 1.0);
+        return max(min(op(f1->eval(effectiveAge), f2->eval(effectiveAge)), 1.0), 0.0);
     }
     
     SimTime sampleAgeOfDecay (LocalRng& rng) const {

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -42,11 +42,11 @@ public:
     
     virtual double getBaseTMult() const =0;
     
-    DecayFuncHet hetSample (LocalRng& rng) const{
-        return DecayFuncHet(het.sample(rng) * getBaseTMult());
+    DecayFunctionHet hetSample (LocalRng& rng) const{
+        return DecayFunctionHet(het.sample(rng) * getBaseTMult());
     }
-    DecayFuncHet hetSample (NormalSample sample) const{
-        return DecayFuncHet(het.sample(sample) * getBaseTMult());
+    DecayFunctionHet hetSample (NormalSample sample) const{
+        return DecayFunctionHet(het.sample(sample) * getBaseTMult());
     }
 };
 
@@ -56,20 +56,20 @@ public:
         DecayFunction( elt )
     {}
 
-    DecayFuncHet hetSample (LocalRng& rng) const{
-        DecayFuncHet ret;
+    DecayFunctionHet hetSample (LocalRng& rng) const{
+        DecayFunctionHet ret;
         ret.tMult = 1.0;
         return ret;
     }
-    DecayFuncHet hetSample (NormalSample sample) const{
-        DecayFuncHet ret;
+    DecayFunctionHet hetSample (NormalSample sample) const{
+        DecayFunctionHet ret;
         ret.tMult = 1.0;
         return ret;
     }
     
     double eval(double effectiveAge) const{
         // Note: we now require all decay functions to return 0 when time > 0
-        // and the DecayFuncHet is default-constructed. So const *after deployment*.
+        // and the DecayFunctionHet is default-constructed. So const *after deployment*.
         if( effectiveAge == numeric_limits<double>::infinity() )
             return 0.0;
         return 1.0;

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -75,9 +75,9 @@ public:
     }
 
     DecayFunctionHet _sample(double hetFactor) const {
-        shared_ptr<ConstantDecayFunction> copy = make_shared<ConstantDecayFunction>(*this);
+        unique_ptr<ConstantDecayFunction> copy = make_unique<ConstantDecayFunction>(*this);
         copy->hetFactor = hetFactor;
-        return DecayFunctionHet(copy);
+        return DecayFunctionHet(move(copy));
     }
 
 private:
@@ -112,9 +112,9 @@ public:
     }
 
     DecayFunctionHet _sample(double hetFactor) const {
-        shared_ptr<StepDecayFunction> copy = make_shared<StepDecayFunction>(*this);
+        unique_ptr<StepDecayFunction> copy = make_unique<StepDecayFunction>(*this);
         copy->hetFactor = hetFactor;
-        return DecayFunctionHet(copy);
+        return DecayFunctionHet(move(copy));
     }
     
 private:
@@ -145,9 +145,9 @@ public:
     }
 
     DecayFunctionHet _sample(double hetFactor) const {
-        shared_ptr<LinearDecayFunction> copy = make_shared<LinearDecayFunction>(*this);
+        unique_ptr<LinearDecayFunction> copy = make_unique<LinearDecayFunction>(*this);
         copy->hetFactor = hetFactor;
-        return DecayFunctionHet(copy);
+        return DecayFunctionHet(move(copy));
     }
     
 private:
@@ -172,9 +172,9 @@ public:
     }
 
     DecayFunctionHet _sample(double hetFactor) const {
-        shared_ptr<ExponentialDecayFunction> copy = make_shared<ExponentialDecayFunction>(*this);
+        unique_ptr<ExponentialDecayFunction> copy = make_unique<ExponentialDecayFunction>(*this);
         copy->hetFactor = hetFactor;
-        return DecayFunctionHet(copy);
+        return DecayFunctionHet(move(copy));
     }
     
 private:
@@ -204,9 +204,9 @@ public:
     }
 
     DecayFunctionHet _sample(double hetFactor) const {
-        shared_ptr<WeibullDecayFunction> copy = make_shared<WeibullDecayFunction>(*this);
+        unique_ptr<WeibullDecayFunction> copy = make_unique<WeibullDecayFunction>(*this);
         copy->hetFactor = hetFactor;
-        return DecayFunctionHet(copy);
+        return DecayFunctionHet(move(copy));
     }
     
 private:
@@ -233,9 +233,9 @@ public:
     }
 
     DecayFunctionHet _sample(double hetFactor) const {
-        shared_ptr<HillDecayFunction> copy = make_shared<HillDecayFunction>(*this);
+        unique_ptr<HillDecayFunction> copy = make_unique<HillDecayFunction>(*this);
         copy->hetFactor = hetFactor;
-        return DecayFunctionHet(copy);
+        return DecayFunctionHet(move(copy));
     }
     
 private:
@@ -265,9 +265,9 @@ public:
     }
 
     DecayFunctionHet _sample(double hetFactor) const {
-        shared_ptr<SmoothCompactDecayFunction> copy = make_shared<SmoothCompactDecayFunction>(*this);
+        unique_ptr<SmoothCompactDecayFunction> copy = make_unique<SmoothCompactDecayFunction>(*this);
         copy->hetFactor = hetFactor;
-        return DecayFunctionHet(copy);
+        return DecayFunctionHet(move(copy));
     }
     
 private:

--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -40,13 +40,13 @@ public:
         het.setMeanCV( 1.0, elt.getCV() );
     }
     
-    virtual double getBaseTMult() const =0;
+    virtual double getBaseTimeFactorHet() const =0;
     
     DecayFunctionHet hetSample (LocalRng& rng) const{
-        return DecayFunctionHet(het.sample(rng) * getBaseTMult());
+        return DecayFunctionHet(het.sample(rng) * getBaseTimeFactorHet());
     }
     DecayFunctionHet hetSample (NormalSample sample) const{
-        return DecayFunctionHet(het.sample(sample) * getBaseTMult());
+        return DecayFunctionHet(het.sample(sample) * getBaseTimeFactorHet());
     }
 };
 
@@ -58,12 +58,12 @@ public:
 
     DecayFunctionHet hetSample (LocalRng& rng) const{
         DecayFunctionHet ret;
-        ret.tMult = 1.0;
+        ret.timeFactorHet = 1.0;
         return ret;
     }
     DecayFunctionHet hetSample (NormalSample sample) const{
         DecayFunctionHet ret;
-        ret.tMult = 1.0;
+        ret.timeFactorHet = 1.0;
         return ret;
     }
     
@@ -93,7 +93,7 @@ public:
         invL( 1.0 / readLToDays(elt) )
     {}
     
-    double getBaseTMult() const{
+    double getBaseTimeFactorHet() const{
         return invL;
     }
     double eval(double effectiveAge) const{
@@ -119,7 +119,7 @@ public:
         invL( 1.0 / readLToDays(elt) )
     {}
     
-    double getBaseTMult() const{
+    double getBaseTimeFactorHet() const{
         return invL;
     }
     double eval(double effectiveAge) const{
@@ -146,7 +146,7 @@ public:
         invLambda( log(2.0) / readLToDays(elt) )
     {}
     
-    double getBaseTMult() const{
+    double getBaseTimeFactorHet() const{
         return invLambda;
     }
     double eval(double effectiveAge) const{
@@ -169,7 +169,7 @@ public:
         k( elt.getK() )
     {}
     
-    double getBaseTMult() const{
+    double getBaseTimeFactorHet() const{
         return constOverLambda;
     }
     double eval(double effectiveAge) const{
@@ -197,7 +197,7 @@ public:
         k( elt.getK() )
     {}
     
-    double getBaseTMult() const{
+    double getBaseTimeFactorHet() const{
         return invL;
     }
     double eval(double effectiveAge) const{
@@ -220,7 +220,7 @@ public:
         k( elt.getK() )
     {}
     
-    double getBaseTMult() const{
+    double getBaseTimeFactorHet() const{
         return invL;
     }
     double eval(double effectiveAge) const{
@@ -262,7 +262,7 @@ public:
         invL2 = log(2.0) / halflife_long;
     }
     
-    double getBaseTMult() const{
+    double getBaseTimeFactorHet() const{
         return 1.0;
     }
     double eval(double effectiveAge) const{

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -42,21 +42,21 @@ namespace util {
  * The default constructor only sets an NaN value; new instances must be
  * sampled by DecayFunction::hetSample() before use. */
 class DecayFunctionHet {
-    double tMult;
-    DecayFunctionHet(double tMult): tMult(tMult) {}
+    double timeFactorHet;
+    DecayFunctionHet(double timeFactorHet): timeFactorHet(timeFactorHet) {}
 public:
     /** Default value: should make all eval() calls return 0 (i.e. infinitely
      * old deployment). */
-    DecayFunctionHet() : tMult( numeric_limits<double>::infinity() ) {}
+    DecayFunctionHet() : timeFactorHet( numeric_limits<double>::infinity() ) {}
     
-    inline double getTMult() const{
-        return tMult;
+    inline double getTimeFactorHet() const{
+        return timeFactorHet;
     }
     
     /// Checkpointing
     template<class S>
     void operator& (S& stream) {
-        tMult & stream;
+        timeFactorHet & stream;
     }
     
     friend class BaseHetDecayFunction;
@@ -100,9 +100,9 @@ public:
      * interventions being effective for a month or more. */
     inline double eval( SimTime age, DecayFunctionHet sample )const{
         if(complement)
-            return 1.0 - eval( age * sample.getTMult() );
+            return 1.0 - eval( age * sample.getTimeFactorHet() );
         else
-            return eval( age * sample.getTMult() );
+            return eval( age * sample.getTimeFactorHet() );
     }
     
     /** Sample a DecayFunctionHet value (should be stored per individual).

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -27,13 +27,6 @@
 #include <limits>
 #include <memory>
 
-namespace scnXml
-{
-    class DecayFunction;
-    class DecayFunctionValue;
-}
-class DecayFunctionSuite;
-
 namespace OM {
 namespace util {
 
@@ -88,7 +81,7 @@ public:
     bool complement;
 
 protected:
-    DecayFunction() : complement(true) {}
+    DecayFunction() : complement(false) {}
     // Protected version. Note that the het sample parameter is needed even
     // when heterogeneity is not used so don't try calling this without that.
 };

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -39,7 +39,7 @@ namespace util {
 class DecayFunction
 {
 public:
-    DecayFunction(bool complement = false) : complement(complement) {}
+    DecayFunction(bool increasing = false) : increasing(increasing) {}
 
     virtual ~DecayFunction() {}
     
@@ -72,8 +72,8 @@ public:
      * @returns Age at which an object should decay. */
     virtual SimTime sampleAgeOfDecay (LocalRng& rng) const =0;
     
-    double eval(double ageDays) const {
-        if(complement)
+    inline double eval(double ageDays) const {
+        if(increasing)
             return 1.0 - _eval( ageDays );
         else
             return _eval( ageDays );
@@ -88,22 +88,8 @@ public:
 protected:
     virtual double _eval(double ageDays) const =0;
 
-    bool complement;
+    bool increasing;
 };
-
-class NullDecayFunction : public DecayFunction
-{
-public:
-    virtual double _eval(double ageDays) const { return 0.0; }
-
-    virtual unique_ptr<DecayFunction> hetSample (LocalRng& rng) const { return make_unique<NullDecayFunction>(); };
-    
-    /** Generate a DecayFunctionHet value from an existing sample. */
-    virtual unique_ptr<DecayFunction> hetSample (NormalSample sample) const { return make_unique<NullDecayFunction>(); };
-
-    virtual SimTime sampleAgeOfDecay (LocalRng& rng) const { return 0; };
-};
-
 
 } }
 #endif

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -93,7 +93,7 @@ protected:
  * sampled by DecayFunction::hetSample() before use. */
 class DecayFunctionHet {
 public:
-    DecayFunctionHet(shared_ptr<DecayFunction> d): sample(d) {}
+    DecayFunctionHet(unique_ptr<DecayFunction> d): sample(move(d)) {}
 
     /** Default value: should make all eval() calls return 0 (i.e. infinitely
      * old deployment). */
@@ -122,7 +122,7 @@ public:
     }
 
     // TEMPORARY
-    shared_ptr<DecayFunction> sample;
+    unique_ptr<DecayFunction> sample;
  };
 
 class NullDecayFunction : public DecayFunction

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -41,13 +41,13 @@ namespace util {
  *
  * The default constructor only sets an NaN value; new instances must be
  * sampled by DecayFunction::hetSample() before use. */
-class DecayFuncHet {
+class DecayFunctionHet {
     double tMult;
-    DecayFuncHet(double tMult): tMult(tMult) {}
+    DecayFunctionHet(double tMult): tMult(tMult) {}
 public:
     /** Default value: should make all eval() calls return 0 (i.e. infinitely
      * old deployment). */
-    DecayFuncHet() : tMult( numeric_limits<double>::infinity() ) {}
+    DecayFunctionHet() : tMult( numeric_limits<double>::infinity() ) {}
     
     inline double getTMult() const{
         return tMult;
@@ -62,11 +62,11 @@ public:
     friend class BaseHetDecayFunction;
     friend class ConstantDecayFunction;
  };
-
+ 
 /** An interface for a few types of decay function (some of which may also be
  * suitible survival functions).
  *
- * Heterogeneity is implemented by passing a DecayFuncHet object to the eval
+ * Heterogeneity is implemented by passing a DecayFunctionHet object to the eval
  * function; this should be sampled by the same DecayFunction.
  *****************************************************************************/
 class DecayFunction
@@ -91,29 +91,29 @@ public:
      * the intervention.
      * 
      * @param age Age of intervention/decayed property
-     * @param sample A DecayFuncHet value sampled for the intervention and
+     * @param sample A DecayFunctionHet value sampled for the intervention and
      *  individual.
      * 
      * NOTE: As it is, values are calculated for the end of the time-period
      * being updated over. It would be more accurate to return the mean value
      * over this period (from age-1 to age), but difference should be small for
      * interventions being effective for a month or more. */
-    inline double eval( SimTime age, DecayFuncHet sample )const{
+    inline double eval( SimTime age, DecayFunctionHet sample )const{
         if(complement)
             return 1.0 - eval( age * sample.getTMult() );
         else
             return eval( age * sample.getTMult() );
     }
     
-    /** Sample a DecayFuncHet value (should be stored per individual).
+    /** Sample a DecayFunctionHet value (should be stored per individual).
      * 
-     * Note that a DecayFuncHet is needed to call eval() even if heterogeneity
+     * Note that a DecayFunctionHet is needed to call eval() even if heterogeneity
      * is not wanted. If sigma = 0 then the random number stream will not be
      * touched. */
-    virtual DecayFuncHet hetSample (LocalRng& rng) const =0;
+    virtual DecayFunctionHet hetSample (LocalRng& rng) const =0;
     
-    /** Generate a DecayFuncHet value from an existing sample. */
-    virtual DecayFuncHet hetSample (NormalSample sample) const =0;
+    /** Generate a DecayFunctionHet value from an existing sample. */
+    virtual DecayFunctionHet hetSample (NormalSample sample) const =0;
     
     /** Say you have a population of objects which each have two states:
      * decayed and not decayed. If you want to use a DecayFunction to model

--- a/model/util/DecayFunction.h
+++ b/model/util/DecayFunction.h
@@ -41,9 +41,7 @@ class DecayFunctionHet;
 class DecayFunction
 {
 public:
-    DecayFunction(double timeFactorHet = 0, bool complement = false) :
-        timeFactorHet(timeFactorHet), complement(complement)
-    {}
+    DecayFunction(bool complement = false) : complement(complement) {}
 
     virtual ~DecayFunction() {}
     
@@ -78,12 +76,10 @@ public:
     
     double eval(double ageDays) const {
         if(complement)
-            return 1.0 - _eval( ageDays * timeFactorHet);
+            return 1.0 - _eval( ageDays );
         else
-            return _eval( ageDays * timeFactorHet);
+            return _eval( ageDays );
     }
-
-    double timeFactorHet;
 
 protected:
     virtual double _eval(double ageDays) const =0;

--- a/model/util/SimpleDecayingValue.h
+++ b/model/util/SimpleDecayingValue.h
@@ -64,11 +64,8 @@ public:
      * also 0 if no decay function or initial value was set,
      * otherwise between zero and the inital value). */
     inline double current_value (SimTime time) const{
-        if( decay.get() == 0 ) return 0.0;  // decay wasn't set: the always return 0
-        if (het.sample == nullptr)
-            cout << "nullptr" <<endl;
-        double a= initial * het.eval( time - deploy_t );
-        return a;
+        if( decay.get() == 0 || het == nullptr) return 0.0;  // decay wasn't set: the always return 0
+        else return initial * het->eval( time - deploy_t );
     }
     
     /** Checkpointing: only checkpoint parameters which change after initial
@@ -87,7 +84,7 @@ private:
     double initial;
     
     /** Description of larviciding decay. */
-    util::DecayFunctionHet het;
+    unique_ptr<util::DecayFunction> het;
     
     /** Time of larviciding deployment. */
     SimTime deploy_t = sim::never();

--- a/model/util/SimpleDecayingValue.h
+++ b/model/util/SimpleDecayingValue.h
@@ -65,8 +65,10 @@ public:
      * otherwise between zero and the inital value). */
     inline double current_value (SimTime time) const{
         if( decay.get() == 0 ) return 0.0;  // decay wasn't set: the always return 0
-        
-        return initial * decay->eval( time - deploy_t, het );
+        if (het.sample == nullptr)
+            cout << "nullptr" <<endl;
+        double a= initial * het.eval( time - deploy_t );
+        return a;
     }
     
     /** Checkpointing: only checkpoint parameters which change after initial

--- a/model/util/SimpleDecayingValue.h
+++ b/model/util/SimpleDecayingValue.h
@@ -85,7 +85,7 @@ private:
     double initial;
     
     /** Description of larviciding decay. */
-    util::DecayFuncHet het;
+    util::DecayFunctionHet het;
     
     /** Time of larviciding deployment. */
     SimTime deploy_t = sim::never();

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -148,7 +148,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
      <xs:enumeration value="weibull"/>
      <xs:enumeration value="hill"/>
      <xs:enumeration value="smooth-compact"/>
-     <xs:enumeration value="biphasic"/>
+     <xs:enumeration value="addition"/>
     </xs:restriction>
    </xs:simpleType>
   </xs:attribute>
@@ -203,7 +203,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     <xs:appinfo>units:User-defined (defaults to years);min:0;name:L;</xs:appinfo>
    </xs:annotation>
   </xs:attribute>
-  <xs:attribute name="initial_efficacy" type="xs:double" use="optional">
+  <xs:attribute name="initialEfficacy" type="xs:double" use="optional" default="1">
    <xs:annotation>
     <xs:documentation>
           biphasic: Efficacy between 0 and 1.

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -145,6 +145,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
      <xs:enumeration value="weibull"/>
      <xs:enumeration value="hill"/>
      <xs:enumeration value="smooth-compact"/>
+     <xs:enumeration value="biphasic"/>
     </xs:restriction>
    </xs:simpleType>
   </xs:attribute>
@@ -197,6 +198,35 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
           between 0 and 1.
 </xs:documentation>
     <xs:appinfo>units:User-defined (defaults to years);min:0;name:L;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="initial_efficacy" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: Efficacy between 0 and 1.
+        </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="rho" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: Proportion between 0 and 1, proportion of the response that is short-lived.</xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="halflife_short" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: halflife of short lived component (default to years).
+
+        </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="halflife_long" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: halflife of long lived component (default to years).
+
+        </xs:documentation>
    </xs:annotation>
   </xs:attribute>
  </xs:complexType>

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -148,7 +148,10 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
      <xs:enumeration value="weibull"/>
      <xs:enumeration value="hill"/>
      <xs:enumeration value="smooth-compact"/>
-     <xs:enumeration value="addition"/>
+     <xs:enumeration value="plus"/>
+     <xs:enumeration value="minus"/>
+     <xs:enumeration value="divides"/>
+     <xs:enumeration value="multiplies"/>
     </xs:restriction>
    </xs:simpleType>
   </xs:attribute>

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -192,7 +192,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     <xs:appinfo>min:0;name:Coefficient of Variation;</xs:appinfo>
    </xs:annotation>
   </xs:attribute>
-  <xs:attribute name="complement" type="xs:boolean" default="false">
+  <xs:attribute name="increasing" type="xs:boolean" default="false">
    <xs:annotation>
     <xs:documentation>
           (Boolean) If True, this tells OpenMalaria to use the complement of the

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -114,6 +114,9 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
       </xs:documentation>
    <xs:appinfo>name:Decay or survival of a parameter</xs:appinfo>
   </xs:annotation>
+  <xs:sequence minOccurs="0" maxOccurs="unbounded">
+   <xs:element name="decay" type="om:DecayFunction"/>
+  </xs:sequence>
   <xs:attribute name="function" use="required">
    <xs:annotation>
     <xs:documentation>

--- a/unittest/DecayFunctionSuite.h
+++ b/unittest/DecayFunctionSuite.h
@@ -57,11 +57,11 @@ public:
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         // First test: with a default-constructed DecayFunctionHet and positive age, result should be zero
         DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
         // Second test: with an appropriately sampled helper value, we should get the results we want
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(10), dHet ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::zero() ) , 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(10 ) ), 1.0 );
         // Third test: time of decay (age plus now) should always be in the future
         TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), sim::future() );
     }
@@ -70,11 +70,11 @@ public:
         dfElt.setFunction( "step" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.0 );
         TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), sim::fromYearsI(10) );
     }
     
@@ -82,53 +82,53 @@ public:
         dfElt.setFunction( "linear" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.4 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.4 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.0 );
     }
     
     void testExponential () {
         dfElt.setFunction( "exponential" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.65975394736842108 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.25 );
+        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.65975394736842108 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.25 );
     }
     
     void testWeibull () {
         dfElt.setFunction( "weibull" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFunctionHet dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.73631084210526321 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.122306 );
+        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.73631084210526321 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.122306 );
     }
     
     void testHill () {
         dfElt.setFunction( "hill" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.6936673684210527 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.24805074736842106 );
+        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.6936673684210527 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.24805074736842106 );
     }
     
     void testSmoothCompact () {
         dfElt.setFunction( "smooth-compact" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
+        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.40656965789473687 );
-        TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.40656965789473687 );
+        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.0 );
     }
     
 private:

--- a/unittest/DecayFunctionSuite.h
+++ b/unittest/DecayFunctionSuite.h
@@ -28,7 +28,6 @@
 #include "util/DecayFunction.h"
 
 using ::OM::util::DecayFunction;
-using ::OM::util::NullDecayFunction;
 
 class DecayFunctionSuite : public CxxTest::TestSuite
 {
@@ -55,11 +54,8 @@ public:
     void testConstant () {
         dfElt.setFunction( "constant" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        // First test: with a default-constructed DecayFunctionHet and positive age, result should be zero
-        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
-        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
         // Second test: with an appropriately sampled helper value, we should get the results we want
-        dHet = df->hetSample(m_rng);
+        unique_ptr<DecayFunction> dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( dHet->eval( sim::zero() ) , 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(10 ) ), 1.0 );
         // Third test: time of decay (age plus now) should always be in the future
@@ -69,9 +65,7 @@ public:
     void testStep () {
         dfElt.setFunction( "step" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
-        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
-        dHet = df->hetSample(m_rng);
+        unique_ptr<DecayFunction> dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.0 );
@@ -81,9 +75,7 @@ public:
     void testLinear () {
         dfElt.setFunction( "linear" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
-        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
-        dHet = df->hetSample(m_rng);
+        unique_ptr<DecayFunction> dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.4 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.0 );
@@ -92,9 +84,7 @@ public:
     void testExponential () {
         dfElt.setFunction( "exponential" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
-        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
-        dHet = df->hetSample(m_rng);
+        unique_ptr<DecayFunction> dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.65975394736842108 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.25 );
@@ -103,7 +93,7 @@ public:
     void testWeibull () {
         dfElt.setFunction( "weibull" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        unique_ptr<DecayFunction> dHet= df->hetSample(m_rng);
+        unique_ptr<DecayFunction> dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.73631084210526321 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.122306 );
@@ -112,9 +102,7 @@ public:
     void testHill () {
         dfElt.setFunction( "hill" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
-        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
-        dHet = df->hetSample(m_rng);
+        unique_ptr<DecayFunction> dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.6936673684210527 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.24805074736842106 );
@@ -123,9 +111,7 @@ public:
     void testSmoothCompact () {
         dfElt.setFunction( "smooth-compact" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
-        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
-        dHet = df->hetSample(m_rng);
+        unique_ptr<DecayFunction> dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.40656965789473687 );
         TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.0 );

--- a/unittest/DecayFunctionSuite.h
+++ b/unittest/DecayFunctionSuite.h
@@ -28,7 +28,7 @@
 #include "util/DecayFunction.h"
 
 using ::OM::util::DecayFunction;
-using ::OM::util::DecayFuncHet;
+using ::OM::util::DecayFunctionHet;
 
 class DecayFunctionSuite : public CxxTest::TestSuite
 {
@@ -55,8 +55,8 @@ public:
     void testConstant () {
         dfElt.setFunction( "constant" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        // First test: with a default-constructed DecayFuncHet and positive age, result should be zero
-        DecayFuncHet dHet;
+        // First test: with a default-constructed DecayFunctionHet and positive age, result should be zero
+        DecayFunctionHet dHet;
         TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         // Second test: with an appropriately sampled helper value, we should get the results we want
         dHet = df->hetSample(m_rng);
@@ -69,7 +69,7 @@ public:
     void testStep () {
         dfElt.setFunction( "step" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFuncHet dHet;
+        DecayFunctionHet dHet;
         TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
@@ -81,7 +81,7 @@ public:
     void testLinear () {
         dfElt.setFunction( "linear" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFuncHet dHet;
+        DecayFunctionHet dHet;
         TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
@@ -92,7 +92,7 @@ public:
     void testExponential () {
         dfElt.setFunction( "exponential" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFuncHet dHet;
+        DecayFunctionHet dHet;
         TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
@@ -103,7 +103,7 @@ public:
     void testWeibull () {
         dfElt.setFunction( "weibull" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFuncHet dHet = df->hetSample(m_rng);
+        DecayFunctionHet dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
         TS_ASSERT_APPROX( df->eval( sim::fromYearsI(6), dHet ), 0.73631084210526321 );
         TS_ASSERT_APPROX( df->eval( sim::fromYearsI(20), dHet ), 0.122306 );
@@ -112,7 +112,7 @@ public:
     void testHill () {
         dfElt.setFunction( "hill" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFuncHet dHet;
+        DecayFunctionHet dHet;
         TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );
@@ -123,7 +123,7 @@ public:
     void testSmoothCompact () {
         dfElt.setFunction( "smooth-compact" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFuncHet dHet;
+        DecayFunctionHet dHet;
         TS_ASSERT_EQUALS( df->eval( sim::fromDays(5), dHet ), 0.0 );
         dHet = df->hetSample(m_rng);
         TS_ASSERT_APPROX( df->eval( sim::zero(), dHet ), 1.0 );

--- a/unittest/DecayFunctionSuite.h
+++ b/unittest/DecayFunctionSuite.h
@@ -28,7 +28,7 @@
 #include "util/DecayFunction.h"
 
 using ::OM::util::DecayFunction;
-using ::OM::util::DecayFunctionHet;
+using ::OM::util::NullDecayFunction;
 
 class DecayFunctionSuite : public CxxTest::TestSuite
 {
@@ -56,12 +56,12 @@ public:
         dfElt.setFunction( "constant" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
         // First test: with a default-constructed DecayFunctionHet and positive age, result should be zero
-        DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
+        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
+        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
         // Second test: with an appropriately sampled helper value, we should get the results we want
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( dHet.eval( sim::zero() ) , 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(10 ) ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::zero() ) , 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(10 ) ), 1.0 );
         // Third test: time of decay (age plus now) should always be in the future
         TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), sim::future() );
     }
@@ -69,66 +69,66 @@ public:
     void testStep () {
         dfElt.setFunction( "step" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
+        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
+        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.0 );
         TS_ASSERT_EQUALS( df->sampleAgeOfDecay(m_rng), sim::fromYearsI(10) );
     }
     
     void testLinear () {
         dfElt.setFunction( "linear" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
+        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
+        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.4 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.4 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.0 );
     }
     
     void testExponential () {
         dfElt.setFunction( "exponential" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
+        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
+        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.65975394736842108 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.25 );
+        TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.65975394736842108 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.25 );
     }
     
     void testWeibull () {
         dfElt.setFunction( "weibull" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFunctionHet dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.73631084210526321 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.122306 );
+        unique_ptr<DecayFunction> dHet= df->hetSample(m_rng);
+        TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.73631084210526321 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.122306 );
     }
     
     void testHill () {
         dfElt.setFunction( "hill" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
+        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
+        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.6936673684210527 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.24805074736842106 );
+        TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.6936673684210527 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.24805074736842106 );
     }
     
     void testSmoothCompact () {
         dfElt.setFunction( "smooth-compact" );
         df = DecayFunction::makeObject( dfElt, "DecayFunctionSuite" );
-        DecayFunctionHet dHet;
-        TS_ASSERT_EQUALS( dHet.eval( sim::fromDays(5 ) ), 0.0 );
+        unique_ptr<DecayFunction> dHet = make_unique<NullDecayFunction>();
+        TS_ASSERT_EQUALS( dHet->eval( sim::fromDays(5 ) ), 0.0 );
         dHet = df->hetSample(m_rng);
-        TS_ASSERT_APPROX( dHet.eval( sim::zero() ), 1.0 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(6 ) ), 0.40656965789473687 );
-        TS_ASSERT_APPROX( dHet.eval( sim::fromYearsI(20 ) ), 0.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::zero() ), 1.0 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(6 ) ), 0.40656965789473687 );
+        TS_ASSERT_APPROX( dHet->eval( sim::fromYearsI(20 ) ), 0.0 );
     }
     
 private:

--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -90,7 +90,7 @@
             <component id="GVI_example">
                 <GVI>
                     <!-- Exponential decay with a half-life of 3 years, see: https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions -->
-                    <decay function="exponential" L="3y"/>
+                    <decay function="multiply" f1="exponential" f2="step"/>
                     <anophelesParams mosquito="gambiae_ss">
                         <deterrency value="0.7696"/>
                         <postprandialKillingEffect value="0.0544"/>

--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -90,7 +90,7 @@
             <component id="GVI_example">
                 <GVI>
                     <!-- Exponential decay with a half-life of 3 years, see: https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions -->
-                    <decay function="multiply" f1="exponential" f2="step"/>
+                    <decay function="exponential" L="3y"/>
                     <anophelesParams mosquito="gambiae_ss">
                         <deterrency value="0.7696"/>
                         <postprandialKillingEffect value="0.0544"/>


### PR DESCRIPTION
This is a major refactoring of the decay function implementation. Decay function objects have now entire control on the heterogeneity implementation, which was not the case before. This allows for more complex decay functions to exist.

Decay functions are now stored as unique_ptr. They still need to be sampled via the hetSample method. When doing so, the hetSample method now returns a new (sampled cloned) instance of the decay function, rather than a heterogeneity factor. This allows the decay functions to have their own implementation of heterogeneity, whether it is just sampling and returning a new internal heterogeneity factor or something more complicated depends on the decay function type.

Heterogeneity can be enabled with the CV parameter. Older decay functions sample the half-life of the decay function using a log-normal sampler. Each host then has a different copy of the decay function with a half-life that differs from the mean.

This pull request adds the ability to describe advanced decay function and brings four new decay function types: plus, minus, divides and multiplies, as illustrated below.

Example 1. A biphasic function as the sum of two exponential decays. Note that both the plus, minus, divides and multiplies decay functions expect exactly two other decay functions and they will return an error otherwise. In this example, the other decay functions are added together. This decay function is maxed at 1.0. **Note that we can give an initiallEfficacy to each decay function to weigh their importance. initialEfficay is 1.0 by default and is only really needed for the plus and minus decay functions, but it can be used for all decay functions.**
```
<decay function="plus">
    <decay function="exponential" L="1y" initialEfficacy="0.5"/>
    <decay function="exponential" L="20y" initialEfficacy="0.5"/>
</decay>
```

Example 2. Using s step function to abruptly stop the decay. Here the exponential decay will suddenly stop after 2 years.
```
<effect function="multiplies">
    <decay function="exponential" L="5y" />
    <decay function="step" L="2y" />
</effect>
``` 

Example 3. Recursive definitions are allowed.
```
<decay function="multiplies">
    <decay function="plus">
        <decay function="exponential" L="1y" initialEfficacy="0.5"/>
        <decay function="exponential" L="20y" initialEfficacy="0.5"/>
    </decay>
    <decay function="step" L="25y" initialEfficacy="1.0"/>
</decay>
```

Example 4. Biphasic with heterogeneity.
```
<decay function="plus">
    <decay function="exponential" L="5y" initialEfficacy="1.0" CV="2"/>
    <decay function="exponential" L="10y" initialEfficacy="0.0" CV="2"/>
</decay>
```

In addition, the parameter used to make a decay function increased has been renamed from `complement` to `increasing`.