### PR TITLE
New encrypted token to allow appveyor to push releases to Github

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ deploy:
   provider: GitHub
   description: "OpenMalaria build for Windows"
   auth_token:
-    secure: 55I3piJ00R39LqRqJWX+vq7gbt655ZSdBFhJWpcVX5cjTQJ4cPrzgz6TIKMXwXo6
+    secure: H6XDjpkpbS8cfYxfGwOwEDBQEuAqnIeDtnG3eHuqTf6gdOjge80AFM2h5iaqTLcw
   artifact: openMalaria-windows.zip
   draft: false
   prerelease: false


### PR DESCRIPTION
The previous token has expired and the even though the last build was successful, Appveyor was not authorized to upload the Windows release zip file to Github: https://github.com/SwissTPH/openmalaria/releases/tag/schema-46.0

This will fix the issue.