### PR TITLE
fix availability based intervention error when loading from a checkpoint

### DIFF
--- a/model/main.cpp
+++ b/model/main.cpp
@@ -218,6 +218,9 @@ int main(int argc, char* argv[])
         {
             Continuous.init(scenario->getMonitoring(), true);
             readCheckpoint(checkpointFileName, endTime, estEndTime, *population, *transmission);
+
+            /** Calculate ento availability percentiles **/
+            Transmission::PerHostAnophParams::calcAvailabilityPercentiles();
         }
         else
         {


### PR DESCRIPTION
The availability percentiles are not stored in the checkpoints and were not recomputed when loading from a checkpoint, which lead to a crash. This pull request adds the computation of the percentiles when loading from a checkpoint, which fixes the issue.