### PR TITLE
change CMake minimum version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright © 2005-2013 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 # Licence: GNU General Public Licence version 2 or later (see COPYING)
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.5)
 
 project (OpenMalaria CXX)
 


### PR DESCRIPTION
CMake will drop support for versions < 3.5 and suggests to change the minimum version to 3.5 (latest version is 3.29).

This does not change anything for OpenMalaria.