### PR TITLE
add docker files for versions 44.0 and 45.0

### DIFF
--- a/docker/44.0
+++ b/docker/44.0
@@ -1,0 +1,29 @@
+FROM ubuntu:kinetic as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git libz-dev python3 cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-44.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_44.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:kinetic as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl27 libxerces-c3.2 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml

--- a/docker/45.0
+++ b/docker/45.0
@@ -1,0 +1,29 @@
+FROM ubuntu:kinetic as builder
+WORKDIR /
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential ca-certificates git libz-dev python3 cmake libgsl-dev libxerces-c-dev xsdcxx libboost-dev \
+  && rm -rf /var/lib/apt/lists/* \
+  && git clone --depth 1 --branch schema-45.0 https://github.com/SwissTPH/openmalaria.git \
+  && cd openmalaria \
+  # && echo "schema-30.3" > version.txt \
+  && mkdir build \
+  && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release .. \
+  && make -j8 \
+  && cd .. \
+  && mkdir openmalariaRelease \
+  && cp build/openMalaria openmalariaRelease/ \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/scenario_45.xsd \
+  && cp build/schema/scenario_current.xsd openmalariaRelease/ \
+  && cp test/*.csv openmalariaRelease/
+
+FROM ubuntu:kinetic as openmalaria
+WORKDIR /om/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgsl27 libxerces-c3.2 \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /openmalaria/openmalariaRelease/* ./
+ENTRYPOINT ["/om/openMalaria"]  
+
+# docker build -t openmalaria .
+# docker run -it --rm -v /home/acavelan/git/openmalaria/nhh:/root/nhh openmalaria -p nhh -s scenarioNonHumanHosts.xml


### PR DESCRIPTION
Add docker files for versions 44.0 and 45.0.

The Docker images are hosted at: https://hub.docker.com/r/swisstph/openmalaria/tags

To use on the cluster:
```
singularity run docker://swisstph/openmalaria:45.0 -s <scenarioName>.xml
```

To use on a local laptop:
```
docker run -it --rm -v <absolute_path_to_local_dir>:/root/mnt acavelan/openmalaria:45.0 -s /root/mnt/<scenarioName>.xml -o /root/mnt/output.txt
```