### PR TITLE
Add --progress command line option and remove progress updates by default

### DIFF
--- a/model/main.cpp
+++ b/model/main.cpp
@@ -119,7 +119,8 @@ void run(Population &population, TransmissionModel &transmission, SimTime humanW
 
         sim::end_update();
 
-        print_progress(lastPercent, estEndTime);
+        if (!util::CommandLine::option(util::CommandLine::QUIET))
+            print_progress(lastPercent, estEndTime);
         print_errno();
     }
 

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -119,7 +119,7 @@ void run(Population &population, TransmissionModel &transmission, SimTime humanW
 
         sim::end_update();
 
-        if (!util::CommandLine::option(util::CommandLine::QUIET))
+        if (util::CommandLine::option(util::CommandLine::PROGRESS))
             print_progress(lastPercent, estEndTime);
         print_errno();
     }

--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -81,6 +81,10 @@ namespace OM { namespace util {
 				clo.assign (clo, 2, clo.size()-2);
 				if (clo == "verbose") {
 					options.set (VERBOSE);
+				} else if (clo == "quiet") {
+					options.set (QUIET);
+					if (options.test(VERBOSE))
+						throw cmd_exception ("--quiet is incompatible with --verbose");
 				} else if (clo == "resource-path") {
 					if (resourcePath.size())
 						throw cmd_exception ("--resource-path (or -p) may only be given once");

--- a/model/util/CommandLine.cpp
+++ b/model/util/CommandLine.cpp
@@ -81,10 +81,8 @@ namespace OM { namespace util {
 				clo.assign (clo, 2, clo.size()-2);
 				if (clo == "verbose") {
 					options.set (VERBOSE);
-				} else if (clo == "quiet") {
-					options.set (QUIET);
-					if (options.test(VERBOSE))
-						throw cmd_exception ("--quiet is incompatible with --verbose");
+				} else if (clo == "progress") {
+					options.set (PROGRESS);
 				} else if (clo == "resource-path") {
 					if (resourcePath.size())
 						throw cmd_exception ("--resource-path (or -p) may only be given once");

--- a/model/util/CommandLine.h
+++ b/model/util/CommandLine.h
@@ -39,6 +39,8 @@ namespace OM { namespace util {
 			PRINT_MODEL_OPTIONS = 0,
 	    /// Verbose output
 			VERBOSE,
+		/// No progress, cancel VERBOSE
+			QUIET,
 	    /// Forces checkpointing just before starting the main phase.
 			CHECKPOINT,
 	    /// Exit after writing checkpoint

--- a/model/util/CommandLine.h
+++ b/model/util/CommandLine.h
@@ -39,8 +39,8 @@ namespace OM { namespace util {
 			PRINT_MODEL_OPTIONS = 0,
 	    /// Verbose output
 			VERBOSE,
-		/// No progress, cancel VERBOSE
-			QUIET,
+		/// Show progress
+			PROGRESS,
 	    /// Forces checkpointing just before starting the main phase.
 			CHECKPOINT,
 	    /// Exit after writing checkpoint


### PR DESCRIPTION
This will disable progress outputs, e.g. 85%, 86%, ... **by default**, but not error outputs or warnings. 

Add the --progress command line option to get the progress output back.

The reason for this is performance. When users are running large simulations with many OpenMalaria instances on the same computing node, all the outputs are creating a congestion on the file system.

Eventually, the standard output (which contains the progress outputs) is written to a file and when hundreds of instances are trying to write to a file every iteration this creates a congestion. The shared file system on any computing node is slow and does not work in parallel so each instance has to wait for the file system to be available.

We observed a loss of efficiency of up to 50%, so with this pull request we can expect up to a 50% improvement in performance on large simulations.  