### PR TITLE
remove text output in LinearDecayFunction

### DIFF
--- a/model/util/DecayFunction.cpp
+++ b/model/util/DecayFunction.cpp
@@ -106,7 +106,7 @@ public:
     {}
     
     double compute(double effectiveAge) const{
-        cout << "Linear " << effectiveAge << " " << invL << " " << hetFactor <<endl;
+        // cout << "Linear " << effectiveAge << " " << invL << " " << hetFactor <<endl;
         if( effectiveAge * invL * hetFactor < 1.0 ){
             return 1.0 - effectiveAge * invL * hetFactor;
         }else{


### PR DESCRIPTION
An unnecessary text output was left in the LinearDecayFunction, this pull request removes it.