### PR TITLE
add Gamma distribution for entoAvailability

### DIFF
--- a/model/Transmission/Anopheles/AnophelesModel.cpp
+++ b/model/Transmission/Anopheles/AnophelesModel.cpp
@@ -452,7 +452,7 @@ void AnophelesModel::deployVectorTrap(LocalRng &rng, size_t species, size_t inst
     assert(instance < trapParams.size());
     TrapData data;
     data.instance = instance;
-    double adultAvail = PerHostAnophParams::get(species).entoAvailability.mean();
+    double adultAvail = PerHostAnophParams::get(species).entoAvailability->mean();
     data.initialAvail = popSize * adultAvail * trapParams[instance].relAvail;
     data.availHet = trapParams[instance].availDecay->hetSample(rng);
     data.deployTime = sim::now();

--- a/model/Transmission/Anopheles/PerHostAnoph.cpp
+++ b/model/Transmission/Anopheles/PerHostAnoph.cpp
@@ -31,7 +31,14 @@ vector<PerHostAnophParams> PerHostAnophParams::params;
 // ----- Per host, per species, non-static -----
 
 PerHostAnophParams::PerHostAnophParams (const scnXml::Mosq& mosq) {
-    entoAvailability.setParams( 1.0, mosq.getAvailability() );
+    const string &distr = mosq.getAvailability().getDistr();
+    if(distr == "const" || distr == "lognormal")
+        entoAvailability = make_unique<util::LognormalSampler>(1.0, mosq.getAvailability());
+    else if(distr == "gamma")
+        entoAvailability = make_unique<util::GammaSampler>(mosq.getAvailability());
+    else
+        throw util::xml_scenario_error( "error ento availability: unknown distirbution "+distr);
+
     probMosqBiting.setParams( mosq.getMosqProbBiting() );
     probMosqFindRestSite.setParams( mosq.getMosqProbFindRestSite() );
     probMosqSurvivalResting.setParams( mosq.getMosqProbResting() );
@@ -40,7 +47,7 @@ PerHostAnophParams::PerHostAnophParams (const scnXml::Mosq& mosq) {
 void PerHostAnoph::initialise (LocalRng& rng, size_t species, double availabilityFactor)
 {
     const PerHostAnophParams& base = PerHostAnophParams::get(species);
-    entoAvailability = base.entoAvailability.sample(rng) * availabilityFactor;
+    entoAvailability = base.entoAvailability->sample(rng) * availabilityFactor;
     probMosqBiting = base.probMosqBiting.sample(rng);
     auto pRest1 = base.probMosqFindRestSite.sample(rng);
     auto pRest2 = base.probMosqSurvivalResting.sample(rng);

--- a/model/Transmission/Anopheles/PerHostAnoph.h
+++ b/model/Transmission/Anopheles/PerHostAnoph.h
@@ -61,7 +61,7 @@ public:
      * It should be called exactly once.
       */
     inline static void scaleEntoAvailability(size_t species, double entoAvailability){
-        params[species].entoAvailability.scaleMean( entoAvailability );
+        params[species].entoAvailability->scaleMean( entoAvailability );
     }
 
     /** @brief Probabilities of finding a host and surviving a feeding cycle
@@ -70,7 +70,8 @@ public:
      * P_C_i and P_D_i across the human population. */
     //@{
     /** Availability rate (α_i) */
-    util::LognormalSampler entoAvailability;
+    // util::LognormalSampler entoAvailability;
+    unique_ptr<util::Sampler> entoAvailability;
 
     /** Probability of mosquito successfully biting host (P_B_i) */
     util::BetaSampler probMosqBiting;

--- a/model/Transmission/PerHost.h
+++ b/model/Transmission/PerHost.h
@@ -263,11 +263,11 @@ public:
     }
     //@}
     
+    vector<PerHostAnoph> speciesData;
+
 private:
     void checkpointIntervs( ostream& stream );
     void checkpointIntervs( istream& stream );
-    
-    vector<PerHostAnoph> speciesData;
     
     // Determines whether human is outside transmission
     bool outsideTransmission;

--- a/model/interventions/Deployments.hpp
+++ b/model/interventions/Deployments.hpp
@@ -469,7 +469,7 @@ public:
                 NhhParamsInterv &p = nhhParams[anophModel->mosq.name];
                 Transmission::Anopheles::Nhh nhh;
 
-                double adultAvail = Transmission::PerHostAnophParams::get(i).entoAvailability.mean();
+                double adultAvail = Transmission::PerHostAnophParams::get(i).entoAvailability->mean();
                 double avail_i = popSize * adultAvail * p.mosqRelativeAvailabilityHuman;
 
                 nhh.avail_i = avail_i;

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -220,7 +220,6 @@ int main(int argc, char* argv[])
                     humanFile << human.perHostTransmission.speciesData[i].getEntoAvailability() << " ";
                 }
                 humanFile << endl;
-                cout << i << endl;
             }
             humanFile.close();
         }

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -210,19 +210,19 @@ int main(int argc, char* argv[])
         
         int lastPercent = -1; // last _integer_ percentage value
         
-        ofstream humanFile ("humans.txt");
-        if (humanFile.is_open())
-        {
-            for(size_t i=0; i<population->getHumans()[0].perHostTransmission.speciesData.size(); i++)
-            {
-                for(const Host::Human &human : population->getHumans())
-                {
-                    humanFile << human.perHostTransmission.speciesData[i].getEntoAvailability() << " ";
-                }
-                humanFile << endl;
-            }
-            humanFile.close();
-        }
+        // ofstream humanFile ("humans.txt");
+        // if (humanFile.is_open())
+        // {
+        //     for(size_t i=0; i<population->getHumans()[0].perHostTransmission.speciesData.size(); i++)
+        //     {
+        //         for(const Host::Human &human : population->getHumans())
+        //         {
+        //             humanFile << human.perHostTransmission.speciesData[i].getEntoAvailability() << " ";
+        //         }
+        //         humanFile << endl;
+        //     }
+        //     humanFile.close();
+        // }
 
         /** Warm-up phase: 
          * Run the simulation using the equilibrium inoculation rates over one

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -210,6 +210,21 @@ int main(int argc, char* argv[])
         
         int lastPercent = -1; // last _integer_ percentage value
         
+        ofstream humanFile ("humans.txt");
+        if (humanFile.is_open())
+        {
+            for(size_t i=0; i<population->getHumans()[0].perHostTransmission.speciesData.size(); i++)
+            {
+                for(const Host::Human &human : population->getHumans())
+                {
+                    humanFile << human.perHostTransmission.speciesData[i].getEntoAvailability() << " ";
+                }
+                humanFile << endl;
+                cout << i << endl;
+            }
+            humanFile.close();
+        }
+
         /** Warm-up phase: 
          * Run the simulation using the equilibrium inoculation rates over one
          * complete lifespan (sim::maxHumanAge()) to reach immunological

--- a/model/util/sampler.cpp
+++ b/model/util/sampler.cpp
@@ -221,11 +221,11 @@ void GammaSampler::setMeanVariance( double mean, double variance ){
     if( variance == 0.0 )
         return;
 
-    variance = variance;
+    this->variance = variance;
     // sigma / mu = 1 / sqrt(k)
     // sqrt(k) = mu / sigma
     // k = mu^2 / variance
-    k = (mu*mu)/variance;
+    k = (mu*mu)/this->variance;
     // k * theta = mean
     // theta = mean / k
     theta = mu / k;
@@ -233,8 +233,10 @@ void GammaSampler::setMeanVariance( double mean, double variance ){
 
 void GammaSampler::scaleMean(double scalar){
     mu *= scalar;
-    if(!isnan(variance))
-        k = (mu*mu)/variance;
+    // if(!isnan(this->variance))
+    // {
+    //     k = (mu*mu)/this->variance;
+    // }
     if(!isnan(k))
         theta = mu / k;
 }

--- a/model/util/sampler.h
+++ b/model/util/sampler.h
@@ -166,7 +166,7 @@ namespace OM { namespace util {
     public:
         GammaSampler(const scnXml::SampledValueCV& elt) :
             mu( 1.0 ),
-            k( 1.0 ),
+            k( numeric_limits<double>::signaling_NaN() ),
             theta( numeric_limits<double>::signaling_NaN() ),
             variance( numeric_limits<double>::signaling_NaN() )
         {

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -290,7 +290,8 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     <xs:documentation>
           The (linear) coefficient of variation.
           
-          This value must be specified when a (non-constant) distribution is used.
+          This value must be specified when a (non-constant) distribution is used. 
+          Note: since version 46, variance can be used instead.
           
           Note that specifying CV=&quot;0&quot; has the same effect as distr=&quot;const&quot; and
           disables sampling of this parameter, even if distr is not &quot;const&quot;. 
@@ -325,11 +326,11 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
   <xs:attribute name="variance" type="xs:double" use="optional">
    <xs:annotation>
     <xs:documentation>
-          The (linear) coefficient of variation.
+          The variance parameter of the distirbution.
           
-          This value must be specified when a (non-constant) distribution is used.
+          This value can be specified when a (non-constant) distribution is used.
           
-          Note that specifying CV=&quot;0&quot; has the same effect as distr=&quot;const&quot; and
+          Note that specifying variance=&quot;0&quot; has the same effect as distr=&quot;const&quot; and
           disables sampling of this parameter, even if distr is not &quot;const&quot;. 
         </xs:documentation>
     <xs:appinfo>name:Coefficient of variation;units:unitless;</xs:appinfo>

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -318,8 +318,22 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     <xs:restriction base="xs:string">
      <xs:enumeration value="const"/>
      <xs:enumeration value="lognormal"/>
+     <xs:enumeration value="gamma"/>
     </xs:restriction>
    </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="variance" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          The (linear) coefficient of variation.
+          
+          This value must be specified when a (non-constant) distribution is used.
+          
+          Note that specifying CV=&quot;0&quot; has the same effect as distr=&quot;const&quot; and
+          disables sampling of this parameter, even if distr is not &quot;const&quot;. 
+        </xs:documentation>
+    <xs:appinfo>name:Coefficient of variation;units:unitless;</xs:appinfo>
+   </xs:annotation>
   </xs:attribute>
  </xs:complexType>
  <xs:complexType name="SampledValueLN">


### PR DESCRIPTION
Add the possibility to sample the host availability from on the following distributions:
- const (default)
- lognormal with CV or variance
- gamma with CV or variance

It can be specified via the <availability ... /> parameter in the entomology section of the xml, for each species.

Some examples include:
```
<availability /> <!-- default -->
<availability distr="gamma" CV="2"/>
<availability distr="lognormal" CV="2"/>
<availability distr="gamma" variance="3"/>
<availability distr="lognormal" CV="3"/>```