### PR TITLE
Update health system memory

### DIFF
--- a/model/Clinical/CM5DayCommon.cpp
+++ b/model/Clinical/CM5DayCommon.cpp
@@ -54,7 +54,6 @@ void CM5DayCommon::init(){
 // ———  per-human, construction and destruction  ———
 
 CM5DayCommon::CM5DayCommon (double tSF) :
-        m_tLastTreatment (sim::never()),
         m_treatmentSeekingFactor (tSF)
 {}
 

--- a/model/Clinical/CM5DayCommon.cpp
+++ b/model/Clinical/CM5DayCommon.cpp
@@ -61,9 +61,7 @@ CM5DayCommon::CM5DayCommon (double tSF) :
 
 // ———  per-human, update  ———
 
-void CM5DayCommon::doClinicalUpdate (Human& human, double ageYears) {
-    const bool isDoomed = doomed != NOT_DOOMED;
-    WithinHost::Pathogenesis::StatePair pg = human.withinHostModel->determineMorbidity( human, ageYears, isDoomed );
+void CM5DayCommon::doClinicalUpdate (Human& human, double ageYears, WithinHost::Pathogenesis::StatePair &pg) {
     Episode::State pgState = static_cast<Episode::State>( pg.state );
 
     if (pgState & Episode::MALARIA) {

--- a/model/Clinical/CM5DayCommon.h
+++ b/model/Clinical/CM5DayCommon.h
@@ -60,7 +60,7 @@ protected:
     static double cureRateSevere;
     static WithinHost::TreatmentId treatmentSevere;
     
-    virtual void doClinicalUpdate (Human& human, double ageYears);
+    virtual void doClinicalUpdate (Human& human, double ageYears, WithinHost::Pathogenesis::StatePair &pg);
 
     virtual void checkpoint (istream& stream);
     virtual void checkpoint (ostream& stream);

--- a/model/Clinical/CM5DayCommon.h
+++ b/model/Clinical/CM5DayCommon.h
@@ -67,9 +67,6 @@ protected:
 
     /** Called when a non-severe/complicated malaria sickness occurs. */
     virtual void uncomplicatedEvent(Human& human, Episode::State pgState) =0;
-    
-    /** Time of the last treatment (sim::never() if never treated). */
-    SimTime m_tLastTreatment = sim::never();
 
     //! treatment seeking for heterogeneity
     double m_treatmentSeekingFactor;

--- a/model/Clinical/CMDecisionTree.cpp
+++ b/model/Clinical/CMDecisionTree.cpp
@@ -161,14 +161,14 @@ private:
     const CMDecisionTree& negative;
 };
 
-class CMDTFever : public CMDecisionTree {
+class CMDTUncomplicated : public CMDecisionTree {
 public:
-    static const CMDecisionTree& create( const ::scnXml::DTFever& node, bool isUC );
+    static const CMDecisionTree& create( const ::scnXml::DTUncomplicated& node, bool isUC );
     
 protected:
     virtual bool operator==( const CMDecisionTree& that ) const{
         if( this == &that ) return true; // short cut: same object thus equivalent
-        const CMDTFever* p = dynamic_cast<const CMDTFever*>( &that );
+        const CMDTUncomplicated* p = dynamic_cast<const CMDTUncomplicated*>( &that );
         if( p == 0 ) return false;      // different type of node
         // if( diagnostic != p->diagnostic ) return false;
         if( positive != p->positive ) return false;
@@ -195,7 +195,7 @@ protected:
     }
     
 private:
-    CMDTFever(
+    CMDTUncomplicated(
         const SimTime lookBack,
         const CMDecisionTree& positive,
         const CMDecisionTree& negative ) :
@@ -576,7 +576,7 @@ const CMDecisionTree& CMDecisionTree::create( const scnXml::DecisionTree& node, 
     // branching nodes
     if( node.getCaseType().present() ) return CMDTCaseType::create( node.getCaseType().get(), isUC );
     if( node.getDiagnostic().present() ) return CMDTDiagnostic::create( node.getDiagnostic().get(), isUC );
-    if( node.getFever().present() ) return CMDTFever::create( node.getFever().get(), isUC );
+    if( node.getUncomplicated().present() ) return CMDTUncomplicated::create( node.getUncomplicated().get(), isUC );
     if( node.getComplicated().present() ) return CMDTComplicated::create( node.getComplicated().get(), isUC );
     if( node.getRandom().present() ) return CMDTRandom::create( node.getRandom().get(), isUC );
     if( node.getAge().present() ) return CMDTAge::create( node.getAge().get(), isUC );
@@ -601,8 +601,8 @@ const CMDecisionTree& CMDTMultiple::create( const scnXml::DTMultiple& node, bool
     for( const scnXml::DTDiagnostic& sn : node.getDiagnostic() ){
         self->children.push_back( &CMDTDiagnostic::create(sn, isUC) );
     }
-    for( const scnXml::DTFever& sn : node.getFever() ){
-        self->children.push_back( &CMDTFever::create(sn, isUC) );
+    for( const scnXml::DTUncomplicated& sn : node.getUncomplicated() ){
+        self->children.push_back( &CMDTUncomplicated::create(sn, isUC) );
     }
     for( const scnXml::DTComplicated& sn : node.getComplicated() ){
         self->children.push_back( &CMDTComplicated::create(sn, isUC) );
@@ -646,8 +646,8 @@ const CMDecisionTree& CMDTDiagnostic::create( const scnXml::DTDiagnostic& node, 
     ) );
 }
 
-const CMDecisionTree& CMDTFever::create( const scnXml::DTFever& node, bool isUC ){
-    return save_decision( new CMDTFever(
+const CMDecisionTree& CMDTUncomplicated::create( const scnXml::DTUncomplicated& node, bool isUC ){
+    return save_decision( new CMDTUncomplicated(
         UnitParse::readShortDuration(node.getLookBack(), UnitParse::STEPS),
         CMDecisionTree::create( node.getPositive(), isUC ),
         CMDecisionTree::create( node.getNegative(), isUC )

--- a/model/Clinical/ClinicalModel.cpp
+++ b/model/Clinical/ClinicalModel.cpp
@@ -155,7 +155,11 @@ void ClinicalModel::update (Human& human, double ageYears, bool newBorn) {
         }
     }
     
-    doClinicalUpdate (human, ageYears);
+    const bool isDoomed = doomed != NOT_DOOMED;
+    WithinHost::Pathogenesis::StatePair pg = human.withinHostModel->determineMorbidity( human, ageYears, isDoomed );
+    latestState = static_cast<Episode::State>(pg.state);
+
+    doClinicalUpdate (human, ageYears, pg);
 }
 
 void ClinicalModel::updateInfantDeaths( SimTime age ){

--- a/model/Clinical/ClinicalModel.h
+++ b/model/Clinical/ClinicalModel.h
@@ -106,6 +106,9 @@ public:
         return latestReport;
     }
     
+    inline const Episode::State &getLatestState () const{
+        return latestState;
+    }
     
     /// Checkpointing
     template<class S>
@@ -123,13 +126,14 @@ protected:
      * @param hostTransmission per-host transmission data of human.
      * @param ageYears Age of human.
      * @param ageGroup Survey age group of human. */
-    virtual void doClinicalUpdate (Human& human, double ageYears) =0;
+    virtual void doClinicalUpdate (Human& human, double ageYears, WithinHost::Pathogenesis::StatePair &pg) =0;
     
     virtual void checkpoint (istream& stream);
     virtual void checkpoint (ostream& stream);
     
     /** Last episode; report to survey pending a new episode or human's death. */
     Episode latestReport;
+    Episode::State latestState;
     
     /** @brief Positive values of _doomed variable (codes). */
     enum {

--- a/model/Clinical/ClinicalModel.h
+++ b/model/Clinical/ClinicalModel.h
@@ -115,6 +115,9 @@ public:
     void operator& (S& stream) {
         checkpoint (stream);
     }
+
+    /** Time of the last treatment (sim::never() if never treated). */
+    SimTime m_tLastTreatment = sim::never();
     
 protected:
     /// Constructor.
@@ -134,7 +137,7 @@ protected:
     /** Last episode; report to survey pending a new episode or human's death. */
     Episode latestReport;
     Episode::State latestState;
-    
+
     /** @brief Positive values of _doomed variable (codes). */
     enum {
         DOOMED_EXPIRED = -35,   // codes less than or equal to this mean "dead now"

--- a/model/Clinical/DecisionTree5Day.cpp
+++ b/model/Clinical/DecisionTree5Day.cpp
@@ -77,16 +77,16 @@ void DecisionTree5Day::setHealthSystem(const scnXml::HSDT5Day& hsDescription){
 
 // ———  per-human, update  ———
 
-void DecisionTree5Day::uncomplicatedEvent ( Human& human, Episode::State pgState ){
-    latestReport.update (human, Episode::State( pgState ) );
-    
+void DecisionTree5Day::uncomplicatedEvent ( Human& human, Episode::State pgState ){    
     // If last treatment prescribed was in recent memory, consider second line.
     CaseType regimen = FirstLine;
     if (m_tLastTreatment + healthSystemMemory > sim::ts0()){
         pgState = Episode::State (pgState | Episode::SECOND_CASE);
         regimen = SecondLine;
     }
-    
+
+    latestReport.update (human, Episode::State( pgState ) );
+
     double x = human.rng.uniform_01();
     if( x < accessUCAny[regimen] * m_treatmentSeekingFactor ){
         CMHostData hostData( human, sim::inYears(human.age(sim::ts0())), pgState );

--- a/model/Clinical/Episode.cpp
+++ b/model/Clinical/Episode.cpp
@@ -39,7 +39,7 @@ void Episode::flush() {
 
 void Episode::update (const Host::Human& human, Episode::State newState)
 {
-    if( time + ClinicalModel::hsMemory() < sim::ts0() ){
+    if( time + ClinicalModel::hsMemory() <= sim::ts0() ){
         report ();
 
         time = sim::ts0();

--- a/model/Clinical/EventScheduler.cpp
+++ b/model/Clinical/EventScheduler.cpp
@@ -159,12 +159,8 @@ bool ClinicalEventScheduler::isExistingCase() {
         return sim::now() > timeLastTreatment && sim::now() <= timeLastTreatment + healthSystemMemory;
 }
 
-void ClinicalEventScheduler::doClinicalUpdate (Human& human, double ageYears){
+void ClinicalEventScheduler::doClinicalUpdate (Human& human, double ageYears, WithinHost::Pathogenesis::StatePair &pg){
     WHInterface& withinHostModel = *human.withinHostModel;
-    // Run pathogenesisModel
-    // Note: we use Episode::COMPLICATED instead of Episode::SEVERE.
-    const bool isDoomed = doomed != NOT_DOOMED;
-    WithinHost::Pathogenesis::StatePair pg = human.withinHostModel->determineMorbidity( human, ageYears, isDoomed );
     Episode::State newState = static_cast<Episode::State>( pg.state );
     util::streamValidate( (newState << 16) & pgState );
     

--- a/model/Clinical/EventScheduler.h
+++ b/model/Clinical/EventScheduler.h
@@ -52,7 +52,7 @@ public:
     virtual bool isExistingCase();
 
 protected:
-    virtual void doClinicalUpdate (Human& human, double ageYears);
+    virtual void doClinicalUpdate (Human& human, double ageYears, WithinHost::Pathogenesis::StatePair &pg);
 
     virtual void checkpoint (istream& stream);
     virtual void checkpoint (ostream& stream);

--- a/model/Clinical/ImmediateOutcomes.cpp
+++ b/model/Clinical/ImmediateOutcomes.cpp
@@ -174,12 +174,15 @@ void ImmediateOutcomes::uncomplicatedEvent (
     Human& human,
     Episode::State pgState
 ) {
+    // If last treatment prescribed was in recent memory, consider second line.
+    CaseType regimen = FirstLine;
+    if (m_tLastTreatment + healthSystemMemory > sim::ts0()){
+        pgState = Episode::State (pgState | Episode::SECOND_CASE);
+        regimen = SecondLine;
+    }
+
     latestReport.update (human, Episode::State( pgState ) );
 
-    // If last treatment prescribed was in recent memory, consider second line.
-    CaseType regimen = (m_tLastTreatment + healthSystemMemory > sim::ts0()) ?
-        SecondLine : FirstLine;
-    
     double x = human.rng.uniform_01();
     if( x < accessUCAny[regimen] * m_treatmentSeekingFactor ){
         // UC1: official care OR self treatment

--- a/model/interventions/HumanInterventionComponents.hpp
+++ b/model/interventions/HumanInterventionComponents.hpp
@@ -326,7 +326,7 @@ public:
     void deploy( Human& human, mon::Deploy::Method method, VaccineLimits )const{
         Clinical::CMDTOut out = tree.exec( Clinical::CMHostData(human,
                 sim::inYears(human.age(sim::nowOrTs1())),
-                human.clinicalModel->getLatestReport().state) );
+                human.clinicalModel->getLatestState()) );
         if( out.treated ){
             mon::reportEventMHD( mon::MHD_TREAT, human, method );
         }

--- a/model/interventions/HumanInterventionComponents.hpp
+++ b/model/interventions/HumanInterventionComponents.hpp
@@ -326,7 +326,7 @@ public:
     void deploy( Human& human, mon::Deploy::Method method, VaccineLimits )const{
         Clinical::CMDTOut out = tree.exec( Clinical::CMHostData(human,
                 sim::inYears(human.age(sim::nowOrTs1())),
-                Clinical::Episode::NONE /*parameter not needed*/) );
+                human.clinicalModel->getLatestReport().state) );
         if( out.treated ){
             mon::reportEventMHD( mon::MHD_TREAT, human, method );
         }

--- a/schema/healthSystem.xsd
+++ b/schema/healthSystem.xsd
@@ -674,6 +674,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <xs:element name="caseType" type="om:DTCaseType"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic"/>
    <xs:element name="fever" type="om:DTFever"/>
+   <xs:element name="complicated" type="om:DTComplicated"/>
    <xs:element name="random" type="om:DTRandom"/>
    <xs:element name="age" type="om:DTAge"/>
    <!-- actions -->
@@ -712,6 +713,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <xs:element name="caseType" type="om:DTCaseType" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="fever" type="om:DTFever" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="complicated" type="om:DTComplicated" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="random" type="om:DTRandom" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="age" type="om:DTAge" minOccurs="0" maxOccurs="unbounded"/>
    <!-- actions -->
@@ -783,6 +785,40 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
   </xs:attribute>
  </xs:complexType>
  <xs:complexType name="DTFever">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on the outcome
+        of some type of diagnostic.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (diagnostic);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="positive" type="om:DecisionTree"/>
+   <xs:element name="negative" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="lookBack" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Follow-up period during which a recurrence is
+          considered to be a treatment failure
+          
+          Can be specified in steps (e.g. 6t) or days (e.g. 28d).
+        </xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to steps);
+          name:Number of days to look back for fevers. This must be less than or equal to the healthsystem memory parameter. In general, this should be less than or equal to the repeatStep in MSAT with contiuous deployment;
+        </xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTComplicated">
   <xs:annotation>
    <xs:documentation>
         A switch which choses a branch deterministically, based on the outcome

--- a/schema/healthSystem.xsd
+++ b/schema/healthSystem.xsd
@@ -673,7 +673,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <!-- branching points -->
    <xs:element name="caseType" type="om:DTCaseType"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic"/>
-   <xs:element name="fever" type="om:DTFever"/>
+   <xs:element name="uncomplicated" type="om:DTUncomplicated"/>
    <xs:element name="complicated" type="om:DTComplicated"/>
    <xs:element name="random" type="om:DTRandom"/>
    <xs:element name="age" type="om:DTAge"/>
@@ -712,7 +712,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <!-- branching points -->
    <xs:element name="caseType" type="om:DTCaseType" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic" minOccurs="0" maxOccurs="unbounded"/>
-   <xs:element name="fever" type="om:DTFever" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="uncomplicated" type="om:DTUncomplicated" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="complicated" type="om:DTComplicated" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="random" type="om:DTRandom" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="age" type="om:DTAge" minOccurs="0" maxOccurs="unbounded"/>
@@ -784,7 +784,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    </xs:annotation>
   </xs:attribute>
  </xs:complexType>
- <xs:complexType name="DTFever">
+ <xs:complexType name="DTUncomplicated">
   <xs:annotation>
    <xs:documentation>
         A switch which choses a branch deterministically, based on the outcome

--- a/schema/healthSystem.xsd
+++ b/schema/healthSystem.xsd
@@ -805,7 +805,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     <xs:appinfo>name:Name;</xs:appinfo>
    </xs:annotation>
   </xs:attribute>
-  <xs:attribute name="lookBack" type="xs:string" use="required">
+  <xs:attribute name="memory" type="xs:string" use="optional" default="1">
    <xs:annotation>
     <xs:documentation>
           Follow-up period during which a recurrence is
@@ -838,7 +838,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     <xs:appinfo>name:Name;</xs:appinfo>
    </xs:annotation>
   </xs:attribute>
-  <xs:attribute name="lookBack" type="xs:string" use="required">
+  <xs:attribute name="memory" type="xs:string" use="optional">
    <xs:annotation>
     <xs:documentation>
           Follow-up period during which a recurrence is

--- a/schema/healthSystem.xsd
+++ b/schema/healthSystem.xsd
@@ -674,7 +674,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <xs:element name="caseType" type="om:DTCaseType"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic"/>
    <xs:element name="uncomplicated" type="om:DTUncomplicated"/>
-   <xs:element name="complicated" type="om:DTComplicated"/>
+   <xs:element name="severe" type="om:DTSevere"/>
    <xs:element name="random" type="om:DTRandom"/>
    <xs:element name="age" type="om:DTAge"/>
    <!-- actions -->
@@ -683,7 +683,8 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <xs:element name="treatFailure" type="om:DTTreatFailure"/>
    <xs:element name="treatPKPD" type="om:DTTreatPKPD" maxOccurs="unbounded"/>
    <xs:element name="treatSimple" type="om:DTTreatSimple" maxOccurs="unbounded"/>
-   <xs:element name="deploy" type="om:DTDeploy" maxOccurs="unbounded"/>
+   <xs:element name="deploy" type="om:DTDeploy" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="cohort" type="om:DTCohort"/>
   </xs:choice>
   <xs:attribute name="name" type="xs:string" use="optional">
    <xs:annotation>
@@ -713,7 +714,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <xs:element name="caseType" type="om:DTCaseType" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="uncomplicated" type="om:DTUncomplicated" minOccurs="0" maxOccurs="unbounded"/>
-   <xs:element name="complicated" type="om:DTComplicated" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="severe" type="om:DTSevere" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="random" type="om:DTRandom" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="age" type="om:DTAge" minOccurs="0" maxOccurs="unbounded"/>
    <!-- actions -->
@@ -721,6 +722,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <xs:element name="treatSimple" type="om:DTTreatSimple" minOccurs="0"/>
    <xs:element name="deploy" type="om:DTDeploy" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="report" type="om:DTReport" maxOccurs="unbounded" minOccurs="0"/>
+   <xs:element name="cohort" type="om:DTCohort" minOccurs="0" maxOccurs="unbounded"/>
   </xs:choice>
   <xs:attribute name="name" type="xs:string" use="optional">
    <xs:annotation>
@@ -787,10 +789,9 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
  <xs:complexType name="DTUncomplicated">
   <xs:annotation>
    <xs:documentation>
-        A switch which choses a branch deterministically, based on the outcome
-        of some type of diagnostic.
+        A switch which choses a branch deterministically, based on whether the host has an uncomplicated case. This could be a Malaria fever or a non-Malaria fever. If non-Malaria fevers are enable, it is possible to add a &lt;diagnostic&gt; node.
       </xs:documentation>
-   <xs:appinfo>name:Switch (diagnostic);</xs:appinfo>
+   <xs:appinfo>name:Switch (uncomplicated);</xs:appinfo>
   </xs:annotation>
   <xs:all>
    <xs:element name="positive" type="om:DecisionTree"/>
@@ -818,13 +819,12 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    </xs:annotation>
   </xs:attribute>
  </xs:complexType>
- <xs:complexType name="DTComplicated">
+ <xs:complexType name="DTSevere">
   <xs:annotation>
    <xs:documentation>
-        A switch which choses a branch deterministically, based on the outcome
-        of some type of diagnostic.
+        A switch which choses a branch deterministically, based on whether the host has a severe case or not. Note that this include severe cases due to comorbidities.
       </xs:documentation>
-   <xs:appinfo>name:Switch (diagnostic);</xs:appinfo>
+   <xs:appinfo>name:Switch (severe);</xs:appinfo>
   </xs:annotation>
   <xs:all>
    <xs:element name="positive" type="om:DecisionTree"/>
@@ -1099,6 +1099,39 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
           The identifier (short name) of a component.
         </xs:documentation>
     <xs:appinfo>name:Component identifier;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTCohort">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on whether the host is part of the cohort (defined by the intervention component) or not.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (cohort);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="positive" type="om:DecisionTree"/>
+   <xs:element name="negative" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="component" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Follow-up period during which a recurrence is
+          considered to be a treatment failure
+          
+          Can be specified in steps (e.g. 6t) or days (e.g. 28d).
+        </xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to steps);
+          name:Number of days to look back for fevers. This must be less than or equal to the healthsystem memory parameter. In general, this should be less than or equal to the repeatStep in MSAT with contiuous deployment;
+        </xs:appinfo>
    </xs:annotation>
   </xs:attribute>
  </xs:complexType>

--- a/test/scenarioDecisionTree5DayDielmo.xml
+++ b/test/scenarioDecisionTree5DayDielmo.xml
@@ -81,7 +81,7 @@
               </negative>
             </diagnostic>
 
-            <fever lookBack="5d">
+            <uncomplicated>
               <positive>
                 <multiple>
                   <!-- Treat 87.2% as in the original study, but report all -->
@@ -99,8 +99,7 @@
               <negative>
                 <noTreatment/>
               </negative>
-            </fever>
-
+            </uncomplicated>
           </multiple>
         </decisionTree>
       </component>


### PR DESCRIPTION
The clinical element currently simply has a healthSystemMemory attribute: if, when a sickness bout occurs, the previous episode was less than or equal to this many time-steps ago, the new bout is considered a second case (second-line treatment may be used and the two bouts will likely be reported as a single episode). The healthSystemMemory is defined in time steps. 

Currently in the 5 day model, a value of 6 corresponds to 35 days (not the 30 days previously claimed).

This pull request will make a value of 6 correspond to 30 days.