### PR TITLE
add model option for health system memory fix, true by default

### DIFF
--- a/model/Clinical/Episode.cpp
+++ b/model/Clinical/Episode.cpp
@@ -40,7 +40,14 @@ void Episode::flush() {
 
 void Episode::update (const Host::Human& human, Episode::State newState)
 {
-    if( time + ClinicalModel::hsMemory() <= sim::ts0() ){
+    bool toReport = false;
+
+    if (healthSystemMemoryFix && (time + ClinicalModel::hsMemory() <= sim::ts0()))
+        toReport = true;
+    else if (!healthSystemMemoryFix && (time + ClinicalModel::hsMemory() < sim::ts0()))
+        toReport = true;
+
+    if(toReport) {
         infectionType = human.withinHostModel->getInfectionType();
 
         report ();

--- a/model/Clinical/Episode.h
+++ b/model/Clinical/Episode.h
@@ -27,6 +27,7 @@
 #include "Host/WithinHost/Infection/Infection.h"
 #include "mon/AgeGroup.h"
 #include "mon/info.h"
+#include "util/ModelOptions.h"
 #include <ostream>
 
 namespace OM {
@@ -85,7 +86,10 @@ public:
             ageGroup(),
             cohortSet(0),
             state(NONE)
-    {};
+    {
+        healthSystemMemoryFix = util::ModelOptions::option (util::HEALTH_SYSTEM_MEMORY_FIX);
+    };
+
   ~Episode();
     
     /// Report anything pending, as on destruction
@@ -124,6 +128,8 @@ private:
      * hospital, i.e. with EVENT_IN_HOSPITAL, only), SEQUELAE and DIRECT_DEATH
      * (both in and out of hospital). */
     void report();
+
+    bool healthSystemMemoryFix = false;
 };
 
 } }

--- a/model/util/ModelOptions.cpp
+++ b/model/util/ModelOptions.cpp
@@ -78,6 +78,7 @@ namespace OM { namespace util {
         codeMap["INDIRECT_MORTALITY_FIX"] = INDIRECT_MORTALITY_FIX;
         codeMap["VACCINE_GENOTYPE"] = VACCINE_GENOTYPE;
         codeMap["CFR_PF_USE_HOSPITAL"] = CFR_PF_USE_HOSPITAL;
+        codeMap["HEALTH_SYSTEM_MEMORY_FIX"] = HEALTH_SYSTEM_MEMORY_FIX;
 	}
 	
 	OptionCodes operator[] (const string s) {
@@ -120,8 +121,9 @@ namespace OM { namespace util {
 	// State of all default options:
 	bitset<NUM_OPTIONS> defaultOptSet;
 	defaultOptSet.set (MAX_DENS_CORRECTION);
-        defaultOptSet.set (INNATE_MAX_DENS);
-        defaultOptSet.set (INDIRECT_MORTALITY_FIX);
+    defaultOptSet.set (INNATE_MAX_DENS);
+    defaultOptSet.set (INDIRECT_MORTALITY_FIX);
+    defaultOptSet.set (HEALTH_SYSTEM_MEMORY_FIX);
 	
 	// Set options to defaults, then override any given in the XML file:
 	options = defaultOptSet;

--- a/model/util/ModelOptions.h
+++ b/model/util/ModelOptions.h
@@ -256,6 +256,15 @@ namespace OM { namespace util {
      	 */
         VACCINE_GENOTYPE,
 
+        /** This makes the health system memory behaves as expected. With this
+         * option, specifying a health system memory of 30 days means that a 
+         * new clinical case will be reported as early as 30 days after the 
+         * initial case (6 time-steps), rather than 35d (7 time-steps) 
+         * currently. Setting the health system memory to 5 days allows the 
+         * model to report a new clinical case every time step.
+         */
+        HEALTH_SYSTEM_MEMORY_FIX,
+
         
 	// Used by tests; should be 1 more than largest option
 	NUM_OPTIONS,

--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -272,6 +272,7 @@
         <ModelOptions>
             <option name="INNATE_MAX_DENS" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
             <option name="INDIRECT_MORTALITY_FIX" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
+            <option name="HEALTH_SYSTEM_MEMORY_FIX" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
         </ModelOptions>
 
         <!-- Clinical model parameters.


### PR DESCRIPTION
Add the following model option:

```
HEALTH_SYSTEM_MEMORY_FIX
```

This option is set to true by default. It must be set to false if used with the current base model:

```
<option name="HEALTH_SYSTEM_MEMORY_FIX" value="false"/>
```

This makes the health system memory behaves as expected. With this option, specifying a health system memory of 30 days means that a new clinical case will be reported as early as 30 days after the initial case (6 time-steps), rather than 35d (7 time-steps) currently. With this option, setting the health system memory to 5 days allows the model to report a new clinical case every time step.