### PR TITLE
Schema-47.0

### DIFF
--- a/model/util/DocumentLoader.h
+++ b/model/util/DocumentLoader.h
@@ -34,7 +34,7 @@ namespace OM
 { 
     namespace util
     {
-        static const int SCHEMA_VERSION = 46;
+        static const int SCHEMA_VERSION = 47;
 
         unique_ptr<scnXml::Scenario> loadScenario(std::string lXmlFile);
     }

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -27,7 +27,7 @@ foreach (XSD_NAME ${SCHEMA_NAMES})
     COMMAND ${XSD_EXECUTABLE} cxx-tree
         --std c++11
         --type-naming ucc --function-naming java
-        --namespace-map http://openmalaria.org/schema/scenario_46=scnXml
+        --namespace-map http://openmalaria.org/schema/scenario_47=scnXml
 #         --generate-serialization
         --generate-doxygen
         --generate-intellisense

--- a/schema/demography.xsd
+++ b/schema/demography.xsd
@@ -2,8 +2,8 @@
 <!-- Schema for OpenMalaria input documents
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46"
-           xmlns:om="http://openmalaria.org/schema/scenario_46"
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47"
+           xmlns:om="http://openmalaria.org/schema/scenario_47"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <!---HumanPopulationStructure-->
   <xs:complexType name="Demography">

--- a/schema/entomology.xsd
+++ b/schema/entomology.xsd
@@ -2,8 +2,8 @@
 <!-- Schema for OpenMalaria input documents
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46"
-           xmlns:om="http://openmalaria.org/schema/scenario_46"
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47"
+           xmlns:om="http://openmalaria.org/schema/scenario_47"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="util.xsd"/>
   <xs:complexType name="Entomology">

--- a/schema/healthSystem.xsd
+++ b/schema/healthSystem.xsd
@@ -3,7 +3,7 @@
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
 <!-- HealthSystem & Clinical data -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46" xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47" xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xs="http://www.w3.org/2001/XMLSchema">
  <xs:include schemaLocation="util.xsd"/>
  <!-- root element for clinical data outside the healthSystem element -->
  <xs:complexType name="Clinical">

--- a/schema/interventions.xsd
+++ b/schema/interventions.xsd
@@ -2,7 +2,7 @@
 <!-- Schema for OpenMalaria input documents
 Copyright © 2005-2012 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46" xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47" xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xs="http://www.w3.org/2001/XMLSchema">
  <xs:include schemaLocation="healthSystem.xsd"/>
  <xs:include schemaLocation="entomology.xsd"/>
  <xs:include schemaLocation="util.xsd"/>

--- a/schema/monitoring.xsd
+++ b/schema/monitoring.xsd
@@ -2,8 +2,8 @@
 <!-- Schema for OpenMalaria input documents
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46"
-           xmlns:om="http://openmalaria.org/schema/scenario_46"
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47"
+           xmlns:om="http://openmalaria.org/schema/scenario_47"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="util.xsd"/>
   <xs:complexType name="Monitoring">

--- a/schema/pharmacology.xsd
+++ b/schema/pharmacology.xsd
@@ -3,7 +3,7 @@
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
 <!-- Drug parameters — PK, PD and resistance -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46" xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47" xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xs="http://www.w3.org/2001/XMLSchema">
  <xs:include schemaLocation="util.xsd"/>
  <xs:complexType name="Pharmacology">
   <xs:annotation>

--- a/schema/scenario.xsd
+++ b/schema/scenario.xsd
@@ -2,8 +2,8 @@
 <!-- Schema for OpenMalaria input documents
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46"
-           xmlns:om="http://openmalaria.org/schema/scenario_46"
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47"
+           xmlns:om="http://openmalaria.org/schema/scenario_47"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="demography.xsd"/>
   <xs:include schemaLocation="monitoring.xsd"/>

--- a/schema/scenario_46.xsd
+++ b/schema/scenario_46.xsd
@@ -1,4 +1,4 @@
-<xs:schema xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://openmalaria.org/schema/scenario_46">
+<xs:schema xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://openmalaria.org/schema/scenario_47">
   
   
   

--- a/schema/scenario_47.xsd
+++ b/schema/scenario_47.xsd
@@ -1,0 +1,6541 @@
+<xs:schema xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://openmalaria.org/schema/scenario_47">
+  
+  
+  
+  
+  
+  
+  <xs:element name="scenario">
+    <xs:annotation>
+      <xs:documentation>Description of scenario</xs:documentation>
+      <xs:appinfo>name:Scenario;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="demography" type="om:Demography">
+          <xs:annotation>
+            <xs:documentation>
+              Description of demography
+            </xs:documentation>
+            <xs:appinfo>name:Human age distribution;</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="monitoring" type="om:Monitoring">
+          <xs:annotation>
+            <xs:documentation>
+              Description of surveys
+            </xs:documentation>
+            <xs:appinfo>name:Measures to be reported;</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="interventions" type="om:Interventions">
+          <xs:annotation>
+            <xs:documentation>
+              List of interventions. Generally these are either point-time
+              distributions of something to some subset of the population, or
+              continuous-time distribution targetting individuals when they
+              reach a certain age.
+            </xs:documentation>
+            <xs:appinfo>name:Preventative interventions;</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="healthSystem" type="om:HealthSystem">
+          <xs:annotation>
+            <xs:documentation>
+              Description of health system.
+            </xs:documentation>
+            <xs:appinfo>name:Health system description;</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="entomology" type="om:Entomology">
+          <xs:annotation>
+            <xs:documentation>
+              Description of entomological data
+            </xs:documentation>
+            <xs:appinfo>name:Transmission and vector bionomics;</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="parasiteGenetics" type="om:ParasiteGenetics" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              A specification of genotypes of infection parasites.
+              
+              May be omitted; in this case there is no modelling of genetic
+              differences of infections (resistance, fitness).
+            </xs:documentation>
+            <xs:appinfo>name:Parasite genetics;</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="pharmacology" type="om:Pharmacology" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              Drug model parameters and drug usage parameters
+            </xs:documentation>
+            <xs:appinfo>name:Drug parameters (PK, PD and usage);</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="diagnostics" type="om:Diagnostics" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>
+              Diagnostic model parameters
+            </xs:documentation>
+            <xs:appinfo>name:Diagnostic parameters;</xs:appinfo>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="model">
+          <xs:annotation>
+            <xs:documentation>
+            Encapsulation of all parameters which describe the model according
+            to which fitting is done.
+            </xs:documentation>
+            <xs:appinfo>name:Model options and parameters;</xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:all>
+              <xs:element name="ModelOptions" type="om:OptionSet">
+                <xs:annotation>
+                  <xs:documentation>
+                    All model options (bug fixes, choices between models, etc.).                    
+                    The list of recognised options can be found in the code at:
+                    model/util/ModelOptions.h and should also be in the wiki.
+                  </xs:documentation>
+                  <xs:appinfo>name:Model Options;</xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="clinical" type="om:Clinical"/>
+              <xs:element name="human" type="om:Human"/>
+              <xs:element name="vivax" type="om:Vivax" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>
+                    This describes Vivax model parameters, and is required when using the
+                    VIVAX_SIMPLE_MODEL model option.
+                  </xs:documentation>
+                  <xs:appinfo>name:Vivax model parameters;</xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="parameters" type="om:Parameters">
+                <xs:annotation>
+                  <xs:documentation>
+                    Parameters of the epidemiological model
+                  </xs:documentation>
+                  <xs:appinfo>name:Parameters of the model of epidemiology;</xs:appinfo>
+                </xs:annotation>
+              </xs:element>
+            </xs:all>
+          </xs:complexType>
+        </xs:element>
+      </xs:all>
+      <xs:attribute name="schemaVersion" type="xs:int" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Version of xml schema. If not equal to the current version
+            an error is thrown. Use SchemaTranslator to update xml files.
+          </xs:documentation>
+          <xs:appinfo>name:Version of the xml schema;exposed:false;</xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="analysisNo" type="xs:int" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            Unique identifier of scenario
+          </xs:documentation>
+          <xs:appinfo>units: Number;min:1;max:100000000;name:Reference number of the analysis;exposed:false;
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Name of intervention
+          </xs:documentation>
+          <xs:appinfo>name:Name of intervention;</xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="wuID" type="xs:int" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            Work unit ID. Obselete and no longer required.
+          </xs:documentation>
+          <xs:appinfo>
+            units:Number;name:Work unit identifier;exposed:false;
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!--Parameters-->
+  <xs:complexType name="Parameter">
+    <xs:attribute name="name" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Name of parameter</xs:documentation>
+        <xs:appinfo>units:string;name:Name of parameter;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="number" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Reference number of input parameter
+        </xs:documentation>
+        <xs:appinfo>units:Number;min:1;max:100;name:Parameter number;exposed:false;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="value" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>Parameter value</xs:documentation>
+        <xs:appinfo>units:Number;min:0;name:Parameter value;sweepable:true;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="include" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          True if parameter is to be sampled in optimization
+          runs. Not used in simulator app.
+        </xs:documentation>
+        <xs:appinfo>units:Number;min:0;max:1;name:Sampling indicator;exposed:false;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="Parameters">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="parameter" type="om:Parameter"/>
+    </xs:sequence>
+    <xs:attribute name="interval" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation>Simulation step</xs:documentation>
+        <xs:appinfo>units:Days;name:Simulation step;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="iseed" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation>Seed for RNG</xs:documentation>
+        <xs:appinfo>units:Number;name:Random number seed;sweepable:true;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="latentp" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Pre-erythrocytic latent period
+          
+          Can be specified in steps (e.g. 3t) or days (e.g. 15d).
+        </xs:documentation>
+        <xs:appinfo>units:User defined (default: steps);min:0;max:20;name:Pre-erythrocytic latent period;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- Host data -->
+  <xs:complexType name="Human">
+    <xs:annotation>
+      <xs:documentation>
+        Parameters of host models.
+      </xs:documentation>
+      <xs:appinfo>name:Human;</xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="availabilityToMosquitoes" type="om:AgeGroupValues">
+        <xs:annotation>
+          <xs:documentation>
+            Availability of humans to mosquitoes relative to an adult, categorized by age group
+          </xs:documentation>
+          <xs:appinfo>name:Availability to mosquitoes;units:None;min:0;max:1;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="weight" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            By age group data on human weight (mass).
+          </xs:documentation>
+          <xs:appinfo>name:Weight;units:kg;min:0</xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="om:AgeGroupValues">
+              <xs:attribute name="multStdDev" type="xs:double" use="required">
+                <xs:annotation>
+                  <xs:documentation>
+                    Each human is assigned a weight multiplier from a normal distribution
+                    with mean 1 and this standard deviation at birth. His/her weight
+                    is this multiplier times the mean from age distribution.
+                    A standard deviation of zero for no heterogeneity is valid; a rough
+                    value from Tanzanian data is 0.14.
+                  </xs:documentation>
+                  <xs:appinfo>name:Standard deviation;units:None;min:0</xs:appinfo>
+                </xs:annotation>
+              </xs:attribute>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="ParasiteGenetics">
+    <xs:sequence>
+      <xs:element name="locus" type="om:ParasiteLocus" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Describes a locus, or a point at which an infection may
+            vary. The genotype of an infection is determined by
+            choosing one allele at each locus. Initial frequencies of
+            alleles are specified independently for each locus, but
+            subsequent infections are selected according to success of
+            genotypes.
+            
+            Alleles at loci can affect fitness and resistance to any
+            number of drugs.
+          </xs:documentation>
+          <xs:appinfo>name:Locus;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="samplingMode" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          This controls how genotypes are determined for new infections during
+          the intervention period. Prior to this (in initialisation phases),
+          genotypes are always sampled using the specified initial frequencies.
+          
+          Mode &quot;initial&quot; continues to sample genotypes using initial
+          frequencies (i.e. independent of the success of parent generations of
+          parasites).
+          
+          Mode &quot;tracking&quot; samples genotypes based on the success parent
+          generations of parasites have in infecting mosquitoes, tracked per
+          genotype.
+          
+          It is possible that in the future a recombination option will be
+          added to this list, however designing a suitable model is not
+          trivial.
+        </xs:documentation>
+        <xs:appinfo>Name:Sampling mode;</xs:appinfo>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="initial"/>
+          <xs:enumeration value="tracking"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="ParasiteGenotype">
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Name of the genotype; used to refer to it elsewhere.
+        </xs:documentation>
+        <xs:appinfo>name:Name (for reference purposes);</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="initialFrequency" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Specification of how commonly this genotype occurs during
+          initialisation phases of the simulation relative to other genotypes.
+        </xs:documentation>
+        <xs:appinfo>name:Initial frequency;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fitness" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Fitness factor of the genotype. This is multiplication factor used to
+          speed up or slow down replication of parasites.
+          
+          For example, if a genotype has a fitness factor of 0.8, then the
+          parasites with this genotype will replicate 20% slower in the host
+          than the baseline.
+        </xs:documentation>
+        <xs:appinfo>name:Fitness factor;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="ParasiteLocus">
+    <xs:sequence>
+      <xs:element name="allele" type="om:ParasiteAllele" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            Describes an allele, or one possible genetic option
+            of multiple at one point of variance.
+          </xs:documentation>
+          <xs:appinfo>name:Allele;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>Name of the Locus</xs:documentation>
+        <xs:appinfo>name:Name of locus;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="ParasiteAllele">
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Name of the allele; used to refer to it elsewhere.
+        </xs:documentation>
+        <xs:appinfo>name:Name;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="initialFrequency" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Specification of how commonly this allele occurs during warmup
+          relative to other alleles of the same locus.
+          
+          During the simulation's initialisation phases, the frequency at which
+          each allele of each locus occurs is fixed. After the initialisation
+          phase, frequency of alleles is modelled as an emergent property of
+          the success of genotypes.
+        </xs:documentation>
+        <xs:appinfo>name:Initial frequency;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fitness" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Fitness factor of the allele. This is multiplication factor used to
+          speed up or slow down replication of parasites.
+          
+          For example, if a genotype has an allele with a fitness factor of 1
+          at one locus and another allele with a fitness factor of 0.8 at a
+          second locus, then the parasites with the genotype will replicate 20%
+          slower than the baseline.
+        </xs:documentation>
+        <xs:appinfo>name:Fitness factor;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="hrp2_deletion" type="xs:boolean" default="false">
+      <xs:annotation>
+        <xs:documentation>
+          If true, marks this allele as having deleted HRP2.
+          
+          The effect on the simulation is that any diagnostic dependent on HRP2
+          behaves as if infections with deleted HRP2 have density 0.
+          
+          A diagnostic MUST explicitly set mechanism=&quot;HRP2&quot; for this to have any
+          effect.
+        </xs:documentation>
+        <xs:appinfo>name:HRP2 deletion;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
+  <xs:complexType name="Diagnostics">
+    <xs:sequence>
+      <xs:element name="diagnostic" type="om:Diagnostic" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Diagnostic">
+    <!-- Description of a generic parasitaemia diagnostic. -->
+    <!-- Garki/non-Garki measurement biases are not taken into account by this
+      code; the effect could be included via parameterisation or via adjusting
+      input density. -->
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="deterministic">
+          <xs:annotation>
+            <xs:documentation>
+              Specify that an artificial deterministic test is used: outcome is
+              positive if parasite density is at least the minimum given.
+            </xs:documentation>
+            <xs:appinfo>name:Deterministic detection;</xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="minDensity" type="xs:double" use="required">
+              <xs:annotation>
+                <xs:documentation>
+                  The minimum density at which parasites can be detected. If 0,
+                  the test outcome is always positive.
+                </xs:documentation>
+                <xs:appinfo>name:Minimum detectible density;units:parasites/microlitre;min:0;</xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="stochastic">
+          <xs:annotation>
+            <xs:documentation>
+              An improved model of detection which is non-deterministic, including
+              false positive results as well as false negatives.
+              
+              The probability of a positive outcome is modelled as 1 + s×(x/(x+d) - 1)
+              where x is the parasite density, d is the density at which the test outcome
+              has a 50% chance of being positive, and s is the probability of a positive
+              outcome given no parasites (the specificity).
+              
+              Some parameterisations:
+              
+              Microscopy sensitivity/specificity data in Africa;
+              Source: expert opinion — Allan Schapira
+                dens_50 = 20.0
+                specificity = .75
+              
+              RDT sensitivity/specificity for Plasmodium falciparum in Africa
+              Source: Murray et al (Clinical Microbiological Reviews, Jan. 2008)
+                dens_50 = 50.0;
+                specificity = .942;
+            </xs:documentation>
+            <xs:appinfo>name:Non-deterministic detection</xs:appinfo>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="dens_50" type="xs:double" use="required">
+              <xs:annotation>
+                <xs:documentation>
+                  The density at which the test outcome has a 50% chance of being positive.
+                </xs:documentation>
+                <xs:appinfo>name:Density 50;units:parasites/microlitre;min:0;</xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="specificity" type="xs:double" use="required">
+              <xs:annotation>
+                <xs:documentation>
+                  The probability of a positive test outcome in the absense of parasites.
+                </xs:documentation>
+                <xs:appinfo>units:Dimensionless;name:Specificity;min:0;max:1;</xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Name of this diagnostic (parameterisation). May be used elsewhere in
+          the XML document to refer to this set of diagnostic parameters.
+        </xs:documentation>
+        <xs:appinfo>name:Name of diagnostic;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="units" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Parasite densities, as estimated according to standard microscopy
+          methods, the Garki method, and as derived from Malariatherapy data
+          are not equivalent. Internally, a &quot;bias&quot; factor is used to convert
+          values estimated by one methods to values comparable with another
+          (see AJTMHv75 supplement 2 pp20-21).
+          
+          This option allows specification of which methodology the density
+          given in the diagnostic specification is measured with. Values
+          allowed are: Malariatherapy, Garki and Other. If not specified,
+          Other is assumed, unless the GARKI_DENSITY_BIAS model option is used,
+          in which case this option must be specified.
+        </xs:documentation>
+        <xs:appinfo>name:Parasite density units / methodology;</xs:appinfo>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Other"/>
+          <xs:enumeration value="Garki"/>
+          <xs:enumeration value="Malariatherapy"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="mechanism" default="Other">
+      <xs:annotation>
+        <xs:documentation>
+          Mechanism by which this diagnostic functions.
+          
+          Possible values are: HRP2, Other. In the case of HRP2, infections with
+          an hrp2_deletion will be invisible to this diagnostic. In the case of
+          Other, the diagnostic is unaffected by infection genome.
+          
+          The diagnostic used for monitoring cannot use HRP2. (This is a
+          restriction made to simplify implementation.)
+        </xs:documentation>
+        <xs:appinfo>name:Mechanism;</xs:appinfo>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="Other"/>
+          <xs:enumeration value="HRP2"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+
+ 
+ <!-- root element for clinical data outside the healthSystem element -->
+ <xs:complexType name="Clinical">
+  <xs:annotation>
+   <xs:documentation>
+        Description of clinical parameters that are related to the health-system description, but which contain data
+        that cannot be changed as part of an intervention and that are not restricted to treatment.
+      </xs:documentation>
+   <xs:appinfo>name:Description of clinical parameters;</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="NeonatalMortality" minOccurs="0">
+    <xs:annotation>
+     <xs:appinfo>name:Neonatal mortality parameters;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="diagnostic" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                The name of a diagnostic used to parameterise the model.
+                
+                Neonatal mortality is derived from malaria patency of a certain
+                sub-population of humans. This is the diagnostic used to asses
+                patency for this purpose.
+                
+                If this is not specified, the monitoring diagnostic is used.
+              </xs:documentation>
+       <xs:appinfo>name:Diagnostic used to parameterise model;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="NonMalariaFevers" minOccurs="0">
+    <xs:complexType>
+     <xs:annotation>
+      <xs:documentation>
+              Description of the incidence of non-malaria fever. Non-malaria fevers
+              are only modelled if the NON_MALARIA_FEVERS option is used.
+            </xs:documentation>
+      <xs:appinfo>name:Non-malaria fevers;</xs:appinfo>
+     </xs:annotation>
+     <xs:sequence>
+      <xs:element name="incidence" type="om:AgeGroupValues">
+       <xs:annotation>
+        <xs:documentation>
+                  Probability that a non-malaria fever occurs given that no concurrent
+                  malaria fever occurs.
+                </xs:documentation>
+        <xs:appinfo>name:P(NMF); units:Dimensionless;min:0.0;max:1.0;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="prNeedTreatmentNMF" type="om:AgeGroupValues" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                  Probability that a non-malarial fever requires treatment with
+                  antibiotics (assuming fever is not induced by malaria, although
+                  concurrent parasites may be present).
+                </xs:documentation>
+        <xs:appinfo>name:P(need treatment | NMF);units:Dimensionless;min:0;max:1;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="prNeedTreatmentMF" type="om:AgeGroupValues" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                  Probability that a malaria fever needs treatment with
+                  antibiotics (assuming fever is induced by malaria, although
+                  concurrent bacteria may be present).
+                   
+                  Meaning partially overlaps with separate model for comorbidity
+                  given malaria.
+                </xs:documentation>
+        <xs:appinfo>name:P(need treatment | MF);units:Dimensionless;min:0;max:1;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+  </xs:all>
+  <xs:attribute name="healthSystemMemory" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Follow-up period during which a recurrence is
+          considered to be a treatment failure
+          
+          Can be specified in steps (e.g. 6t) or days (e.g. 28d).
+        </xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to steps);
+          name:Follow-up period during which recurrence is considered a treatment failure;
+        </xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <!-- the healthSystem element -->
+ <xs:complexType name="HealthSystem">
+  <xs:annotation>
+   <xs:documentation>
+        Description of case management system, used to specify the initial model
+        or a replacement (an intervention). Encompasses case management
+        data and some other data required to derive case outcomes.
+        
+        Contains a sub-element describing the particular health-system in use.
+        Health system data is here defined as data used to decide on a treatment
+        strategy, given a case requiring treatment.
+      </xs:documentation>
+   <xs:appinfo>name:Case management system;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:choice>
+    <xs:element name="EventScheduler" type="om:HSEventScheduler"/>
+    <xs:element name="ImmediateOutcomes" type="om:HSImmediateOutcomes"/>
+    <xs:element name="DecisionTree5Day" type="om:HSDT5Day"/>
+   </xs:choice>
+   <xs:element name="CFR" type="om:AgeGroupValues">
+    <xs:annotation>
+     <xs:documentation>
+            Case fatality rate (probability of an inpatient fatality from a
+            bout of severe malaria, per age-group).
+          </xs:documentation>
+     <xs:appinfo>name:Case fatality rate for inpatients;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pSequelaeInpatient" type="om:AgeGroupValues">
+    <xs:annotation>
+     <xs:documentation>
+            List of age-specific probabilities of sequelae in inpatients,
+            during a severe bout of malaria.
+          </xs:documentation>
+     <xs:appinfo>units:Dimensionless;name:Probabilities of sequelae in inpatients;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="LiverStageDrug">
+  <xs:annotation>
+   <xs:documentation>
+        Parameters for drug treatment which have an effect on the liver-stage of parasites (Primaquine and potentially Tafenoquine); for use with the Vivax model only.
+        
+        Note: if this section is not listed, the following default values are
+        assumed: pHumanCannotReceive=0, pUseUncomplicated=0,
+        effectivenessOnUse=1.
+      </xs:documentation>
+   <xs:appinfo>name:Liver stage drug treatment parameters (Vivax);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="pHumanCannotReceive" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Chance that a human is determined to be unable to receive liver-stage drug
+            treatment. Treatment is neither reported or given for such humans.
+            
+            This is sampled once per human at birth.
+          </xs:documentation>
+     <xs:appinfo>units:Probability;min:0;max:1;
+            name:Probability that human is incompatible with liver-stage drug treatment;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="ignoreCannotReceive" type="om:BooleanValue" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            If true, ignore pHumanCannotReceive and consider all humans eligible
+            for treatment; if false (or not specified), do not treat those demed
+            incompatible with liver-stage drug treatment.
+            
+            The point of this is that pHumanCannotReceive cannot be altered by
+            changeHS interventions, but this property can be.
+          </xs:documentation>
+     <xs:appinfo>name:Ignore liver-stage drug treatment incompatibility;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pUseUncomplicated" type="om:DoubleValue" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            This feature is deprecated; it is suggested to use the &quot;simple
+            treatment&quot; feature configured to clear liver-stage parasites,
+            leaving this option unset or zero.
+            
+            Chance of liver-stage drug treatment being used for routine treatment of an
+            uncomplicated case.
+          </xs:documentation>
+     <xs:appinfo>units:Probability;min:0;max:1;name:Prob use in UC case;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="effectivenessOnUse" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Chance that liver-stage drug treatment is effective.
+            
+            On application, a random variable is sampled against this probability.
+            If false, the treatment does nothing; if true, the treatment clears all
+            liver stage parasites. Where effectiveness is longer than a single
+            time step (prophylactic effect), this sample still only happens once
+            (thus either no effect or all liver stages cleared over multiple steps).
+          </xs:documentation>
+     <xs:appinfo>units:Probability;min:0;max:1;name:Effectiveness;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:all>
+ </xs:complexType>
+ <!-- healthSystem: 5-day model -->
+ <xs:complexType name="HSImmediateOutcomes">
+  <xs:annotation>
+   <xs:documentation>
+        Description of &quot;immediate outcomes&quot; health system:
+        Tediosi et al case management model (Case management as
+        described in AJTMH 75 (suppl 2) pp90-103).
+      </xs:documentation>
+   <xs:appinfo>name:Case Management (Tediosi et al);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="drugRegimen">
+    <xs:annotation>
+     <xs:documentation>
+            Description of drug regimen.
+          </xs:documentation>
+     <xs:appinfo>name:Description of drug regimen;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="firstLine" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                Code for first line drug
+              </xs:documentation>
+       <xs:appinfo>units:Drug code;name:First line drug;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="secondLine" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                Code for second line drug
+              </xs:documentation>
+       <xs:appinfo>units:Drug code;name:Second line drug;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="inpatient" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                Code for drug used for treating
+                inpatients
+              </xs:documentation>
+       <xs:appinfo>units:Drug code;name:Drug use for treating inpatients;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="initialACR" type="om:TreatmentDetails">
+    <xs:annotation>
+     <xs:documentation>
+            Initial cure rate
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Initial cure rate;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="compliance" type="om:TreatmentDetails">
+    <xs:annotation>
+     <xs:documentation>
+            Adherence to treatment
+          </xs:documentation>
+     <xs:appinfo>units:Dimensionless;min:0.0;max:1.0;name:Adherence to treatment;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="nonCompliersEffective" type="om:TreatmentDetails">
+    <xs:annotation>
+     <xs:documentation>
+            Effectiveness of treatment for non-compliant patients
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Effectiveness of treatment in non-adherent patients;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="treatmentActions">
+    <xs:complexType>
+     <xs:all>
+      <xs:element name="CQ" type="om:TreatmentOption" minOccurs="0"/>
+      <xs:element name="SP" type="om:TreatmentOption" minOccurs="0"/>
+      <xs:element name="AQ" type="om:TreatmentOption" minOccurs="0"/>
+      <xs:element name="SPAQ" type="om:TreatmentOption" minOccurs="0"/>
+      <xs:element name="ACT" type="om:TreatmentOption" minOccurs="0"/>
+      <xs:element name="QN" type="om:TreatmentOption" minOccurs="0"/>
+     </xs:all>
+    </xs:complexType>
+   </xs:element>
+   <!-- begin elements in common with DecisionTree5Day -->
+   <!-- note: we cannot use class extension without reordering existing XMLs -->
+   <xs:element name="pSeekOfficialCareUncomplicated1" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with newly incident
+            uncomplicated disease seeks official care
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a patient with uncomplicated disease seeks official care immediately.
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pSelfTreatUncomplicated" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with uncomplicated disease without
+            recent history of disease (i.e. first line) will self-treat.
+            
+            Note that in second line cases there is no probability of self-treatment.
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a patient with uncomplicated disease will self-treat.
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pSeekOfficialCareUncomplicated2" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with recurrence of
+            uncomplicated disease seeks official care
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a recurring patient seeks official care;
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pSeekOfficialCareSevere" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with severe disease
+            obtains appropriate care
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a patient with severe disease obtains appropriate care;
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="liverStageDrug" type="om:LiverStageDrug" minOccurs="0"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          Name of health system
+        </xs:documentation>
+    <xs:appinfo>name:Name of case management parameterisation;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="useDiagnosticUC" type="xs:boolean" default="false"/>
+ </xs:complexType>
+ <xs:complexType name="TreatmentDetails">
+  <xs:sequence>
+   <xs:element maxOccurs="1" minOccurs="0" name="CQ" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>Chloroquine</xs:documentation>
+     <xs:appinfo>name:Chloroquine;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element maxOccurs="1" minOccurs="0" name="SP" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Sulphadoxine-pyrimethamine
+          </xs:documentation>
+     <xs:appinfo>name:Sulphadoxine-pyrimethamine;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element maxOccurs="1" minOccurs="0" name="AQ" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>Amodiaquine</xs:documentation>
+     <xs:appinfo>name:Amodiaquine</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element maxOccurs="1" minOccurs="0" name="SPAQ" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Sulphadoxine-pyrimethamine/Amodiaquine
+          </xs:documentation>
+     <xs:appinfo>name:Sulphadoxine-pyrimethamine/Amodiaquine;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element maxOccurs="1" minOccurs="0" name="ACT" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Artemisinine combination therapy
+          </xs:documentation>
+     <xs:appinfo>name:Artemisinine based combination therapy;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element maxOccurs="1" minOccurs="0" name="QN" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>Quinine</xs:documentation>
+     <xs:appinfo>name:Quinine;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="selfTreatment" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability of self-treatment
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0;max:1name:P(self-treat);
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <!-- health system: 5-day with flexible case management -->
+ <xs:complexType name="HSDT5Day">
+  <xs:annotation>
+   <xs:documentation>
+        Description of the health system using the 5-day timestep with decision
+        tree model: access is configured as in the Tediosi et al case
+        management model (Case management as described in AJTMH 75 (suppl 2)
+        pp90-103) while treatment decisions are configured via decision trees.
+        
+        Besides greater flexibility, this allows treatment via PK/PD models.
+      </xs:documentation>
+   <xs:appinfo>name:Case Management (Tediosi et al with programmable decision trees);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <!-- begin elements in common with DecisionTree5Day -->
+   <!-- note: we cannot use class extension without reordering existing XMLs -->
+   <xs:element name="pSeekOfficialCareUncomplicated1" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with newly incident
+            uncomplicated disease seeks official care
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a patient with uncomplicated disease seeks official care immediately.
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pSelfTreatUncomplicated" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with uncomplicated disease without
+            recent history of disease (i.e. first line) will self-treat.
+            
+            Note that in second line cases there is no probability of self-treatment.
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a patient with uncomplicated disease will self-treat.
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pSeekOfficialCareUncomplicated2" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with recurrence of
+            uncomplicated disease seeks official care
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a recurring patient seeks official care;
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="pSeekOfficialCareSevere" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that a patient with severe disease
+            obtains appropriate care
+          </xs:documentation>
+     <xs:appinfo>
+            units:Dimensionless;min:0.0;max:1.0;name:Probability that a patient with severe disease obtains appropriate care;
+          </xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="liverStageDrug" type="om:LiverStageDrug" minOccurs="0"/>
+   <xs:element name="treeUCOfficial" type="om:DecisionTree"/>
+   <xs:element name="treeUCSelfTreat" type="om:DecisionTree"/>
+   <xs:element name="cureRateSevere" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            The probability of clearing parasites given access to
+            appropriate (hospital) care, for a severe case.
+          </xs:documentation>
+     <xs:appinfo>name:Cure rate (severe cases);min:0;max:1;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="treatmentSevere" type="om:TreatmentOption"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          Name of health system
+        </xs:documentation>
+    <xs:appinfo>name:Name of case management parameterisation;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <!-- healthSystem: 1-day model -->
+ <xs:complexType name="HSEventScheduler">
+  <xs:sequence>
+   <xs:element name="uncomplicated" type="om:DecisionTree"/>
+   <xs:element name="complicated" type="om:DecisionTree"/>
+   <xs:element name="ClinicalOutcomes" type="om:ClinicalOutcomes"/>
+   <xs:element name="NonMalariaFevers" type="om:HSESNMF" minOccurs="0"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="ClinicalOutcomes">
+  <xs:annotation>
+   <xs:documentation>
+        Description of base parameters of the clinical model.
+      </xs:documentation>
+   <xs:appinfo>name:Clinical Outcomes;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="maxUCSeekingMemory" type="xs:int">
+    <xs:annotation>
+     <xs:documentation>
+            Maximum number of timesteps (including first day of case) that an individual with an uncomplicated case of
+            malaria will remember he/she was sick before resetting. 
+          </xs:documentation>
+     <xs:appinfo>name:Max UC treatment-seeking memory;units:Days;min:0;max:unbounded</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="uncomplicatedCaseDuration" type="xs:int">
+    <xs:annotation>
+     <xs:documentation>
+            Fixed length of an uncomplicated case of malarial or non-malarial
+            sickness (from treatment seeking until return to life-as-usual).
+            Usually 3.
+          </xs:documentation>
+     <xs:appinfo>name:Uncomplicated case duration;units:Days;min:1;max:unbounded</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="complicatedCaseDuration" type="xs:int">
+    <xs:annotation>
+     <xs:documentation>
+            Fixed length of a complicated or severe case of malaria
+            (from treatment seeking until return to life-as-usual).
+          </xs:documentation>
+     <xs:appinfo>name:Complicated case duration;units:Days;min:1;max:unbounded</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="complicatedRiskDuration" type="xs:int">
+    <xs:annotation>
+     <xs:documentation>
+            Number of days for which humans are at risk of death during a severe
+            or complicated case of malaria. Cannot be greater than the duration
+            of a complicated case or less than 1 day.
+          </xs:documentation>
+     <xs:appinfo>name:Complicated risk duration;units:Days;min:1;max:unbounded</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="dailyPrImmUCTS" type="xs:double" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation>
+            It is sometimes desirable to model delays to treatment-seeking in
+            uncomplicated cases. While treatment of drugs can be delayed within
+            case management trees to provide a similar effect, this doesn't
+            delay any of the decisions, including diagnostics using the current
+            parasite density.
+            
+            Instead a list of dailyPrImmUCTS elements can be used, describing
+            successive daily probabilities of treatment (sum must be 1). For
+            example, with a list of two elements with values 0.8 and 0.2, for
+            80% of UC cases the decision tree is evaluated immediately, and for
+            20% of cases evaluation is delayed by one day.
+            
+            For no delay, use one element with a value of 1.
+          </xs:documentation>
+     <xs:appinfo>name:Daily probability of immediate treatment seeking for uncomplicated cases;units:Dimensionless;min:0.0;max:1.0</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="HSESNMF">
+  <xs:annotation>
+   <xs:documentation>
+        Description of non-malaria fever health-system modelling (treatment,
+        outcomes and costing). Incidence is described by the 
+        model-&gt;clinical-&gt;NonMalariaFevers element. Non-malaria fevers are only
+        modelled if the NON_MALARIA_FEVERS option is used.
+        
+        As further explanation of the parameters below, we first take:
+        β₀ = logit(P₀) - β₃·P(need),
+        and then calculate the probability of antibiotic administration, P(AB),
+        dependent on treatment seeking location.
+        No seeking: P(AB) = 0
+        Informal sector: logit(P(AB)) = β₀ + β₄
+        Health facility: logit(P(AB)) = β₀ + β₁·I(neg) + β₂·I(pos) + β₃·I(need)
+        (where I(X) is 1 when event X is true and 0 otherwise,
+        logit(p)=log(p/(1-p)), event &quot;need&quot; is the event that death may occur
+        without treatment, events &quot;neg&quot; and &quot;pos&quot; are the events that a malaria
+        parasite diagnositic was used and indicated no parasites and parasites
+        respectively).
+      </xs:documentation>
+   <xs:appinfo>name:Non-malaria fevers;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="prTreatment" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+            Probability of a non-malaria fever being treated with an antibiotic
+            given that no malaria diagnostic was used but independent of need.
+            Symbol: P₀.
+          </xs:documentation>
+     <xs:appinfo>name:P(treatment|no diagnostic);units:Dimensionless;min:0.0;max:1.0;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="effectNegativeTest" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+            The effect of a negative malaria diagnostic on the odds ratio of
+            receiving antibiotics. Symbol: exp(β₁).
+          </xs:documentation>
+     <xs:appinfo>name:Effect of a negative test;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="effectPositiveTest" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+            The effect of a positive malaria diagnostic on the odds ratio of
+            receiving antibiotics. Symbol: exp(β₂).
+          </xs:documentation>
+     <xs:appinfo>name:Effect of a positive test;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="effectNeed" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+            The effect of needing antibiotic treatment on the odds ratio of
+            receiving antibiotics. Symbol: exp(β₃).
+          </xs:documentation>
+     <xs:appinfo>name:Effect of need;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="effectInformal" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+            The effect of seeking treatment from an informal provider (i.e.
+            a provider untrained in NMF diagnosis) on the odds ratio of
+            receiving antibiotics. Symbol: exp(β₄)
+          </xs:documentation>
+     <xs:appinfo>name:Effect of informal provider;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="CFR" type="om:AgeGroupValues">
+    <xs:annotation>
+     <xs:documentation>
+            Base case fatality rate for non-malaria fevers (probability of
+            death from a fever requiring antibiotic treatment given that no
+            antibiotic treatment is received, per age-group).
+          </xs:documentation>
+     <xs:appinfo>name:Case fatality rate;units:Dimensionless;min:0.0;max:1.0;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="TreatmentEfficacy" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+            Probability that treatment would prevent a death (i.e. CFR is
+            multiplied by one minus this when treatment occurs).
+          </xs:documentation>
+     <xs:appinfo>units:Dimensionless;name:Treatment efficacy;min:0.0;max:1.0;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <!-- decision trees -->
+ <xs:complexType name="DecisionTree">
+  <xs:annotation>
+   <xs:documentation>
+        Describes how &quot;decisions&quot; are made, both probabilistically and
+        deterministically, and what actions are carried out.
+        
+        Quantities may also be reported as a side effect of decisions made in
+        the tree, for example the number of diagnostics used.
+      </xs:documentation>
+   <xs:appinfo>name:Decision tree;</xs:appinfo>
+  </xs:annotation>
+  <xs:choice>
+   <xs:element name="multiple" type="om:DTMultiple"/>
+   <!-- branching points -->
+   <xs:element name="caseType" type="om:DTCaseType"/>
+   <xs:element name="diagnostic" type="om:DTDiagnostic"/>
+   <xs:element name="uncomplicated" type="om:DTUncomplicated"/>
+   <xs:element name="severe" type="om:DTSevere"/>
+   <xs:element name="random" type="om:DTRandom"/>
+   <xs:element name="age" type="om:DTAge"/>
+   <!-- actions -->
+   <xs:element name="noTreatment" type="om:DTNoTreatment"/>
+   <xs:element name="report" type="om:DTReport" maxOccurs="unbounded"/>
+   <xs:element name="treatFailure" type="om:DTTreatFailure"/>
+   <xs:element name="treatPKPD" type="om:DTTreatPKPD" maxOccurs="unbounded"/>
+   <xs:element name="treatSimple" type="om:DTTreatSimple" maxOccurs="unbounded"/>
+   <xs:element name="deploy" type="om:DTDeploy" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="cohort" type="om:DTCohort"/>
+  </xs:choice>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTMultiple">
+  <xs:annotation>
+   <xs:documentation>
+        A special node allowing multiple sub-trees to be evaluated.
+        
+        This is different from an ordinary decision tree node in that:
+        
+        a) multiple types of child can occur simultaneously (e.g. multiple
+        types of treatment or treatment plus a 'random' sub-tree)
+        
+        b) the 'noTreatment' and 'treatFailure' nodes are not allowed
+      </xs:documentation>
+   <xs:appinfo>name:Decision tree;</xs:appinfo>
+  </xs:annotation>
+  <xs:choice minOccurs="0" maxOccurs="unbounded">
+   <!-- branching points -->
+   <xs:element name="caseType" type="om:DTCaseType" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="diagnostic" type="om:DTDiagnostic" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="uncomplicated" type="om:DTUncomplicated" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="severe" type="om:DTSevere" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="random" type="om:DTRandom" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="age" type="om:DTAge" minOccurs="0" maxOccurs="unbounded"/>
+   <!-- actions -->
+   <xs:element name="treatPKPD" type="om:DTTreatPKPD" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="treatSimple" type="om:DTTreatSimple" minOccurs="0"/>
+   <xs:element name="deploy" type="om:DTDeploy" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="report" type="om:DTReport" maxOccurs="unbounded" minOccurs="0"/>
+   <xs:element name="cohort" type="om:DTCohort" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:choice>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTCaseType">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on whether the
+        patient was treated recently (second line) or not (first line).
+        
+        For uncomplicated cases only.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (first/second line);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="firstLine" type="om:DecisionTree"/>
+   <xs:element name="secondLine" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTDiagnostic">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on the outcome
+        of some type of diagnostic.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (diagnostic);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="positive" type="om:DecisionTree"/>
+   <xs:element name="negative" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="diagnostic" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Should match the name of some parameterised diagnostic (see
+          scenario/diagnostics).
+        </xs:documentation>
+    <xs:appinfo>name:Name of diagnostic;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTUncomplicated">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on whether the host has an uncomplicated case. This could be a Malaria fever or a non-Malaria fever. If non-Malaria fevers are enable, it is possible to add a &lt;diagnostic&gt; node.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (uncomplicated);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="positive" type="om:DecisionTree"/>
+   <xs:element name="negative" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="memory" type="xs:string" use="optional" default="1">
+   <xs:annotation>
+    <xs:documentation>
+          Follow-up period during which a recurrence is
+          considered to be a treatment failure
+          
+          Can be specified in steps (e.g. 6t) or days (e.g. 28d).
+        </xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to steps);
+          name:Number of days to look back for fevers. This must be less than or equal to the healthsystem memory parameter. In general, this should be less than or equal to the repeatStep in MSAT with contiuous deployment;
+        </xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTSevere">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on whether the host has a severe case or not. Note that this include severe cases due to comorbidities.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (severe);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="positive" type="om:DecisionTree"/>
+   <xs:element name="negative" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="memory" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          Follow-up period during which a recurrence is
+          considered to be a treatment failure
+          
+          Can be specified in steps (e.g. 6t) or days (e.g. 28d).
+        </xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to steps);
+          name:Number of days to look back for fevers. This must be less than or equal to the healthsystem memory parameter. In general, this should be less than or equal to the repeatStep in MSAT with contiuous deployment;
+        </xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTRandom">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch randomly.
+        
+        Each branch must be listed with a probability; the sum of all these
+        probabilities must equal 1.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (probabilistic);</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="outcome" minOccurs="1" maxOccurs="unbounded">
+    <xs:complexType>
+     <xs:complexContent>
+      <xs:extension base="om:DecisionTree">
+       <xs:attribute name="p" type="xs:double" use="required">
+        <xs:annotation>
+         <xs:documentation>
+                    Probability of selecting this outcome. The sum of
+                    probabilities across all outcomes must be 1.
+                  </xs:documentation>
+         <xs:appinfo>units:None;min:0;max:1;name:Probability;</xs:appinfo>
+        </xs:annotation>
+       </xs:attribute>
+      </xs:extension>
+     </xs:complexContent>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTAge">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on the
+        patient's age (in years).
+        
+        Categories must uniquely cover all ages from birth, with no upper
+        bound. Categories must be listed in order of age, increasing; the first
+        must have lower bound 0. Upper bounds are equal to the lower bound of
+        the next category, (but are exclusive where lower bounds are
+        inclusive); the last category has no upper bound.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (age of patient);</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="age" minOccurs="1" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation>
+            Describes a branch, selected for patients of a certain age.
+          </xs:documentation>
+     <xs:appinfo>name:Age range;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:complexContent>
+      <xs:extension base="om:DecisionTree">
+       <xs:attribute name="lb" type="xs:double" use="required">
+        <xs:annotation>
+         <xs:appinfo>name:Lower bound (inclusive);min:0;</xs:appinfo>
+        </xs:annotation>
+       </xs:attribute>
+      </xs:extension>
+     </xs:complexContent>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTNoTreatment">
+  <xs:annotation>
+   <xs:documentation>
+        An end node doing nothing. This exists to explicitly state that no
+        treatment happens and to prevent trees from accidentally being left
+        incomplete.
+      </xs:documentation>
+   <xs:appinfo>name:No treatment;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTReport">
+  <xs:annotation>
+   <xs:documentation>        This increments measure 80 (nCMDTReport) by one every time this node is visited. This can be useful to report the results of mass test and treat interventions using the decision tree.</xs:documentation>
+   <xs:appinfo>name:DT Report;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="outputNumber" type="xs:int" default="0">
+   <xs:annotation>
+    <xs:documentation>
+          Optionally, this can be given to delay the start of treatment by a
+          given number of hours. If not specified, treatment is not delayed. If
+          a delay is given, all medications within the treatment schedule used
+          are delayed by this number of hours.
+        </xs:documentation>
+    <xs:appinfo>name:Delay (hours);</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTTreatFailure">
+  <xs:annotation>
+   <xs:documentation>
+        An end node which reports treatment but does not change parasitalogical
+        status. This allows correct labelling of second-line cases.
+      </xs:documentation>
+   <xs:appinfo>name:Failed treatment;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTTreatPKPD">
+  <xs:annotation>
+   <xs:documentation>
+        A command to administer drugs according to a given schedule and
+        dosage table, optionally with a delay.
+      </xs:documentation>
+   <xs:appinfo>name:Treatment (PK/PD model);</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="schedule" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The name of a schedule to use for treatment.
+        </xs:documentation>
+    <xs:appinfo>name:Name of treatment schedule;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="dosage" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The name of a dosage table to use for treatment.
+        </xs:documentation>
+    <xs:appinfo>name:Name of dosage table;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="delay_h" type="xs:double" default="0">
+   <xs:annotation>
+    <xs:documentation>
+          Optionally, this can be given to delay the start of treatment by a
+          given number of hours. If not specified, treatment is not delayed. If
+          a delay is given, all medications within the treatment schedule used
+          are delayed by this number of hours.
+        </xs:documentation>
+    <xs:appinfo>name:Delay (hours);</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTTreatSimple">
+  <xs:annotation>
+   <xs:documentation>
+        Simple treatment model, targetting liver- and/or blood-stage
+        infections. This is all-or-nothing treatment which, when deploymed,
+        completely clears all infections of the targetted stages. This makes it
+        unsuitable for modeling resistance, but suitable for use with simple
+        infection models.
+        
+        Infections are considered liver-stage when less than five days old and
+        blood-stage after that. Effects are described independently for the two
+        stages.
+      </xs:documentation>
+   <xs:appinfo>name:Simple treatment;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="durationLiver" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Controls action on liver-stage infections. 0 means no action, -1 step
+          is a compatibility option to act like treatment before schema version
+          32 (which removed infections retrospectively), 1 step or any duration
+          which equals some whole number of steps n&gt;0 means to clear all
+          liver-stage infections found on the next 1 or n steps.
+          
+          Note on -1 compatibility option: the main difference to 1 step
+          (clearing on the next timestep) is that parasite densities will be
+          reduced immediately, and thus from the point of view of surveys and
+          mass screen and treat interventions a peak in density which is
+          immediately treated through case management will not be seen.
+          
+          Can be specified in steps (e.g. 1t, -1t) or days (e.g. 5d).
+        </xs:documentation>
+    <xs:appinfo>name:Length of liver-stage effect;units:User defined;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="durationBlood" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Controls action on blood-stage infections. 0 means no action, -1 step
+          is a compatibility option to act like treatment before schema version
+          32 (which removed infections retrospectively), 1 step or any duration
+          which equals some whole number of steps n&gt;0 means to clear all
+          blood-stage infections found on the next 1 or n steps.
+          
+          Note on -1 compatibility option: the main difference to 1 step
+          (clearing on the next timestep) is that parasite densities will be
+          reduced immediately, and thus from the point of view of surveys and
+          mass screen and treat interventions a peak in density which is
+          immediately treated through case management will not be seen.
+          
+          Can be specified in steps (e.g. 1t, -1t) or days (e.g. 5d).
+        </xs:documentation>
+    <xs:appinfo>name:Length of blood-stage effect;units:User defined;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTDeploy">
+  <xs:annotation>
+   <xs:documentation>
+        Deploy one or more intervention components.
+      </xs:documentation>
+   <xs:appinfo>name:Deploy intervention;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="component" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The identifier (short name) of a component.
+        </xs:documentation>
+    <xs:appinfo>name:Component identifier;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTCohort">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on whether the host is part of the cohort (defined by the intervention component) or not.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (cohort);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="positive" type="om:DecisionTree"/>
+   <xs:element name="negative" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="component" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Follow-up period during which a recurrence is
+          considered to be a treatment failure
+          
+          Can be specified in steps (e.g. 6t) or days (e.g. 28d).
+        </xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to steps);
+          name:Number of days to look back for fevers. This must be less than or equal to the healthsystem memory parameter. In general, this should be less than or equal to the repeatStep in MSAT with contiuous deployment;
+        </xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <!-- treatments -->
+ <!-- unused: we could use a list like this to describe all options
+  <xs:complexType name="TreatmentDescriptions">
+    <xs:annotation>
+      <xs:documentation>
+        This describes a set of different treatments.
+        
+        Currently it should contain descriptions of all 5-day timestep
+        treatment actions but does not include PK/PD model treatments.
+      </xs:documentation>
+      <xs:appinfo>name:Description of treatments;</xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="option" maxOccurs="unbounded" type="om:TreatmentOption"/>
+    </xs:sequence>
+    </xs:complexType> -->
+ <xs:complexType name="TreatmentOption">
+  <xs:annotation>
+   <xs:documentation>
+        Describes the effects of the treatment, assuming this
+        compliance/adherence/... option is selected. Effects are described
+        in terms of a list of options, each of which acts independently but
+        with all effects being activated simultaneously.
+      </xs:documentation>
+   <xs:appinfo>name:Group (for compliance/adherence/drug effect);</xs:appinfo>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:extension base="om:TriggeredDeployments">
+    <xs:sequence>
+     <xs:element name="clearInfections" minOccurs="0" maxOccurs="unbounded">
+      <xs:annotation>
+       <xs:documentation>
+                This clears infections according to several options: it can clear
+                all blood stage infections, all liver stage infections or both, and
+                it can act on multiple timesteps. To have a probability of no
+                action add another treatment option (which does nothing) and set
+                the probabilities of selection appropriately.
+                
+                This allows immediate (legacy) or delayed action, a prophylactic
+                period, and selection of which stages are targeted. It is a simple
+                model but appropriate enough for use with the five day timestep
+                when assuming no resistance and that drug
+                failure is mainly caused by bad drugs or compliance.
+                
+                The old treatment action for the five-day timestep model is
+                essentially this, with immediateAction (timesteps=-1) and
+                stage=both, except for the IPT model's SP action, which was more
+                like with timesteps&gt;1 and stage=blood.
+              </xs:documentation>
+       <xs:appinfo>name:Prophylactic treatment;</xs:appinfo>
+      </xs:annotation>
+      <xs:complexType>
+       <xs:attribute name="timesteps" type="xs:string" use="required">
+        <xs:annotation>
+         <xs:documentation>
+                    The number of timesteps during which this action remains
+                    in effect (e.g. 2 means clear infections during the next
+                    two timestep updates). Full clearance of the targeted stages
+                    occurs during this time.
+                    
+                    A special value of -1 means act immediately (retrospectively);
+                    this the old behaviour. A value of 1 means act on the next
+                    timestep only.
+                    
+                    Both of these can be thought of as a model for short-acting
+                    effective drug treatment; the main differences are that the
+                    latter means parasite densities will remain high from the point
+                    of view of surveys and diagnostics (i.e. mass screen and treat)
+                    used before the next timestep and that the latter will also
+                    remove infections starting the next timestep. Arguably the
+                    latter is a better model, but the differences are perhaps
+                    small, excepting where immediate treatment of fevers (i.e.
+                    through the health system) can hide high parasite densities
+                    from reporting and mass-screen-and-treat diagnostics. For
+                    use by interventions, the latter model has nicer behaviour in
+                    that the order of deployment of multiple interventions
+                    deployed at the same time does not matter, and that the former
+                    model retrospectively treats infections which may already have
+                    caused fever, thus may have a lower health impact than it
+                    should.
+                    
+                    It is recommended to use the new model (value 1, or greater
+                    than 1 if prophylactic effect is desired) unless wanting to
+                    emulate the old behaviour.
+                    
+                    Values of 0 or less than -1 are not allowed.
+                    
+                    Can be specified in steps (e.g. 1t, -1t) or days (e.g. 5d).
+                  </xs:documentation>
+         <xs:appinfo>name:Length of effect;units:User defined (defaults to steps);</xs:appinfo>
+        </xs:annotation>
+       </xs:attribute>
+       <xs:attribute name="stage" use="required">
+        <xs:annotation>
+         <xs:documentation>
+                    Controls whether liver-stage or blood-stage infections
+                    are cleared, or both.
+                    
+                    Infections are considered liver-stage for one 5-day timestep,
+                    blood-stage but pre-patent for some number of timesteps
+                    (latentp - 1), then start the patent blood stage. If stage is
+                    set to &quot;liver&quot;, infections are only cleared during their first
+                    timestep; if stage is set to &quot;blood&quot;, infections are cleared
+                    during pre-patent and patent blood stages; if stage is set to
+                    &quot;both&quot; all infections are cleared.
+                    
+                    The old behaviour (oddly considering the drugs it is meant to
+                    emulate) is to clear both stages, except for the IPT model of
+                    SP action, which cleared only patent blood-stage infections.
+                  </xs:documentation>
+         <xs:appinfo>name:Target stage;</xs:appinfo>
+        </xs:annotation>
+        <xs:simpleType>
+         <xs:restriction base="xs:string">
+          <xs:enumeration value="liver"/>
+          <xs:enumeration value="blood"/>
+          <xs:enumeration value="both"/>
+         </xs:restriction>
+        </xs:simpleType>
+       </xs:attribute>
+      </xs:complexType>
+     </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="optional">
+     <xs:annotation>
+      <xs:documentation>
+              Describes what this compliance option represents (e.g.
+              &quot;good compliance&quot;, &quot;poor compliance with good drugs&quot;, ...).
+            </xs:documentation>
+      <xs:appinfo>name:Name;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <!-- an identifier may be useful (see other comments, in particular in how
+        this is used for MDA interventions)
+        <xs:attribute name="id" type="xs:string" use="required">
+          <xs:annotation>
+            <xs:documentation>
+              A textual identifier for this treatment option.
+            </xs:documentation>
+            <xs:appinfo>name:Identifier;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+        -->
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+
+  
+  <xs:complexType name="Monitoring">
+    <xs:sequence>
+      <xs:element name="continuous" minOccurs="0">
+        <xs:complexType>
+          <xs:complexContent>
+            <xs:extension base="om:OptionSet">
+              <xs:attribute name="period" type="xs:string" use="required">
+                <xs:annotation>
+                  <xs:documentation>
+                    Delay between reports; typically one time step but can be
+                    greater.
+                    
+                    Can be specified in steps (e.g. 1t) or days (e.g. 5d).
+                  </xs:documentation>
+                  <xs:appinfo>units:User defined (default: steps);name:Delay between reports;</xs:appinfo>
+                </xs:annotation>
+              </xs:attribute>
+              <xs:attribute name="duringInit" type="xs:boolean" use="optional">
+                <xs:annotation>
+                  <xs:documentation>
+                    Also output during initialization. By default this is
+                    disabled (only intervention-period data is output). This
+                    should not be used for predictions, but can be useful for
+                    model validation.
+                    
+                    In this mode, 'simulation time' is output as the first
+                    column (in addition to 'timestep'), since 'timestep' is dis-
+                    continuous across the start of the intervention period.
+                  </xs:documentation>
+                  <xs:appinfo>units:Days;min:1;max:unbounded;name:During initialization;</xs:appinfo>
+                </xs:annotation>
+              </xs:attribute>
+            </xs:extension>
+          </xs:complexContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="SurveyOptions" type="om:MonitoringOptions">
+        <xs:annotation>
+          <xs:documentation>
+            List of all active survey options. See model/mon/OutputMeasures.h for a list of
+            supported outputs. Should also be on the wiki.
+          </xs:documentation>
+          <xs:appinfo>name:Name of quantity;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="surveys">
+        <xs:annotation>
+          <xs:documentation>
+            List of survey times
+          </xs:documentation>
+          <xs:appinfo>name:Survey times (time steps);</xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="surveyTime" maxOccurs="unbounded">
+              <xs:annotation>
+                <xs:documentation>
+                  Time of a survey. A report will be made for those measures
+                  enabled under SurveyOptions. Reported data is either from the
+                  moment the survey is done (immediate data) or is collected 
+                  over the time since the previous survey, or in some cases
+                  over a fixed time span (usually one year).
+                  
+                  Times can be specified in time steps, starting from 0, or as
+                  a date (see monitoring/startDate), or in days (e.g. 15d) or
+                  years (e.g. 1y). Relative times mean the time since the start
+                  of the intervention period, and must be non-negative (zero is
+                  valid, but some measures, e.g. nUncomp, will be zero).
+                  
+                  The simulation ends immediately after the last survey is taken.
+                </xs:documentation>
+                <xs:appinfo>units:User defined (defaults to steps);min:0;name:Survey time;</xs:appinfo>
+              </xs:annotation>
+              <xs:complexType>
+                <!--NOTE: this is an extension of xs:int for backwards compatibility.-->
+                <xs:simpleContent>
+                  <xs:extension base="xs:string">
+                    <xs:attribute name="repeatStep" type="xs:string" use="optional">
+                      <xs:annotation>
+                        <xs:documentation>See repeatEnd's documentation.</xs:documentation>
+                        <xs:appinfo>name:Step of repetition;units:User defined;</xs:appinfo>
+                      </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="repeatEnd" type="xs:string" use="optional">
+                      <xs:annotation>
+                        <xs:documentation>
+                          Either both repeatStep and repeatEnd should be present
+                          or neither. If present, the survey is repeated every
+                          repeatStep timesteps (i.e. if t0 is the initial time
+                          and x is repeatStep, surveys are done at times t0,
+                          t0+x, t0+2*x, ...), ending before repeatEnd
+                          (final repetition is the one before repeatEnd).
+                          
+                          Note that repeatEnd may be specified as a date but
+                          repeatStep must be a duration (days, steps or years).
+                        </xs:documentation>
+                        <xs:appinfo>name:End of repetition (exclusive);units:User defined;</xs:appinfo>
+                      </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="reported" type="xs:boolean" default="true">
+                      <xs:annotation>
+                        <xs:documentation>For normal surveys, reporting=true. If set false,
+                          quantities are measured but not reported. The reason for doing this is
+                          to update conditions set on reportable measures.
+                          
+                          Multiple surveys may be given here for the same date, e.g. if using
+                          &quot;repeatStep&quot; for both reporting and non-reporting surveys. These are
+                          combined such that a maximum of one survey is carried out per time-step,
+                          and the survey is reported if any of the listed surveys for this date is
+                          configured as &quot;reporting&quot;.
+                          
+                          Note that adding non-reporting surveys will not affect value output by
+                          reported surveys, with the exception that generated psuedo-random numbers
+                          may be altered (specifically, when any stochastic diagnostics are used in
+                          surveys).
+                        </xs:documentation>
+                      </xs:annotation>
+                    </xs:attribute>
+                  </xs:extension>
+                </xs:simpleContent>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="detectionLimit" type="xs:double" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                Deprecated: limit above which a human's infection is reported
+                as patent.
+                
+                Alternative: do not specify this; instead specify &quot;diagnostic&quot;.
+              </xs:documentation>
+              <xs:appinfo>units:parasites/microlitre;min:0;name:Detection limit for parasitaemia;</xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="diagnostic" type="xs:string" use="optional">
+            <xs:annotation>
+              <xs:documentation>
+                Name of a parameterised diagnostic to use in surveys (see
+                scenario/diagnostics).
+              </xs:documentation>
+              <xs:appinfo>name:Name of monitoring diagnostic;</xs:appinfo>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ageGroup" type="om:MonAgeGroup">
+        <xs:annotation>
+          <xs:documentation>
+            List of age groups included in demography or surveys
+          </xs:documentation>
+          <xs:appinfo>name:Age groups;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="cohorts" minOccurs="0" type="om:Cohorts">
+        <xs:annotation>
+          <xs:documentation>
+            Allows the configuration of multiple cohorts (output segregated
+            according to membership within specific sub-populations).
+            
+            If this element is omitted, monitoring surveys cover the entire
+            simulated human population.
+            
+            It does not affect the &quot;continuous&quot; outputs (these never take
+            cohorts into account).
+          </xs:documentation>
+          <xs:appinfo>name:Cohorts;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Name of monitoring settings
+        </xs:documentation>
+        <xs:appinfo>name:Name of monitoring settings;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="startDate" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          An optional date for the start of monitoring. If given, dates may be
+          used to specify when other events (surveys, intervention deployments)
+          occur; alternately times relative to the start of the intervention
+          period may be used to specify event times.
+          
+          Setting this to 1st January of some year might simplify usage of
+          dates, and putting the start a couple of years before the start of
+          intervention deployment (along with some extra surveys) may be useful
+          to check transmission stabilises to the expected pre-intervention
+          levels.
+          
+          As an example, if this date is set to 2000-01-01, then the following
+          event times are equivalent (assuming 1t=5d):
+          15t, 75d, 0.2y, 2000-03-16.
+          
+          Must be in the form YYYY-MM-DD, e.g. 2003-01-01.
+        </xs:documentation>
+        <xs:appinfo>name:Start of monitoring;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="MonAgeGroup">
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="group" type="om:MonGroupBounds"/>
+    </xs:sequence>
+    <xs:attribute name="lowerbound" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Lower bound of age group
+        </xs:documentation>
+        <xs:appinfo>units:Years;min:0;max:100;name:lower bound of age group</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="MonGroupBounds">
+    <xs:attribute name="upperbound" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Upper bound of age group
+        </xs:documentation>
+        <xs:appinfo>units:Years;min:0;max:100;name:upper bound of age group</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="Cohorts">
+    <xs:sequence>
+      <xs:element name="subPop" maxOccurs="unbounded" type="om:CohortSubPop">
+        <xs:annotation>
+          <xs:documentation>
+            Consider a certain sup-population a cohort, and segregate outputs
+            according to membership. Where multiple sub-populations are listed,
+            segregate output according to all combinations of membership: e.g.
+            if sub-populations A and B are listed, there will be outputs for
+            &quot;member of A and B&quot;, &quot;member of A but not B&quot;, &quot;B but not A&quot; and
+            &quot;not a member of A or B&quot;. Listing n sub-populations implies 2^n
+            sets of outputs (each is further segregated by age groups, survey
+            times and enabled output measures, which could lead to excessive
+            program memory usage and output file size).
+            
+            To identify outputs, each sub-population has a power of two number
+            as identifier (see &quot;number&quot; attribute). Each of the 2^n output sets
+            is identified by a number: the output set is the output from humans
+            who are members in some set of sub-populations (S1, S2, ...) and
+            not members in some others (T1, T2, ...); the number identifying
+            the set is the sum of the numbers identifying the sets S1, S2, etc.
+            
+            In the output file, the output set is identified by multiplying
+            this number by 1000 then adding it to the age group column.
+          </xs:documentation>
+          <xs:appinfo>name:Sub-population;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="CohortSubPop">
+    <xs:attribute name="id" use="required" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Textual identifier for the sub-population (i.e. for an intervention
+          component, since sub-populations are defined as the hosts an
+          intervention component is deployed to).
+        </xs:documentation>
+        <xs:appinfo>name:Sub-population identifier;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="number" type="xs:integer" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Number identifying a sub-population; used to define identifiers of
+          output sets. This number must be a power of 2 (i.e. 1, 2, 4, 8, ...).
+          See documentation of subPop element.
+        </xs:documentation>
+        <xs:appinfo>name:Sub-population number;units:dimensionless;min:1;max:2097152;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="MonitoringOptions">
+    <xs:sequence>
+      <xs:element name="option" type="om:MonitoringOption" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="onlyNewEpisode" type="xs:boolean" default="false">
+      <xs:annotation>
+        <xs:documentation>
+          If set, some statistics exclude humans who have been treated in the
+          recent past (precisely, when the time of last treatment was before
+          the current step and no more than health-system-memory days/steps
+          ago).
+          
+          This is a rough replacement for the REPORT_ONLY_AT_RISK option,
+          with one difference: the maximum age of treatment for
+          REPORT_ONLY_AT_RISK was fixed at 20 days.
+          
+          Affected measures include (as of version 35):
+          nHost (0),
+          nInfect(1),
+          nExpectd (2),
+          nPatent (3),
+          sumLogPyrogenThres (4),
+          sumlogDens (5),
+          totalInfs (6),
+          totalPatentInf (8),
+          sumPyrogenThresh (10),
+          nSubPopRemovalFirstEvent (62),
+          sumAge (68),
+          nInfectByGenotype (69),
+          nPatentByGenotype (70),
+          logDensByGenotype (71),
+          nHostDrugConcNonZero (72),
+          sumLogDrugConcNonZero (73).
+        </xs:documentation>
+        <xs:appinfo>name:Report only for new cases;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="MonitoringOption">
+    <xs:complexContent>
+      <xs:extension base="om:Option">
+        <xs:attribute name="outputNumber" type="xs:int" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              Number identifying this monitoring measure in the output
+              file (3rd column). Normally this is determined from the
+              measure, but it can be set manually, e.g. for when the same
+              measure is recorded twice (to accumulate across different
+              categories).
+            </xs:documentation>
+            <xs:appinfo>name:Number identifying measure in output;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="byAge" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              If true, the measure is reported for each age category. If
+              false, values are summed across all age categories and only
+              the sum reported. If not specified, separate categories
+              will be reported if the measure supports this.
+            </xs:documentation>
+            <xs:appinfo>name:Report by age category;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="byCohort" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              If true, the measure is reported for each cohort separately.
+              If false, values are summed across all cohorts and only
+              the sum reported. If not specified, separate categories
+              will be reported if the measure supports this.
+            </xs:documentation>
+            <xs:appinfo>name:Report by cohort;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="bySpecies" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              If true, the measure is reported for each mosquito species
+              separately. If false, values are summed across all species
+              and only the sum reported. If not specified, separate
+              categories will be reported if the measure supports this.
+            </xs:documentation>
+            <xs:appinfo>name:Report by mosquito species;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="byGenotype" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              If true, the measure is reported for each parasite genotype
+              separately. If false, values are summed across all genotypes
+              and only the sum reported. If not specified, separate
+              categories will be reported if the measure supports this.
+            </xs:documentation>
+            <xs:appinfo>name:Report by parasite genotype;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="byDrugType" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>
+              If true, the measure is reported for each drug type
+              separately. If false, values are summed across all drug types
+              and only the sum reported. If not specified, separate
+              categories will be reported if the measure supports this.
+            </xs:documentation>
+            <xs:appinfo>name:Report by drug type;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+ 
+ 
+ 
+ <xs:complexType name="Interventions">
+  <xs:all>
+   <xs:element minOccurs="0" name="changeHS">
+    <xs:annotation>
+     <xs:documentation>
+            Changes to the health system
+          </xs:documentation>
+     <xs:appinfo>name:Change health system;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="timedDeployment" minOccurs="0" maxOccurs="unbounded">
+       <xs:complexType>
+        <xs:complexContent>
+         <xs:extension base="om:HealthSystem">
+          <xs:annotation>
+           <xs:documentation>
+                        A complete replacement health system. Replaces all previous properties.
+                        (Health system can be replaced multiple times if necessary.)
+                      </xs:documentation>
+           <xs:appinfo>name:Timed replacement;</xs:appinfo>
+          </xs:annotation>
+          <xs:attribute name="time" type="xs:string" use="required">
+           <xs:annotation>
+            <xs:documentation>
+                          Time at which this replacement occurs. See doc on
+                          intervention period and on monitoring/startDate for
+                          details of how times work.
+                          
+                          Can be specified in steps, days, years, or as a date
+                          (examples: 15t, 75d, 0.2y, 2000-03-16).
+                        </xs:documentation>
+            <xs:appinfo>name:Time;units:User defined (defauls to steps);min:0;</xs:appinfo>
+           </xs:annotation>
+          </xs:attribute>
+         </xs:extension>
+        </xs:complexContent>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="name" type="xs:string" use="optional">
+      <xs:annotation>
+       <xs:documentation>
+                Name of intervention
+              </xs:documentation>
+       <xs:appinfo>name:Name of intervention;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="changeEIR">
+    <xs:annotation>
+     <xs:documentation>
+            New description of transmission level for models not
+            supporting vector control interventions. Use of this overrides
+            previous transmission levels such that human infectiousness no
+            longer has any feedback effect on transmission. Supplied EIR
+            data must last until end of simulation.
+          </xs:documentation>
+     <xs:appinfo>name:Change transmission levels;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="timedDeployment" minOccurs="0" maxOccurs="unbounded">
+       <xs:complexType>
+        <xs:complexContent>
+         <xs:extension base="om:NonVector">
+          <xs:annotation>
+           <xs:documentation>
+                        Replacement transmission levels. Disables feedback of
+                        human infectiousness to mosquitoes on further mosquito
+                        to human transmission. Must last until end of simulation.
+                      </xs:documentation>
+           <xs:appinfo>name:Timed replacement;</xs:appinfo>
+          </xs:annotation>
+          <xs:attribute name="time" type="xs:string" use="required">
+           <xs:annotation>
+            <xs:documentation>
+                          Time at which this replacement occurs. See doc on
+                          intervention period and on monitoring/startDate for
+                          details of how times work.
+                          
+                          Can be specified in steps, days, years, or as a date
+                          (examples: 15t, 75d, 0.2y, 2000-03-16).
+                        </xs:documentation>
+            <xs:appinfo>name:Time;units:User defined (defauls to steps);min:0;</xs:appinfo>
+           </xs:annotation>
+          </xs:attribute>
+         </xs:extension>
+        </xs:complexContent>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="name" type="xs:string" use="optional">
+      <xs:annotation>
+       <xs:documentation>
+                Name of intervention
+              </xs:documentation>
+       <xs:appinfo>name:Name of intervention;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="importedInfections">
+    <xs:annotation>
+     <xs:documentation>
+            Models importation of P. falciparum infections directly into humans
+            from an external source. This is infections, not inoculations or
+            EIR being imported.
+          </xs:documentation>
+     <xs:appinfo>name:Imported infections;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="timed">
+       <xs:annotation>
+        <xs:documentation>
+                  Rate of case importation, as a step function. Each value is
+                  valid until replaced by the next value.
+                </xs:documentation>
+        <xs:appinfo>name:Rate of importation</xs:appinfo>
+       </xs:annotation>
+       <xs:complexType>
+        <xs:sequence>
+         <xs:element name="rate" minOccurs="1" maxOccurs="unbounded">
+          <xs:complexType>
+           <xs:complexContent>
+            <xs:extension base="om:DoubleValue">
+             <xs:annotation>
+              <xs:documentation>A time-rate pair.</xs:documentation>
+              <xs:appinfo>name:Rate;units:Imported cases per thousand people per year;</xs:appinfo>
+             </xs:annotation>
+             <xs:attribute name="time" type="xs:string" use="required">
+              <xs:annotation>
+               <xs:documentation>
+                                Time at which this importation rate becomes active.
+                                
+                                See doc on intervention period and on monitoring/startDate for
+                                details of how times work. Can be specified in steps, days,
+                                years, or as a date (examples: 15t, 75d, 0.2y, 2000-03-16).
+                              </xs:documentation>
+               <xs:appinfo>name:Time of start;units:User defined (defauls to steps);min:0;</xs:appinfo>
+              </xs:annotation>
+             </xs:attribute>
+            </xs:extension>
+           </xs:complexContent>
+          </xs:complexType>
+         </xs:element>
+        </xs:sequence>
+        <xs:attribute name="period" type="xs:string" default="0">
+         <xs:annotation>
+          <xs:documentation>
+                      If period is 0 (or effectively infinite), the last specified
+                      value remains indefinitely in effect.
+                      
+                      If period is less than the length of the simulation's intervention phase,
+                      then all &quot;rate&quot; deployments are repeated with this periodicity.
+                      In this case, the first &quot;rate&quot; deployment must coincide with the start of
+                      the intervention phase (monitoring/startDate).
+                      
+                      Can be specified in steps (e.g. 1t) or days (e.g. 365d).
+                    </xs:documentation>
+          <xs:appinfo>name:Period of repetition;units:User defined (default: steps);min:0</xs:appinfo>
+         </xs:annotation>
+        </xs:attribute>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="name" type="xs:string" use="optional">
+      <xs:annotation>
+       <xs:documentation>
+                Name of intervention
+              </xs:documentation>
+       <xs:appinfo>name:Name of intervention;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="insertR_0Case">
+    <xs:annotation>
+     <xs:documentation>
+            Used to simulate R_0. First, infections should be eliminated,
+            immunity removed, and the population given an effective transmission-
+            blocking vaccine (not done by this intervention). Then this
+            intervention may be used to: pick one human, infect him, administer
+            a fully effective Preerythrocytic vaccine and remove
+            transmission-blocking vaccine effect on this human. Thus only this
+            one human will be a source of infections in an unprotected population,
+            and will not reinfected himself.
+          </xs:documentation>
+     <xs:appinfo>name:Insert R_0 case;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="timedDeployment" minOccurs="0" maxOccurs="unbounded">
+       <xs:complexType>
+        <xs:annotation>
+         <xs:appinfo>name:Timed occurrence;</xs:appinfo>
+        </xs:annotation>
+        <xs:attribute name="time" type="xs:string" use="required">
+         <xs:annotation>
+          <xs:documentation>
+                      Time at which this intervention occurs.
+                      
+                      See doc on intervention period and on monitoring/startDate for
+                      details of how times work. Can be specified in steps, days,
+                      years, or as a date (examples: 15t, 75d, 0.2y, 2000-03-16).
+                    </xs:documentation>
+          <xs:appinfo>name:Time;units:User defined (defauls to steps);min:0;</xs:appinfo>
+         </xs:annotation>
+        </xs:attribute>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="name" type="xs:string" use="optional">
+      <xs:annotation>
+       <xs:documentation>
+                Name of intervention
+              </xs:documentation>
+       <xs:appinfo>name:Name of intervention;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="uninfectVectors">
+    <xs:annotation>
+     <xs:documentation>
+            Removes all infections from mosquitoes -- resulting in zero EIR to
+            humans, until such time that mosquitoes are re-infected and become
+            infectious. Only efficacious in dynamic EIR mode (when changeEIR was
+            not used).
+            
+            Hypothetical, but potentially useful to simulate a setting starting
+            from no infections, but with enough mosquitoes to reach a set
+            equilibrium of exposure.
+          </xs:documentation>
+     <xs:appinfo>units:List of elements;name:Uninfect vectors;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="timedDeployment" minOccurs="0" maxOccurs="unbounded">
+       <xs:complexType>
+        <xs:annotation>
+         <xs:appinfo>name:Timed occurrence;</xs:appinfo>
+        </xs:annotation>
+        <xs:attribute name="time" type="xs:string" use="required">
+         <xs:annotation>
+          <xs:documentation>
+                      Time at which this intervention occurs.
+                      
+                      See doc on intervention period and on monitoring/startDate for
+                      details of how times work. Can be specified in steps, days,
+                      years, or as a date (examples: 15t, 75d, 0.2y, 2000-03-16).
+                    </xs:documentation>
+          <xs:appinfo>name:Time;units:User defined (defauls to steps);min:0;</xs:appinfo>
+         </xs:annotation>
+        </xs:attribute>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="name" type="xs:string" use="optional">
+      <xs:annotation>
+       <xs:documentation>
+                Name of intervention
+              </xs:documentation>
+       <xs:appinfo>name:Name of intervention;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="vectorPop">
+    <xs:annotation>
+     <xs:documentation>A list of parameterisations of generic vector host-inspecific interventions.</xs:documentation>
+     <xs:appinfo>name:Vector population intervention;units:List of elements;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <!-- Note: the ONLY reason for this list being wrapped with the
+            extra "vectorPop" element is that XSD 1.0 only allows unrepeated
+            elements in an "all" section or multiple in a "sequence" section.
+            Using the latter would invalidate existing XMLs and cause excess.
+            confusion. XSD 1.1 does not have this limitation but still has
+            limited support. -->
+      <xs:element minOccurs="1" maxOccurs="unbounded" name="intervention" type="om:VectorIntervention"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="vectorTrap">
+    <xs:annotation>
+     <xs:documentation>
+            Traps attract and kill mosquitoes. They are modelled as a
+            non-human-host where the probability of mosquitoes surviving
+            feeding is zero (since otherwise the simulator would assume
+            surviving mosquitoes have had a blood meal), and where this
+            &quot;host&quot; is initially not present.
+            
+            Model: each type of trap has has an initial availability
+            relative to a human and a decay in availability. Each
+            deployment has a fixed maximum lifespan, after which the
+            traps from that deployment are removed (it is up to the
+            user whether this is after availability is effectively zero
+            or sooner, either coinciding with a redeployment or
+            causing a reduction in overall effectiveness of traps).
+          </xs:documentation>
+     <xs:appinfo>name:Baited trap</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="intervention" type="om:VectorTrap" minOccurs="1" maxOccurs="unbounded"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="nonHumanHostsModifications">
+    <xs:annotation>
+     <xs:documentation>List of interventions that modify  parameters of non-human hosts described in the &lt;entomology&gt; &lt;vector&gt; &lt;anopheles&gt;.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element minOccurs="1" maxOccurs="unbounded" name="intervention" type="om:NonHumanHostsIntervention"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="addNonHumanHosts">
+    <xs:annotation>
+     <xs:documentation>List of intervention that add new non-human hosts that have not been described in the &lt;entomology&gt; &lt;vector&gt;
+&lt;anopheles&gt; &lt;nonHumanHosts&gt;.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element minOccurs="1" maxOccurs="unbounded" name="nonHumanHosts" type="om:NonHumanHosts"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="human" type="om:HumanInterventions" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Encapsulates all interventions whose effects are specific to the
+            human host: any interventions where target humans may be selected
+            via population-coverage, age limits and sub-population membership.
+          </xs:documentation>
+     <xs:appinfo>name:Human-specific interventions;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>Name of set of interventions</xs:documentation>
+    <xs:appinfo>name:Name of intervention set;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="HumanInterventions">
+  <xs:sequence>
+   <xs:element name="component" minOccurs="1" maxOccurs="unbounded" type="om:HumanInterventionComponent">
+    <xs:annotation>
+     <xs:documentation>
+            A parameterisation of an effect achieved by one component of an
+            intervention. (An intervention is described as the effects of a set
+            of components plus deployments of those components. This describes
+            the components individually, not deployments or which components
+            comprise an intervention.)
+            
+            Each element describes one component: its effects, decay of the(se)
+            effect(s), and related stuff (e.g. description of indirect decay
+            and of usage levels).
+            
+            Different interventions can deploy the same component to the same
+            perso. In most cases this will just deploy a fresh instance (e.g. a
+            new bed net will replace the old (nobody uses multiple bed nets),
+            or a new drug dose will act on top of previous doses, or in the
+            case of a vaccine, effect depends on the total number of previous
+            inoculations (including from other interventions).
+            
+            Where multiple components of the same type (but with different ids)
+            are deployed (whether within a single intervention or by multiple
+            interventions), they act independently (e.g. two bed nets deployed
+            to a single host would act to reduce attractiveness or survival of
+            mosquitoes biting that host twice — this may be useful to simulate
+            some novel vector intervention since the two nets may have separate
+            parameters).
+          </xs:documentation>
+     <xs:appinfo>name:Component;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element maxOccurs="unbounded" minOccurs="0" name="deployment">
+    <xs:annotation>
+     <xs:documentation>
+            This element describes deployment of an intervention: which
+            components are deployed, how humans are selected for deployment
+            (via timed or age-based deployment) as well as a few additional
+            restrictions (e.g. vaccine dosing restrictions).
+            
+            All components deployed by this intervention are deployed to the
+            same people (each timed or continuous deployment selects recipients
+            and then gives each recipient all components of the intervention).
+          </xs:documentation>
+     <xs:appinfo>name:Deployment;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="component" maxOccurs="unbounded" type="om:Component"/>
+      <xs:element name="condition" minOccurs="0" maxOccurs="unbounded">
+       <xs:annotation>
+        <xs:documentation>
+                  If conditions are specified, deployment of this intervention will only go ahead
+                  if all specified conditions are true. Condition statements are evaluated only
+                  during surveys, so deployment is enabled or disabled depending on the results
+                  of the most recent survey. So called *unreported surveys* can be used to
+                  reevaluate conditions without increasing granularity of output.
+                  
+                  Conditions are evaluated for the whole population, not for individual age-groups
+                  or cohorts.
+                  
+                  This affects all types of deployment.
+                </xs:documentation>
+        <xs:appinfo>name:Condition;</xs:appinfo>
+       </xs:annotation>
+       <xs:complexType>
+        <xs:attribute name="measure" type="xs:string" use="required">
+         <xs:annotation>
+          <xs:documentation>
+                      The monitoring measure to test. Not all measures are available for use.
+                    </xs:documentation>
+          <xs:appinfo>name:Measure;</xs:appinfo>
+         </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="minValue" type="xs:double" use="optional">
+         <xs:annotation>
+          <xs:documentation>
+                      Minimum value. If specified, the measured variable must be greater than 
+                      or equal to this value for the condition to be satisfied.
+                    </xs:documentation>
+          <xs:appinfo>name:Minimum value;</xs:appinfo>
+         </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maxValue" type="xs:double" use="optional">
+         <xs:annotation>
+          <xs:documentation>
+                      Maximum value. If specified, the measured variable must be less than or
+                      equal to this value for the condition to be satisfied.
+                    </xs:documentation>
+          <xs:appinfo>name:Maximum value;</xs:appinfo>
+         </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initialState" type="xs:boolean" use="required">
+         <xs:annotation>
+          <xs:documentation>
+                      Whether this condition is considered true or false before updated by a survey.
+                    </xs:documentation>
+          <xs:appinfo>name:Initial state;</xs:appinfo>
+         </xs:annotation>
+        </xs:attribute>
+       </xs:complexType>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="continuous" type="om:ContinuousList">
+       <xs:annotation>
+        <xs:documentation>List of ages at which deployment takes place
+                (through EPI, post-natal and school-based programmes, etc.).
+                
+                A sub-population restriction may be added as a property of the
+                list of continuous deployments.
+                </xs:documentation>
+        <xs:appinfo>name:Age-based (continuous) deployment;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" maxOccurs="unbounded" name="timed" type="om:MassListWithCum">
+       <xs:annotation>
+        <xs:documentation>
+                  List of timed deployments of the intervention (that is, of
+                  deployment campaigns).
+                  
+                  Cumulative deployment mode can be specified for all deployments in a timed list.
+                  To allow multiple cumulative deployment descriptions, the entire timed list
+                  may be repeated.
+                </xs:documentation>
+        <xs:appinfo>name:Mass (timed) deployment;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="name" type="xs:string" use="optional">
+      <xs:annotation>
+       <xs:documentation>Name of intervention</xs:documentation>
+       <xs:appinfo>name:Intervention name;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="HumanInterventionComponent">
+  <xs:sequence>
+   <xs:choice>
+    <xs:element name="screen" type="om:Screen"/>
+    <xs:element name="treatSimple" type="om:DTTreatSimple"/>
+    <xs:element name="treatPKPD" type="om:DTTreatPKPD"/>
+    <xs:element name="decisionTree" type="om:DecisionTree"/>
+    <xs:element name="PEV" type="om:VaccineDescription">
+     <xs:annotation>
+      <xs:documentation>
+              Pre-erythrocytic vaccine (PEV): prevents a proportion of infections
+              from commencing.
+            </xs:documentation>
+      <xs:appinfo>name:Vaccines;</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="BSV" type="om:VaccineDescription">
+     <xs:annotation>
+      <xs:documentation>
+              Blood-stage vaccine (BSV): acts as a killing factor on blood-stage
+              parasites. Exact action depends on the within host model.
+            </xs:documentation>
+      <xs:appinfo>name:Vaccines;</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="TBV" type="om:VaccineDescription">
+     <xs:annotation>
+      <xs:documentation>
+              Transmission-blocking vaccine (TBV): one minus this scales the
+              probability of transmission to mosquitoes
+            </xs:documentation>
+      <xs:appinfo>name:Vaccines;</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="ITN" type="om:ITNDescription">
+     <xs:annotation>
+      <xs:documentation>
+              Description of bed-net interventions (ITNs, LLINs).
+            </xs:documentation>
+      <xs:appinfo>name:Bed nets;</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="IRS" type="om:IRSDescription">
+     <xs:annotation>
+      <xs:documentation>
+              Description of indoor residual spraying interventions.
+            </xs:documentation>
+      <xs:appinfo>name:Indoor residual spraying;</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="GVI" type="om:GVIDescription">
+     <xs:annotation>
+      <xs:documentation>
+              Low-level description of intervention effects on vectors (i.e.
+              mosquitoes). Can be used to describe simple ITN or IRS
+              interventions (though more complex models are available for these
+              interventions) or other interventions such as mosquito repellant
+              or ivermectin.
+              
+              Note that all actions of this intervention component will decay
+              according to a single decay function. If independant decay is
+              wanted, a separate component can be used for each action.
+            </xs:documentation>
+      <xs:appinfo>name:Generic vector intervention;</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="recruitmentOnly" minOccurs="0">
+     <xs:annotation>
+      <xs:documentation>
+              Recruitment of a host into a sub-population.
+              
+              All human-targeting intervention deployments recruit simulated
+              humans into a sub-population which can be used for the purposes
+              of cumulative deployment, deployment only to a sub-population and
+              defining a cohort. This pseudo-intervention can be used to define
+              a sub-population without also deploying some intervention.
+            </xs:documentation>
+      <xs:appinfo>name:Recruitment only;</xs:appinfo>
+     </xs:annotation>
+     <xs:complexType/>
+    </xs:element>
+    <xs:element name="clearImmunity">
+     <xs:annotation>
+      <xs:documentation>
+              Removes all exposure-related immunitsy gained over time by hosts
+              without removing infections (or affecting the ability to gain
+              immunity through exposure).
+              
+              Hypothetical, but potentially useful to simulate scenarios with
+              unprotected humans.
+            </xs:documentation>
+      <xs:appinfo>name:Clear Immunity;</xs:appinfo>
+     </xs:annotation>
+     <xs:complexType/>
+    </xs:element>
+   </xs:choice>
+   <xs:element name="subPopRemoval" minOccurs="0" type="om:SubPopRemoval"/>
+  </xs:sequence>
+  <xs:attribute name="id" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          A short name or code identifying the intervention component
+          (used to refer to this component when describing an intervention).
+          Also the id of the sub-population defined as those hosts who have
+          received this intervention and who haven't subsequently been removed
+          from the sub-population.
+        </xs:documentation>
+    <xs:appinfo>name:Component identifier;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An informal name/description for the component
+        </xs:documentation>
+    <xs:appinfo>name:Name of component;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="SubPopRemoval">
+  <xs:annotation>
+   <xs:documentation>
+        Each human intervention component corresponds to a sub-population:
+        those who have received or are considered to be protected by the
+        intervention component. Humans automatically become members of this
+        sub-population when receiving an intervention component; this element
+        controls how humans are removed from the sub-population.
+        
+        ITN attrition also removes humans from sub-populations.
+        
+        Note that sub-populations do not directly correspond to an
+        intervention's effects: lack of effectiveness does not imply removal
+        from the sub-population (except as explicitly configured here) and
+        removal from the sub-population does not halt an intervention's
+        effects.
+        
+        Sub-populations may be used to define a cohort, to restrict deployment
+        of other interventions and to use cumulative deployment mode. A sub-
+        population may or may not correspond (roughly) to humans protected by
+        some intervention.
+      </xs:documentation>
+   <xs:appinfo>name:Remove from sub-population ...;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="onFirstBout" type="xs:boolean" default="false">
+   <xs:annotation>
+    <xs:documentation>
+          If true, remove individuals from the sub-population at the start of
+          the first episode (start of a clinical bout) since they were
+          recruited into the sub-population. This is intended for cohort
+          studies which measure time to the first episode, using active
+          case detection.
+          
+          Reports delayed due to health-system memory are forced out when this
+          occurs. Note that this can increase the number of uncomplicated cases
+          reported across the entire population; for this reason reports are
+          not forced on recruitment or most removal options.
+          
+          This does not prevent re-recruitment in the case that recruitment
+          settings could conceivably recruit the same individual twice.
+        </xs:documentation>
+    <xs:appinfo>name:Time to first episode only;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="onFirstTreatment" type="xs:boolean" default="false">
+   <xs:annotation>
+    <xs:documentation>
+          If true, remove individuals from the sub-population when they first
+          seektreatment since they were recruited into the sub-population. This
+          is intended for cohort studies which measure the time to first
+          episode, using passive case detection.
+          
+          Reports delayed due to health-system memory are forced out when this
+          occurs. Note that this can increase the number of uncomplicated cases
+          reported across the entire population; for this reason reports are
+          not forced on recruitment or most removal options.
+          
+          This does not prevent re-recruitment in the case that recruitment
+          settings could conceivably recruit the same individual twice.
+        </xs:documentation>
+    <xs:appinfo>name:Time to first treatment only;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="onFirstInfection" type="xs:boolean" default="false">
+   <xs:annotation>
+    <xs:documentation>
+          If true, remove individuals from the sub-population at completion of
+          the first survey in which they present with a patent infection since
+          they were recruited into the sub-population. This intended for cohort
+          studies which measure time to the first infection, using active
+          case detection.
+          
+          Reports delayed due to health-system memory are forced out when this
+          occurs. Note that this can increase the number of uncomplicated cases
+          reported across the entire population; for this reason reports are
+          not forced on recruitment or most removal options.
+          
+          This does not prevent re-recruitment in the case that recruitment settings could
+          conceivably recruit the same individual twice.
+        </xs:documentation>
+    <xs:appinfo>name:Time to first infection only;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="afterYears" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          If given, membership to the sub-population of humans who have
+          received this intervention component expires after the given number of
+          years. Note that future deployments renew membership (e.g. if this
+          parameter is 4 years and the intervention is redeployed 3 years from
+          now, expiry happens after 7 years).
+          
+          This provides a crude way of modelling a cohort protected by some
+          intervention. A few interventions provide more detailed ways of
+          modelling expiry of protection. In any case, &quot;expiry of protection&quot;
+          is an abstract concept and does not imply that all protection has
+          ceased, even in the simulator.
+          
+          This may also be useful for cumulative deployment.
+          
+          Minimum duration is zero, which implies the human is effectively
+          never a member of the sub-population; a duration of one timestep
+          implies the human is a member of the sub-population while any futher
+          interventions are deployed on the same time as this human becomes a
+          member and on the next update of the human (including transmission
+          and health system events) but not beyond that. If this attribute is
+          not given, the simulated human is a member until death or some other
+          option triggers removal.
+          
+          Input is rounded to the nearest time step.
+        </xs:documentation>
+    <xs:appinfo>name:Remove from sub-population after;units:Years;min:0;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="Screen">
+  <xs:annotation>
+   <xs:documentation>
+        This can be combined with MDA to achieve mass screen and treat (MSAT)
+        or other types of mass screening intervention.
+        
+        When deployed to a host, this simulates a test of patent malaria
+        (microscopy, RDT or some such), then triggers deployment of whichever
+        intervention components are configured (deployments for both positive
+        and negative test outcomes can be configured).
+        
+        The use of the screening itself is reported (if enabled), but not the
+        outcome. Deployment of interventions triggered by the screening may
+        be reported, however.
+      </xs:documentation>
+   <xs:appinfo>name:(Mass) screening;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="positive" minOccurs="0" maxOccurs="unbounded" type="om:Component"/>
+   <xs:element name="negative" minOccurs="0" maxOccurs="unbounded" type="om:Component"/>
+  </xs:sequence>
+  <xs:attribute name="diagnostic" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of a parameterised diagnostic (see scenario/diagnostics).
+        </xs:documentation>
+    <xs:appinfo>name:Name of diagnostic;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="VectorIntervention">
+  <xs:annotation>
+   <xs:documentation>
+        An intervention which may have various effects on the vector populations as a whole. (Not host specific.)
+        
+        Multiple instances of this intervention class are allowed (multiple parameterisations, not just deployments).
+        
+        Each instance may have multiple deployments. In this case the effects of each instance
+        are independent (effects are combined) but the effects of multiple deployments of a single
+        instance are not independent (only the latest deployment has any effect).
+      </xs:documentation>
+   <xs:appinfo>units:List of elements;name:Vector population intervention;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="description">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="anopheles" maxOccurs="unbounded" type="om:VectorSpeciesIntervention"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="timed" type="om:TimedBaseList">
+    <xs:annotation>
+     <xs:documentation>
+            List of timed vector population intervention deployment
+          </xs:documentation>
+     <xs:appinfo>name:Vector population intervention deployment;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of intervention (e.g. larviciding, sugar bait).
+        </xs:documentation>
+    <xs:appinfo>name:Name of intervention;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="VectorTrap">
+  <xs:annotation>
+   <xs:documentation>
+        Parameters and deployment of one type of trap. In case multiple types
+        of trap are needed simultaneously, multiple elements can be used. Note
+        that different types of trap do not interact except that all will
+        attract mosquitoes.
+      </xs:documentation>
+   <xs:appinfo>name:Vector trap intervetion;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="description" minOccurs="1" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation>
+            Parameters associated with a vector trap intervention, per
+            mosquito species.
+          </xs:documentation>
+     <xs:appinfo>name:Description;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="relativeAvailability" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>
+                  Describes the availiability of a trap to a
+                  host-seeking mosquito relative to an average
+                  unprotected adult.
+                  
+                  I.e. if this parameter is 2, then each trap will on
+                  average attract twice as many mosquitoes as
+                  unprotected adults.
+                  
+                  This is the initial availability; it may decay
+                  towards zero depending on the configured
+                  decay function.
+                </xs:documentation>
+        <xs:appinfo>units:Proportion;name:Initial relative availability;min:0;max:inf;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="decayOfAvailability" type="om:DecayFunction">
+       <xs:annotation>
+        <xs:documentation>
+                  Describes how availability decays to zero.
+                  
+                  If decay heterogeneity/variance is used, there will be a
+                  sample once-per-deployment (i.e. all traps of the same
+                  deployment will be affected the same way). There is no
+                  support for variances between traps (except in this crude
+                  way, between deployments).
+                </xs:documentation>
+        <xs:appinfo>name:Decay of availability;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="mosquito" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                Name of the species/subspecies/variant.
+              </xs:documentation>
+       <xs:appinfo>name:Species/subspecies/variant name</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="timed">
+    <xs:annotation>
+     <xs:documentation>
+            List of timed vector trap intervention deployment
+          </xs:documentation>
+     <xs:appinfo>name:Vector trap intervention deployment;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="deploy" minOccurs="0" maxOccurs="unbounded">
+       <xs:complexType>
+        <xs:complexContent>
+         <xs:extension base="om:TimedBase">
+          <xs:attribute name="ratioToHumans" type="xs:double" use="required">
+           <xs:annotation>
+            <xs:documentation>
+                          The number of traps deployed, by this
+                          deployment, per adult human.
+                          
+                          E.g. if there are currently 100 traps and 1000
+                          humans, then a ratio of 0.1 will increase the
+                          number of traps to 200.
+                        </xs:documentation>
+            <xs:appinfo>name:Ratio to humans;unit:dimensionless;min:0;max:inf;</xs:appinfo>
+           </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="lifespan" type="xs:string" use="required">
+           <xs:annotation>
+            <xs:documentation>
+                      Life of the trap until replaced or removed, e.g.
+                      &quot;73t&quot; or &quot;1y&quot;. After this time period, these traps
+                      will be removed from the simulation.
+                      
+                      New deployments do not automatically remove old
+                      traps. Existing traps cannot be refurbished in the
+                      model. It may make sense to make the end-of-life
+                      coincide with a new deployment.
+                        </xs:documentation>
+            <xs:appinfo>name:Lifespan;units:Steps or Days or Years;</xs:appinfo>
+           </xs:annotation>
+          </xs:attribute>
+         </xs:extension>
+        </xs:complexContent>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          Optional name for this type of trap
+        </xs:documentation>
+    <xs:appinfo>name:Descriptive name for type of trap;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="TimedBase">
+  <xs:attribute name="time" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Time at which this deployment occurs.
+          
+          See doc on intervention period and on monitoring/startDate for
+          details of how times work. Can be specified in steps, days,
+          years, or as a date (examples: 15t, 75d, 0.2y, 2000-03-16).
+        </xs:documentation>
+    <xs:appinfo>name:Time;units:User defined (defauls to steps);min:0;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DeploymentBase">
+  <xs:attribute name="coverage" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Proportion of otherwise eligible individuals who will receive this
+          deployment.
+        </xs:documentation>
+    <xs:appinfo>units:dimensionless;min:0;max:1;name:Coverage;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="vaccMinPrevDoses" type="xs:int" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          Applies to vaccines only: vaccine doses are only deployed by this
+          deployment if the previous number of doses (for the component
+          deployed) is at least this number.
+          
+          For example, if this is the second deployment opportunity for this
+          vaccine and this value is 1, then this deployment cannot deploy the
+          vaccine to individuals who did not receive the first deployment.
+        </xs:documentation>
+    <xs:appinfo>name:Vaccine min previous doses;units:inoculations;min:0;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="vaccMaxCumDoses" type="xs:int" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          Applies to vaccines only: vaccine doses are only deployed by this
+          deployment if the previous number of doses (for the component
+          deployed) is less than this number.
+        </xs:documentation>
+    <xs:appinfo>name:Vaccine max cumulative doses;units:inoculations;min:0;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="minAvailability" type="xs:int" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+              Minimum ento availability percentile. 
+              
+              This option is meant to be used with heterogeneity of availability, which can be specified in the entomology section. Without heterogenity (default), all hosts have the same availability and this option will have no effect.
+
+              The percentile must be an integer value between 0 and 100. Percentile 99th represents individuals who are more available than 99% of the population. Percentile 0 represents the least available individuals. 100 is equivalent for infinity.
+            </xs:documentation>
+    <xs:appinfo>units:percent;min:0;name:Minimum ento availability;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="maxAvailability" type="xs:int" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+              Maximum ento availability percentile. 
+              
+              This option is meant to be used with heterogeneity of availability, which can be specified in the entomology section. Without heterogenity (default), all hosts have the same availability and this option will have no effect.
+
+              The percentile must be an integer value between 0 and 100. Percentile 99th represents individuals who are more available than 99% of the population. Percentile 0 represents the least available individuals. 100 is equivalent for infinity.</xs:documentation>
+    <xs:appinfo>units:percent;min:0;name:Maximum ento availability;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="MassDeployment">
+  <xs:complexContent>
+   <xs:extension base="om:DeploymentBase">
+    <xs:attribute name="time" type="xs:string" use="required">
+     <xs:annotation>
+      <xs:documentation>
+              Time at which this deployment occurs.
+              
+              See doc on intervention period and on monitoring/startDate for
+              details of how times work. Can be specified in steps, days,
+              years, or as a date (examples: 15t, 75d, 0.2y, 2000-03-16).
+            </xs:documentation>
+      <xs:appinfo>name:Time;units:User defined (defauls to steps);min:0;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="maxAge" type="xs:double" use="optional">
+     <xs:annotation>
+      <xs:documentation>
+              Maximum age of eligible individuals (defaults to no limit).
+              
+              Input is rounded to the nearest time step.
+            </xs:documentation>
+      <xs:appinfo>units:Years;min:0;name:Maximum age of eligible individuals;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="minAge" type="xs:double" default="0">
+     <xs:annotation>
+      <xs:documentation>
+              Minimum age of eligible individuals (defaults to 0).
+              
+              Input is rounded to the nearest time step.
+            </xs:documentation>
+      <xs:appinfo>units:Years;min:0;name:Minimum age of eligible individuals;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="repeatStep" type="xs:string" use="optional">
+     <xs:annotation>
+      <xs:documentation>See repeatEnd's documentation.</xs:documentation>
+      <xs:appinfo>name:Step of repetition;units:User defined;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="repeatEnd" type="xs:string" use="optional">
+     <xs:annotation>
+      <xs:documentation>
+              Either both repeatStep and repeatEnd should be present
+              or neither. If present, the deployment is repeated every
+              repeatStep timesteps (i.e. if t0 is the initial time
+              and x is repeatStep, depolyments are done at times t0,
+              t0+x, t0+2*x, ...), ending before repeatEnd
+              (final repetition is the one before repeatEnd).
+              
+              Note that repeatEnd may be specified as a date but
+              repeatStep must be a duration (days, steps or years).
+            </xs:documentation>
+      <xs:appinfo>name:End of repetition (exclusive);units:User defined;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <xs:complexType name="ContinuousList">
+  <xs:sequence>
+   <xs:element name="restrictToSubPop" type="om:RestrictToSubPop" minOccurs="0"/>
+   <!-- Note: minimum is 1 to save an extra check in code. -->
+   <xs:element name="deploy" type="om:ContinuousDeployment" minOccurs="1" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="ContinuousDeployment">
+  <xs:complexContent>
+   <xs:extension base="om:DeploymentBase">
+    <xs:attribute name="targetAgeYrs" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:documentation>
+              Target age of intervention.
+              
+              Input is rounded to the nearest time step.
+            </xs:documentation>
+      <xs:appinfo>units:Years;min:0;max:100;name:Target age;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="begin" type="xs:string" use="optional">
+     <xs:annotation>
+      <xs:documentation>
+              First time at which this deployment is active. If not specified,
+              deployment starts at the beginning of the intervention period.
+              
+              See doc on intervention period and on monitoring/startDate for
+              details of how times work. Can be specified in steps, days,
+              years, or as a date (examples: 15t, 75d, 0.2y, 2000-03-16).
+            </xs:documentation>
+      <xs:appinfo>name:First time active;units:User defined (defauls to steps);</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="end" type="xs:string" use="optional">
+     <xs:annotation>
+      <xs:documentation>
+              End of the period during which the intervention is active (to be
+              exact, the first step of the intervention period at which the
+              item becomes inactive). If not specified, deployment never
+              ceases after starting during the simulation.
+              
+              See doc on intervention period and on monitoring/startDate for
+              details of how times work. Can be specified in steps, days,
+              years, or as a date (examples: 15t, 75d, 0.2y, 2000-03-16).
+            </xs:documentation>
+      <xs:appinfo>units:User defined (defauls to steps);name:End step;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <xs:complexType name="TimedBaseList">
+  <xs:sequence>
+   <!-- Note: minimum is 1 to save an extra check in code. -->
+   <xs:element name="deploy" type="om:TimedBase" minOccurs="1" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="MassListWithCum">
+  <xs:sequence>
+   <xs:element name="restrictToSubPop" minOccurs="0" type="om:RestrictToSubPop"/>
+   <xs:element name="cumulativeCoverage" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+          If this element is not specified, standard deployment occurs, where
+          a portion of the population as given by the coverage property of this
+          campaign is selected, and interventions are deployed to all of
+          these people (regardless of previous coverage).
+          
+          If this attribute is specified, instead, the population is divided
+          into two sets: those who are a member of a certain sub-population and
+          those who are not (see &quot;subPopRemoval&quot; element).
+          If the proportion of people in the
+          first set is less than the desired coverage, then the proportion of
+          people from the second set needed to increase total coverage to the
+          desired coverage is calculated. This proportion is then used as the
+          probablity of selection from the second set into a third set of
+          people who then receive all interventions deployed by this campaign.
+          
+          Note that selection is stochastic so the final coverage level may not
+          be exactly that desired. Note also that the component used when
+          selecting people need not actually be one of the components deployed
+          by this intervention, although that is the intended use case.
+          </xs:documentation>
+     <xs:appinfo>name:Cumulative coverage;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="component" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                The identifier (short name) of the component used when
+                selecting people.
+              </xs:documentation>
+       <xs:appinfo>name:Component identifier;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <!-- Note: minimum is 1 to save an extra check in code. -->
+   <xs:element name="deploy" type="om:MassDeployment" minOccurs="1" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="RestrictToSubPop">
+  <xs:annotation>
+   <xs:documentation>
+        If this element is specified, deployment is restricted to some
+        sub-population (specified via the &quot;id&quot; attribute); otherwise the
+        target population is the entire simulated population. Either way, other
+        deployment restrictions (age, time, number of vaccine doeses) still
+        apply.
+      </xs:documentation>
+   <xs:appinfo>name:Restrict to sub-population;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="id" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The identifier (short name) of the sub-population (i.e. the &quot;id&quot; of
+          some intervention component). Also see the &quot;complement&quot; attribute.
+        </xs:documentation>
+    <xs:appinfo>name:Sub-population identifier;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="complement" type="xs:boolean" default="false">
+   <xs:annotation>
+    <xs:documentation>
+          If this is not specified or is false, deployment is restricted to the
+          sub-population of people protected by the intervention component
+          who's id is given. If complement is set to true, deployment is
+          instead restricted to the complement of that sub-population, i.e. to
+          those <i>not</i> protected by the intervention component.
+        </xs:documentation>
+    <xs:appinfo>name:Complement;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="VaccineDescription">
+  <xs:annotation>
+   <xs:documentation>Description of a vaccine's effect</xs:documentation>
+   <xs:appinfo>name:Vaccine descriptions;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="decay" type="om:DecayFunction">
+    <xs:annotation>
+     <xs:documentation>
+            Specification of decay of efficacy. Documentation: see DecayFunction type
+            or https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions
+          </xs:documentation>
+     <xs:appinfo>name:Decay of effect;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="efficacyB" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Measure of variation in vaccine efficacy: efficacy is sampled from
+            a beta distribution with efficacyB its beta parameter and its alpha
+            parameter fixed such that the mean is that given by initialEfficacy.
+          </xs:documentation>
+     <xs:appinfo>units:Positive real;min:0.001;max:1.00E+06;name:Variance parameter for vaccine efficacy;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element maxOccurs="unbounded" minOccurs="0" name="initialEfficacy" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Mean efficacy values before decay (see efficacyB and decay parameter
+            descriptions for sampling and decay). The i-th value in this list
+            is used for the efficacy of the vaccine after the i-th dose. Where
+            more doses are given than there are values in this list, the last
+            value is repeated.
+          </xs:documentation>
+     <xs:appinfo>units:dimensionless;min:0;max:1;name:Initial mean efficacy;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="phenotype" type="om:VaccinePhenotype" minOccurs="0" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation>
+                  Pharmaco-Dynamic parameters for some resistance phenotype.
+                  
+                  To model resistance to this drug, describe multiple infection
+                  phenotypes (with respect to these PD parameters) and list one
+                  or more &quot;restrict&quot; elements for each phenotype.
+                  
+                  Loci are specified elsewhere. Multiple loci may influence the
+                  action of a single drug and each locus may influence multiple
+                  drugs.
+                </xs:documentation>
+     <xs:appinfo>name:PD parameters for some allele / resistance phenotype;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="ITNDescription">
+  <xs:annotation>
+   <xs:appinfo>name:Description</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="usage" type="om:DoubleValue" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+          Usage of nets by humans, from 0 to 1.
+          
+          At the moment this is constant across humans and deterministic:
+          relative attractiveness and survival factors are
+          base*(1-usage*propActing) + intervention_factor*usage*propActing.
+          
+          See also &quot;propActing&quot; (proportion of bits for which net acts).
+        </xs:documentation>
+     <xs:appinfo>units:dimensionless;min:0;max:1;name:Proportion of time nets are used by humans;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="holeRate" type="om:SampledValueLN">
+    <xs:annotation>
+     <xs:documentation>
+          The rate at which new holes are made in nets.
+          
+          nHoles(t) = nHoles(t-1) + X where X~Pois(R/T) where T is the number
+          of time-steps per year. R is sampled from
+          log-normal: R ~ log N( log(mean)-sigma²/2, sigma² ) and is covariant
+          with ripRate and insecticideDecay. (To be exact, a single Gaussian
+          sample is taken, adjusted for each sigma then exponentiated.)
+        </xs:documentation>
+     <xs:appinfo>units:Holes per annum;min:0;name:Rate at which holes are made;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="ripRate" type="om:SampledValueLN">
+    <xs:annotation>
+     <xs:documentation>
+          Each existing hole has a probability of being ripped bigger according
+          to a Poisson process with this rate as (only) parameter.
+          
+          New rips occur in a net at rate X~Pois(h×R/T) where h is the number
+          of existing holes and T the number of time-steps per year. R is
+          sampled from log-normal: R ~ log N( log(mean)-sigma²/2, sigma² )
+          and is covariant with holeRate and insecticideDecay. (To be exact, a
+          single Gaussian sample is taken, adjusted for the each and sigma
+          then exponentiated.)
+        </xs:documentation>
+     <xs:appinfo>units:Rips per existing hole per annum;min:0;name:Rate at which holes are enlarged;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="ripFactor" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+          This factor expresses how important rips are in increasing the hole.
+          
+          The hole index of a net is h + F×x where h and x are the total numbers
+          of holes and rips respectively and F is the rip factor.
+        </xs:documentation>
+     <xs:appinfo>units:none;min:0;name:Rip factor;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="initialInsecticide" type="om:SampledValueN">
+    <xs:annotation>
+     <xs:documentation>
+          The insecticide concentration of new nets is Gaussian distributed with
+          mean &quot;mu&quot; and a standard deviation &quot;sigma&quot;. The standard deviation
+          should be small relative to the mean to avoid negative initial
+          concentration. Any negative values sampled are set to 0.
+        </xs:documentation>
+     <xs:appinfo>units:mg/m²;min:0;name:Initial insecticide;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="insecticideDecay" type="om:DecayFunction">
+    <xs:annotation>
+     <xs:documentation>
+          Decay curve for insecticide content of nets. Documentation: see DecayFunction
+          type or https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions
+          
+          The distribution of decay rates over nets is covariant with the
+          distribution of ripRate and holeRate over nets. This distribution is
+          generated by taking one sample per net from a Gaussian distribution
+          with mean 0 and standard deviation 1. For each variable, the sample
+          is multiplied by the respective sigma and a constant added such that,
+          once exponentiated, the mean of the variable over nets is 1. The
+          variable is then exponentiated and multiplied by the required mean
+          rate for the respective variable.
+        </xs:documentation>
+     <xs:appinfo>units:none;name:Decay of insecticide;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="attritionOfNets" type="om:DecayFunction">
+    <xs:annotation>
+     <xs:documentation>
+          Specifies the rate at which nets are disposed of over time.
+          Documentation: see DecayFunction type or
+          https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions
+          
+          In the current model, nets are disposed of randomly (no correlation
+          with state of decay) such that the chance of each net surviving until
+          age t is the value of this decay function at time t. Equivalently
+          (where a large number of nets are distributed at the same time), the
+          proportion of nets remaining in use should match this decay function
+          over time.
+          
+          Humans are removed from the intervention component's sub-population
+          on disposal (attrition) of their nets. Currently this event is not 
+          reported.
+        </xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Attrition of nets;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="anophelesParams" maxOccurs="unbounded">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="holeIndexMax" type="om:DoubleValue" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                  Used by logit attacking and killing models only, holeIndexMax
+                  is a user defined maximum hole index (typically, the total surface area of a net).
+                </xs:documentation>
+        <xs:appinfo>units:in same unit as holeIndex;name:maximum of holed surface area that has an effect (comparable to no net)</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:choice>
+       <xs:element name="deterrency" type="om:ITNDeterrency">
+        <xs:annotation>
+         <xs:documentation>
+                  Effect of net on attractiveness of humans to mosquitoes relative to
+                  an unprotected adult human. Parameterisations should take into
+                  account that mosquitoes do not always bite indoors.
+                  
+                  Attractiveness of the human is multiplied by
+                  exp(log(H)×h + log(P)×p + log(I)×h×p
+                  where H, P and I are the hole, insecticide and interaction factors
+                  respectively, h=exp(-holeIndex×holeScalingFactor) and
+                  p=1−exp(-insecticideContent×insecticideScalingFactor).
+                  </xs:documentation>
+         <xs:appinfo>units:dimensionless;min:0;max:1;name:Relative attractiveness;</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+       <xs:element name="twoStageDeterrency">
+        <xs:annotation>
+         <xs:documentation>
+                  Effect of net on attractiveness of humans to mosquitoes relative to
+                  an unprotected adult human. Parameterisations should take into
+                  account that mosquitoes do not always bite indoors.
+                  
+                  This deterrency model multiplies human attractiveness by
+                  pEnt×pAtt.
+                  </xs:documentation>
+         <xs:appinfo>units:dimensionless;name:Relative attractiveness;</xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+         <xs:sequence>
+          <xs:choice>
+           <xs:element name="entering" type="om:IRSDeterrency">
+            <xs:annotation>
+             <xs:documentation>
+                            pEnt represents the relative probability of entering due to
+                            ITNs: pEnt = exp(log(P)×p) where P is the insecticide
+                            factor and 
+                            p=1−exp(-insecticideContent×insecticideScalingFactor).
+                          </xs:documentation>
+             <xs:appinfo>units:dimensionless;name:Deterrency: entering;</xs:appinfo>
+            </xs:annotation>
+           </xs:element>
+           <xs:element name="enteringLogit" type="om:ITNEnteringDeterrencyLogit">
+            <xs:annotation>
+             <xs:documentation>
+                            pEnt represents the relative probability of entering due to insecticide
+                            in the hut:
+                                pEnt = exp(logit.pEnt) / (exp(logit.pEnt) + 1)
+                                logit.pEnt = B + P * p
+                            where B is the basefactor (without net); P is insecticide factor, and
+                                p = log(insecticideContent+1).
+                            Without a net, probability of entering a house is
+                                pEnt0 = exp(logit.pEnt0) / (exp(logit.pEnt0) + 1)
+                                logit.pEnt0 = B
+                            Entering of mosquitoes is adjusted via multiplication by pEnt / pEnt0.
+                            To keep this in the range [0,1], we (normally) require that
+                                pEnt ≤ pEnt0
+                            and thus P ≤ 0 and give a warning if this is not fulfilled.
+                          </xs:documentation>
+             <xs:appinfo>units:dimensionless;name:Deterrency: entering (logit model);</xs:appinfo>
+            </xs:annotation>
+           </xs:element>
+          </xs:choice>
+          <xs:choice>
+           <xs:element name="attacking" type="om:ITNKillingEffect">
+            <xs:annotation>
+             <xs:documentation>
+                            pAtt represents the relative probability of attacking a human after
+                            entering a house due to ITNs (i.e. of feeding/dying vs. flying off):
+                                pAtt = B + H×h + P×p + I×h×p
+                            where B is the base (without net) probability; H, P and I are the hole,
+                            insecticide and interaction factors respectively,
+                                h=exp(-holeIndex × holeScalingFactor)
+                            and
+                                p=1 - exp(-insecticideContent × insecticideScalingFactor).
+                          </xs:documentation>
+             <xs:appinfo>units:dimensionless;name:Deterrency: attacking;</xs:appinfo>
+            </xs:annotation>
+           </xs:element>
+           <xs:element name="attackingLogit" type="om:ITNEffectLogit">
+            <xs:annotation>
+             <xs:documentation>
+                            pAtt represents the relative probability of attacking a human
+                            after entering a house due to ITNs (i.e. of feeding/dying vs.
+                            flying off):
+                                pAtt = exp(logit.pAtt) / (exp(logit.pAtt) + 1)
+                                logit.pAtt = B + H×min(h, hMax) + P×p + I×min(h, hMax)×p
+                            where B is the base factor (without net); H, P and
+                            I are the hole, insecticide and interaction factors
+                            respectively, and:
+                                h = log(holeIndex + 1)
+                                p = log(insecticideContent + 1)
+                            Without a net, probability of attacking a human
+                            after entering a house is
+                                pAtt0 = exp(logit.pAtt0) / (exp(logit.pAtt0) + 1)
+                                logit.pAtt0 = B + H×hMax
+                            where hMax=log(holeIndexMax + 1) and holeIndexMax is a user defined
+                            maximum hole index (typically, the total surface area of a net).
+                            Attacking of mosquitoes is adjusted via multiplication by pAtt / pAtt0.
+                            This may be larger and smaller than 1 (but will not be negative).
+                            By definition (through the logit transformation) pAtt0 &gt; 0.  
+                          </xs:documentation>
+             <xs:appinfo>units:dimensionless;name:Deterrency: attacking (logit model);</xs:appinfo>
+            </xs:annotation>
+           </xs:element>
+          </xs:choice>
+         </xs:sequence>
+        </xs:complexType>
+       </xs:element>
+      </xs:choice>
+      <xs:choice>
+       <xs:element name="preprandialKillingEffect" type="om:ITNKillingEffect">
+        <xs:annotation>
+         <xs:documentation>
+                  Effect of net on survival mosquitoes as they seek to bite a human
+                  after choosing that human, relative to the same person not
+                  sleeping under a net. Parameterisations should take into
+                  account that mosquitoes do not always bite indoors.
+                  
+                  Killing proportion is calculated as K = B + H×h + P×p + I×h×p
+                  where B is the base (without net) probability of death,
+                  H, P and I are the hole, insecticide and interaction factors
+                  respectively, h=exp(-holeIndex×holeScalingFactor) and
+                  p=1−exp(-insecticideContent×insecticideScalingFactor).
+                  
+                  Survival of mosquitoes is adjusted via multiplication by (1−K) / (1−B).
+                  To keep this in the range [0,1], we require that B+H ≤ 1, B+P ≤ 1,
+                  B+H+P+I ≤ 1, H ≥ 0, P ≥ 0 and H+P+I ≥ 0.
+                  </xs:documentation>
+         <xs:appinfo>units:dimensionless;min:0;max:1;name:Pre-prandial killing effect;</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+       <xs:element name="preprandialKillingEffectLogit" type="om:ITNEffectLogit">
+        <xs:annotation>
+         <xs:documentation>
+                  Effect of net on survival mosquitoes as they seek to bite a human
+                  after choosing that human, relative to the same person not
+                  sleeping under a net.                 
+                  Killing proportion is calculated as 
+                      K=exp(logit.K)/(exp(logit.K)+1)
+                      logit.K = B + H×min(h,hMax) + P×p + I×min(h,hMax)×p
+                  where B is the basefactor (without net),
+                  H, P and I are the hole, insecticide and interaction factors
+                  respectively, h=log(holeIndex+1) and
+                  p=log(insecticideContent+1).
+                  Without a net, the killing proportion
+                      K0=exp(logit.K0)/(exp(logit.K0)+1)
+                      logit.K0 = B + H×hMax
+                  where hMax=log(holeIndexMax+1) and holeIndexMax is a user defined maximum hole index (typically, the total surface area of a net).
+                  Survival of mosquitoes is adjusted via multiplication by (1−K) / (1−K0).
+                  To keep this in the range [0,1], we require that K ≥ K0. We enforce that P ≥ 0 (It would not make sense biologically if P were negative) and P+I*hMax ≥ 0 and H ≤ 0 and holeIndex ≤ holeIndexMax and give a warning if these conditions are not fulfilled.
+                  </xs:documentation>
+         <xs:appinfo>units:dimensionless;min:0;max:1;name:Pre-prandial killing effect (logit);</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+      </xs:choice>
+      <xs:choice>
+       <xs:element name="postprandialKillingEffect" type="om:ITNKillingEffect">
+        <xs:annotation>
+         <xs:documentation>
+                  Effect of net on survival mosquitoes as they seek to escape from
+                  a human host and rest after a blood meal, relative to the same
+                  person not sleeping under a net. Parameterisations should take
+                  into account that mosquitoes do not always bite indoors.
+                  
+                  Killing proportion is calculated as K = B + H×h + P×p + I×h×p
+                  where B is the base (without net) probability of death,
+                  H, P and I are the hole, insecticide and interaction factors
+                  respectively, h=exp(-holeIndex×holeScalingFactor) and
+                  p=1−exp(-insecticideContent×insecticideScalingFactor).
+                  
+                  Survival of mosquitoes is adjusted via multiplication by (1−K) / (1−B).
+                  To keep this in the range [0,1], we require that B+H ≤ 1, B+P ≤ 1,
+                  B+H+P+I ≤ 1, H ≥ 0, P ≥ 0 and H+P+I ≥ 0.
+                  </xs:documentation>
+         <xs:appinfo>units:dimensionless;min:0;max:1;name:Post-prandial killing effect;</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+       <xs:element name="postprandialKillingEffectLogit" type="om:ITNEffectLogit">
+        <xs:annotation>
+         <xs:documentation>
+                  Effect of net on survival mosquitoes as they seek to escape from
+                  a human host and rest after a blood meal, relative to the same
+                  person not sleeping under a net.
+                  Killing proportion is calculated as 
+                      K=exp(logit.K)/(exp(logit.K)+1)
+                      logit.K = B + H×min(h,hMax) + P×p + I×min(h,hMax)×p
+                  where B is the basefactor (without net),
+                  H, P and I are the hole, insecticide and interaction factors
+                  respectively, h=log(holeIndex+1) and
+                  p=log(insecticideContent+1).
+                  Without a net, the killing proportion
+                      K0=exp(logit.K0)/(exp(logit.K0)+1)
+                      logit.K0 = B + H×hMax
+                  where hMax=log(holeIndexMax+1) and holeIndexMax is a user defined maximum hole index (typically, the total surface area of a net).
+                  Survival of mosquitoes is adjusted via multiplication by (1−K) / (1−K0).
+                  To keep this in the range [0,1], we require that K ≥ K0. We enforce that P ≥ 0 (It would not make sense biologically if P were negative) and P+I*hMax ≥ 0 and H ≤ 0 and holeIndex ≤ holeIndexMax and give a warning if these conditions are not fulfilled.
+                </xs:documentation>
+         <xs:appinfo>units:dimensionless;min:0;max:1;name:Post-prandial killing effect (logit);</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+      </xs:choice>
+      <xs:choice>
+       <xs:element name="fecundityReduction" type="om:ITNKillingEffect" minOccurs="0">
+        <xs:annotation>
+         <xs:documentation>
+                    Effect of net on fertility of mosquitoes who survive feeding
+                    on a protected human, relative to an unprotected human.
+                    
+                    Fertility (number of eggs laid) is multiplied by (1-K) / (1-B),
+                    similar to killing effects. This is not allowed to be greater than 1.
+                  </xs:documentation>
+         <xs:appinfo>name:Fecundity reduction;</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+       <xs:element name="fecundityReductionLogit" type="om:ITNEffectLogit" minOccurs="0">
+        <xs:annotation>
+         <xs:documentation>
+                    Effect of net on fertility of mosquitoes who survive feeding
+                    on a protected human, relative to an unprotected human.
+                    
+                    Fertility (number of eggs laid) is multiplied by (1-K) / (1-K0),
+                    similar to killing effects. This is not allowed to be greater than 1.
+                  </xs:documentation>
+         <xs:appinfo>name:Fecundity reduction (logit);</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+      </xs:choice>
+     </xs:sequence>
+     <xs:attribute name="mosquito" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                Name of the affected anopheles-mosquito species.
+              </xs:documentation>
+       <xs:appinfo>name:Mosquito species;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="propActive" type="xs:double" default="1">
+      <xs:annotation>
+       <xs:documentation>
+              Deprecated: propActive can still be used but its value must be set to either 0 or 1.
+              Any other value will result in an error at initialization.
+              
+              The proportion of bites, when nets are in use, for which the net
+              has any action whatsoever on the mosquito.
+              
+              At the moment this is constant across humans and deterministic:
+              relative attractiveness and survival factors are
+              base*(1-usage*propActing) + intervention_factor*usage*propActing.
+              
+              See also &quot;usage&quot; (proportion of time nets are used by humans).
+            </xs:documentation>
+       <xs:appinfo>units:dimensionless;min:0;max:1;name:Proportion of bites for which net acts;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="GVIDescription">
+  <xs:sequence>
+   <xs:element name="usage" type="om:DoubleValue" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+          Usage of Generic vector interventions, from 0 to 1.
+        </xs:documentation>
+     <xs:appinfo>units:dimensionless;min:0;max:1;name:Proportion of generic vector interventions;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="decay" type="om:DecayFunction">
+    <xs:annotation>
+     <xs:documentation>
+            Description of decay of all intervention effects.
+            Documentation: see DecayFunction type or
+            https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions
+          </xs:documentation>
+     <xs:appinfo>name:Decay;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="anophelesParams" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:appinfo>name:Per-mosquito species parameters;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="deterrency" type="om:DoubleValue" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of intervention on attractiveness of humans to mosquitoes relative to
+                an unprotected adult human. Parameterisations should take into
+                account that mosquitoes do not always bite indoors.
+                
+                Attractiveness of the human is multiplied this factor times
+                survival of effect.
+                </xs:documentation>
+        <xs:appinfo>units:dimensionless;min:0;max:1;name:Relative attractiveness</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="preprandialKillingEffect" type="om:DoubleValue" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of intervention on survival of mosquitoes as they seek to bite a human
+                after choosing that human, relative to the same person not
+                protected by the intervention. Parameterisations should take into account
+                that mosquitoes do not always bite indoors. This parameter has
+                been added since some data shows IRS to have a preprandial
+                killing effect.
+                
+                Killing proportion is this factor multiplied by survival of effect.
+                </xs:documentation>
+        <xs:appinfo>units:dimensionless;min:0;max:1;name:Pre-prandial killing effect</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="postprandialKillingEffect" type="om:DoubleValue" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of intervention on survival of mosquitoes as they seek to escape from
+                a human host and rest after a blood meal, relative to the same
+                person not protected by the intervention. Parameterisations should take
+                into account that mosquitoes do not always bite indoors.
+                
+                Killing proportion is this factor multiplied by survival of effect.
+                </xs:documentation>
+        <xs:appinfo>units:dimensionless;min:0;max:1;name:Post-prandial killing effect</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="fecundityReduction" type="om:DoubleValue" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of intervention on fertility mosquitoes after successfully feeding on
+                a human host, relative to an unproteced human. Parameterisations should take
+                into account that mosquitoes do not always bite indoors.
+                
+                Fertility is multiplied by 1 - (fecundityReduction * decay).
+                </xs:documentation>
+        <xs:appinfo>min:0;name:Fecundity reduction effect</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="mosquito" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                Name of the affected anopheles-mosquito species.
+              </xs:documentation>
+       <xs:appinfo>name:Mosquito species</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="propActive" type="xs:double" default="1">
+      <xs:annotation>
+       <xs:documentation>
+              The proportion of bites for which the IRS
+              has any action whatsoever on the mosquito.
+              
+              At the moment this is constant across humans and deterministic:
+              relative attractiveness and survival factors are
+              base*(1-propActing) + intervention_factor*propActing.
+            </xs:documentation>
+       <xs:appinfo>units:dimensionless;min:0;max:1;name:Proportion of bites for which IRS acts;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="IRSDescription">
+  <xs:annotation>
+   <xs:documentation>
+        Description of effect for the more complex and probably more realistic
+        Briet model: IRS has three effects, whos strength is calculated as a
+        function of surviving insecticide content.
+      </xs:documentation>
+   <xs:appinfo>name:Description (based on decay of insecticide);</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="usage" type="om:DoubleValue" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+          Usage of Indoor residual spraying (IRS) interventions, from 0 to 1.
+        </xs:documentation>
+     <xs:appinfo>units:dimensionless;min:0;max:1;name:Proportion of Indoor residual spraying (IRS) interventions;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="initialInsecticide" type="om:SampledValueN">
+    <xs:annotation>
+     <xs:documentation>
+          The insecticide concentration of IRS (at time of spraying) is
+          Gaussian distributed with mean &quot;mu&quot; and a standard deviation &quot;sigma&quot;.
+          The standard deviation should be small relative to the mean to avoid
+          negative initial concentration. Any negative values sampled are set
+          to 0.
+        </xs:documentation>
+     <xs:appinfo>units:μg/cm²;min:0;name:Initial insecticide</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="insecticideDecay" type="om:DecayFunction">
+    <xs:annotation>
+     <xs:documentation>
+          Decay curve for insecticide content of IRS. Documentation: see DecayFunction
+          type or https://github.com/SwissTPH/openmalaria/wiki/ModelDecayFunctions
+        </xs:documentation>
+     <xs:appinfo>units:none;name:Decay of insecticide</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="anophelesParams" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:appinfo>name:Per-mosquito species parameters;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="deterrency" type="om:IRSDeterrency">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of IRS on attractiveness of humans to mosquitoes relative to
+                an unprotected adult human. Parameterisations should take into
+                account that mosquitoes do not always bite indoors.
+                
+                Attractiveness of the human is multiplied by exp(P×log(p))
+                where P is the insecticide factor,
+                p=1−exp(-insecticideContent×insecticideScalingFactor).
+                </xs:documentation>
+        <xs:appinfo>units:dimensionless;min:0;max:1;name:Relative attractiveness</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="preprandialKillingEffect" type="om:IRSKillingEffect">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of IRS on survival mosquitoes as they seek to bite a human
+                after choosing that human, relative to the same person not
+                protected by IRS. Parameterisations should take into account
+                that mosquitoes do not always bite indoors. This parameter has
+                been added since some data shows IRS to have a preprandial
+                killing effect.
+                
+                Killing proportion is calculated as K = B + P×p where B is the
+                base (without protection) probability of death, and P is the
+                insecticide factor,
+                p=1−exp(-insecticideContent×insecticideScalingFactor).
+                
+                Survival of mosquitoes is adjusted via multiplication by (1−K) / (1−B).
+                To keep this in the range [0,1], we require that B+P ≤ 1 and P ≥ 0.
+                </xs:documentation>
+        <xs:appinfo>units:dimensionless;min:0;max:1;name:Pre-prandial killing effect</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="postprandialKillingEffect" type="om:IRSKillingEffect">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of IRS on survival mosquitoes as they seek to escape from
+                a human host and rest after a blood meal, relative to the same
+                person not protected by IRS. Parameterisations should take
+                into account that mosquitoes do not always bite indoors.
+                
+                Killing proportion is calculated as K = B + P×p where B is the
+                base (without protection) probability of death, and P is the
+                insecticide factor,
+                p=1−exp(-insecticideContent×insecticideScalingFactor).
+                
+                Survival of mosquitoes is adjusted via multiplication by (1−K) / (1−B).
+                To keep this in the range [0,1], we require that B+P ≤ 1 and P ≥ 0.
+                </xs:documentation>
+        <xs:appinfo>units:dimensionless;min:0;max:1;name:Post-prandial killing effect</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="fecundityReduction" type="om:IRSKillingEffect" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                Effect of IRS on fertility mosquitoes after successfully feeding on
+                a human host, relative to an unproteced human. Parameterisations should take
+                into account that mosquitoes do not always bite indoors.
+                
+                First, we calculate K = B + P×p where B is the
+                base (without protection) probability of death, and P is the
+                insecticide factor,
+                p=1−exp(-insecticideContent×insecticideScalingFactor).
+                
+                Fecundity is multiplied by (1−K) / (1−B). It is not allowed to be greater than 1.
+                To keep this in the range [0,1], we require that B+P ≤ 1 and P ≥ 0.
+                </xs:documentation>
+        <xs:appinfo>name:Fecundity reduction</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="mosquito" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                Name of the affected anopheles-mosquito species.
+              </xs:documentation>
+       <xs:appinfo>name:Mosquito species</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="propActive" type="xs:double" default="1">
+      <xs:annotation>
+       <xs:documentation>
+              The proportion of bites for which the IRS
+              has any action whatsoever on the mosquito.
+              
+              At the moment this is constant across humans and deterministic:
+              relative attractiveness and survival factors are
+              base*(1-propActing) + intervention_factor*propActing.
+            </xs:documentation>
+       <xs:appinfo>units:dimensionless;min:0;max:1;name:Proportion of bites for which IRS acts;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="IRSDeterrency">
+  <xs:attribute name="insecticideFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Value expected to be at least 0. Negative values are not
+          necessarily invalid, but allow nets to increase transmission.
+        </xs:documentation>
+    <xs:appinfo>units:none;name:Insecticide factor;max:1</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="insecticideScalingFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:appinfo>units:none;name:Insecticide scaling factor;min:0</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="ITNEnteringDeterrencyLogit">
+  <xs:attribute name="baseFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          See parent element documentation
+        </xs:documentation>
+    <xs:appinfo>units:none;name:Base factor;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="insecticideFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          See parent element documentation
+        </xs:documentation>
+    <xs:appinfo>units:none;name:Insecticide factor;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="IRSKillingEffect">
+  <xs:complexContent>
+   <xs:extension base="om:IRSDeterrency">
+    <xs:attribute name="baseFactor" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:appinfo>units:dimensionless;name:Probability of mosquito death without intervention</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <xs:complexType name="ITNDeterrency">
+  <xs:complexContent>
+   <xs:extension base="om:IRSDeterrency">
+    <xs:attribute name="holeFactor" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:documentation>
+              Value expected to be at least 0. Negative values are not
+              necessarily invalid, but allow nets to increase transmission.
+            </xs:documentation>
+      <xs:appinfo>units:none;name:Hole factor;max:1</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="interactionFactor" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:documentation>
+              holeFactor + insecticideFactor + interactionFactor must not be greater
+              than 1, and is expected to be at least 0. A negative value is not
+              necessarily invalid, but allows nets to increase transmission.
+            </xs:documentation>
+      <xs:appinfo>units:none;name:Interaction factor;max:1</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="holeScalingFactor" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:appinfo>units:none;name:Hole scaling factor;min:0</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <xs:complexType name="ITNKillingEffect">
+  <xs:complexContent>
+   <xs:extension base="om:ITNDeterrency">
+    <xs:attribute name="baseFactor" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:appinfo>units:dimensionless;name:Probability of mosquito death without intervention</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <xs:complexType name="ITNEffectLogit">
+  <xs:attribute name="baseFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Logit of the probability (e.g. of death, of entry, of attacking) without intervention.
+        </xs:documentation>
+    <xs:appinfo>units:dimensionless;name:Base factor;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="insecticideFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Coefficient of log(insecticide content+1) in a generalized linear model with logit link
+          function.
+        </xs:documentation>
+    <xs:appinfo>units:none;name:Insecticide factor;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="holeFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Coefficient of log(total holed surface area (in cm2) +1) in a generalized linear model
+          with logit link function.
+        </xs:documentation>
+    <xs:appinfo>units:none;name:Hole factor;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="interactionFactor" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Coefficient of the interaction term of log(total holed surface area (in cm2) +1) with
+          log(insecticide content+1) in a generalized linear model with logit link function.
+        </xs:documentation>
+    <xs:appinfo>units:none;name:Interaction factor;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="VectorSpeciesIntervention">
+  <xs:annotation>
+   <xs:documentation>
+        Descriptions of the effects of vector interventions with per-species effects.
+      </xs:documentation>
+   <xs:appinfo>units:dimensionless;min:0;max:1;name:Vector population intervention;</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="seekingDeathRateIncrease" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Describe an effect on the increase in the death rate while host
+            seeking (mu_vA) due to this intervention.
+            
+            Enter the rate increase (i.e. if rate increases to 120% of normal,
+            give 0.2). New death rate while seeking is old × (1 + increase)
+            where increase is this factor given. Must have increas ≥ -1.
+          </xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Proportional increase in deaths while host searching;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="decay" type="om:DecayFunction"/>
+     </xs:sequence>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="probDeathOvipositing" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Describe an effect of increased mortality while ovipositing
+            due to this intervention. Enter the probability of dying due to
+            this intervention.
+          </xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Proportion ovipositing mosquitoes killed;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="decay" type="om:DecayFunction"/>
+     </xs:sequence>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:0;max:1;name:Initial probability of killing</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="emergenceReduction" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Describe an effect on emergence of pupa into adults: this value is the
+            proportion of emerging pupa which are killed by this intervention.
+            
+            This can be used as a crude way of modelling larviciding. It ca
+            also be used to increase emergence by giving a negative value.
+            The emergence rate is &quot;old rate&quot; × (1 - factor) where factor is the
+            value given here; thus, for example, using -1 will double emergence.
+          </xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Proportion of emerging pupa killed;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="decay" type="om:DecayFunction"/>
+     </xs:sequence>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-inf;max:1;name:Initial proportion reduction</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="probAdditionalDeathSugarFeeding" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Describe an effect on the increase in the death rate while host
+            seeking (mu_vA) due to this intervention. This works like 
+            adding an non-human host with its own availability. The
+            difference is that biting this sugar bait is associated with a 
+            probability of dying of 1: all mosquitoes biting the sugar bait
+            will die. OpenMalaria will automatically compute the 
+            availability for this host so that the probability of biting this
+            'host' (and thus dying) is equal to the input parameter.
+            
+            Enter the probability of dying while host seeking due to this 
+            intervention. If multiple interventions overlap, the cumulative 
+            probability will be used. Note that it cannot exceed 1, and 
+            OpenMalaria will return an error during the simulation if this
+            ever happens.
+
+            OpenMalaria will dynamically compute the necessary increase 
+            in mu_vA based on the given probability. Note that this is done 
+            by solving an equation numerically every timestep, which can 
+            cause a small drop in performance.</xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Probability of death while host searching as a result of feeding on a sugar bait (used to dynamically adjust mu_vA);</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="decay" type="om:DecayFunction"/>
+     </xs:sequence>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:all>
+  <xs:attribute name="mosquito" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of the species/subspecies/variant.
+        </xs:documentation>
+    <xs:appinfo>name:Species/subspecies/variant name</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="NonHumanHostsIntervention">
+  <xs:annotation>
+   <xs:documentation>This intervention modifies parameters of non-human hosts described in the &lt;entomology&gt; &lt;vector&gt; &lt;anopheles&gt;
+&lt;nonHumanHosts&gt; section of the input scenario file.
+
+The intervention is described by 5 parameters that define the change in each of non-human host parameters: 
+
+reduceAvailability: Reduction in the availability rate, αi. For example a value of 0 will result in no change; a value of 0.2 will reduce the availability to 0.8 of its initial value; and a value of 1 will set the availability to 0;
+
+prePrandialKillingEffect: Reduction in the pre-prandial survival probability, PBi.  For example a value of 0 will result in no change; a value of 0.2 will reduce PBi to 0.8 of its initial value; and a value of 1 will set PBi to 0;
+
+postPrandialKillingEffect: Reduction in the post-prandial survival probability, PCi.  For example a value of 0 will result in no change; a value of 0.2 will reduce PCi to 0.8 of its initial value; and a value of 1 will set PCi to 0;
+
+restingKillingEffect: Reduction in the survival probability of the resting period, PDi.  For example a value of 0 will result in no change; a value of 0.2 will reduce PDi to 0.8 of its initial value; and a value of 1 will set PDi to 0;</xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="decay" type="om:DecayFunction"/>
+   <xs:element name="description">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="anopheles" maxOccurs="unbounded" type="om:NonHumanHostsSpeciesIntervention"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="timed" type="om:TimedBaseList">
+    <xs:annotation>
+     <xs:documentation>
+            List of timed vector population intervention deployment
+          </xs:documentation>
+     <xs:appinfo>name:Vector population intervention deployment;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of intervention (e.g. larviciding, sugar bait).
+        </xs:documentation>
+    <xs:appinfo>name:Name of intervention;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="nonHumanHostsName" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of intervention (e.g. larviciding, sugar bait).
+        </xs:documentation>
+    <xs:appinfo>name:Name of intervention;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="NonHumanHostsSpeciesIntervention">
+  <xs:annotation>
+   <xs:documentation>
+        Descriptions of the effects of non human hosts interventions with per-species effects.
+      </xs:documentation>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="availabilityReduction" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>Reduction in the availability rate, αi. For example a value of 0 will result in no change; a value of 0.2 will reduce the availability to 0.8 of its initial value; and a value of 1 will set the availability to 0;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="preprandialKillingEffect" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>Reduction in the pre-prandial survival probability, PBi. For example a value of 0 will result in no change; a value of 0.2 will reduce PBi to 0.8 of its initial value; and a value of 1 will set PBi to 0;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="postprandialKillingEffect" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>Reduction in the post-prandial survival probability, PCi. For example a value of 0 will result in no change; a value of 0.2 will reduce PCi to 0.8 of its initial value; and a value of 1 will set PCi to 0;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="restingKillingEffect" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>Reduction in the survival probability of the resting period, PDi. For example a value of 0 will result in no change; a value of 0.2 will reduce PDi to 0.8 of its initial value; and a value of 1 will set PDi to 0;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="fecundityReduction" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>Reduction in the number of fertile eggs laid by a mosquito after biting this type of host, relative to an unprotected human. For example a value of 0 will result in no change; a value of 0.2 will reduce the fecundity factor to 0.8 of its initial value; and a value of 1 will set the fecundity factor to 0;</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="initial" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:appinfo>units:dimensionless;min:-1;max:inf;name:Initial proportion increase</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:all>
+  <xs:attribute name="mosquito" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of the species/subspecies/variant.
+        </xs:documentation>
+    <xs:appinfo>name:Species/subspecies/variant name</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="NonHumanHosts">
+  <xs:annotation>
+   <xs:documentation>Describes a new non-human hosts that have not been described in the &lt;entomology&gt; &lt;vector&gt; &lt;anopheles&gt; &lt;nonHumanHosts&gt;.</xs:documentation>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="description">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="anopheles" maxOccurs="unbounded" type="om:NonHumanHostsVectorSpecies"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element minOccurs="0" name="timed">
+    <xs:annotation>
+     <xs:documentation>
+            List of timed vector trap intervention deployment
+          </xs:documentation>
+     <xs:appinfo>name:Vector trap intervention deployment;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="deploy" minOccurs="0" maxOccurs="unbounded">
+       <xs:complexType>
+        <xs:complexContent>
+         <xs:extension base="om:TimedBase">
+          <xs:attribute name="lifespan" type="xs:string" use="required">
+           <xs:annotation>
+            <xs:documentation>
+                      Life of the trap until replaced or removed, e.g.
+                      &quot;73t&quot; or &quot;1y&quot;. After this time period, these traps
+                      will be removed from the simulation.
+                      
+                      New deployments do not automatically remove old
+                      traps. Existing traps cannot be refurbished in the
+                      model. It may make sense to make the end-of-life
+                      coincide with a new deployment.
+                        </xs:documentation>
+            <xs:appinfo>name:Lifespan;units:Steps or Days or Years;</xs:appinfo>
+           </xs:annotation>
+          </xs:attribute>
+         </xs:extension>
+        </xs:complexContent>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of intervention (e.g. larviciding, sugar bait).
+        </xs:documentation>
+    <xs:appinfo>name:Name of intervention;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="NonHumanHostsVectorSpecies">
+  <xs:annotation>
+   <xs:documentation>Descriptions of the effects of new non human hosts with per-species effects.
+      </xs:documentation>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="mosqRelativeAvailabilityHuman" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+                  Relative availability of the population of non-human hosts of
+                  type i to other non-human hosts; the sum of this across all
+                  non-human hosts must be 1.
+                </xs:documentation>
+     <xs:appinfo>units:Proportion; name:Relative availability of non-human host (ξ_i);</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="mosqProbBiting" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>Probability of mosquito successfully biting host</xs:documentation>
+     <xs:appinfo>units:Proportion;name:Probability of mosquito successfully biting host;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="mosqProbFindRestSite" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>Probability that the mosquito escapes host and finds a resting place after biting</xs:documentation>
+     <xs:appinfo>units:Proportion;name:Probability that the mosquito escapes host and finds a resting place after biting;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="mosqProbResting" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>Probability of mosquito successfully resting after finding a resting site</xs:documentation>
+     <xs:appinfo>units:Proportion;name:Probability of mosquito successfully resting after finding a resting site;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="hostFecundityFactor" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>Multiplicative factor for the number of fertile eggs laid by a mosquito after biting this type of host, relative to an unprotected human.</xs:documentation>
+     <xs:appinfo>units:Proportion;name:Probability of mosquito successfully resting after finding a resting site;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:all>
+  <xs:attribute name="mosquito" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of the species/subspecies/variant.
+        </xs:documentation>
+    <xs:appinfo>name:Species/subspecies/variant name</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="PhenotypeRestriction">
+  <xs:annotation>
+   <xs:documentation>
+            Specifies the mapping from genotype to phenotype. For each drug
+            type, if only one phenotype is present, restrictions need not be
+            specified, but otherwise restrictions must be specified.
+            
+            The set of loci affecting phenotypes of this drug's action must be
+            fixed for any drug type. Each phenotype must list, for each of
+            these loci, a restriction to one or more alleles under the locus.
+          </xs:documentation>
+   <xs:appinfo>name:Restrict phenotype applicability to certain alleles;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="onLocus" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+                A locus under which only a restricted set of alleles map to
+                this phenotype.
+              </xs:documentation>
+    <xs:appinfo>name:Locus relevant to the mapping of alleles to this phenotype;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="toAllele" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+                One allele of a locus upon which phenotype choice depends.
+                If multiple alleles under this locus should map to the same
+                phenotype, repeat the whole &quot;restriction onLocus...&quot; element.
+              </xs:documentation>
+    <xs:appinfo>name:Alleles mapping to this phenotype;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="VaccinePhenotype">
+  <xs:sequence>
+   <xs:element name="restriction" minOccurs="0" maxOccurs="unbounded" type="om:PhenotypeRestriction"/>
+   <xs:element maxOccurs="unbounded" minOccurs="1" name="initialEfficacy" type="om:DoubleValue">
+    <xs:annotation>
+     <xs:documentation>
+            Mean efficacy values before decay (see efficacyB and decay parameter
+            descriptions for sampling and decay). The i-th value in this list
+            is used for the efficacy of the vaccine after the i-th dose. Where
+            more doses are given than there are values in this list, the last
+            value is repeated.
+          </xs:documentation>
+     <xs:appinfo>units:dimensionless;min:0;max:1;name:Initial mean efficacy;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" use="optional" type="xs:string">
+   <xs:annotation>
+    <xs:documentation>
+          Name of the phenotype; for documentation use only.
+        </xs:documentation>
+    <xs:appinfo>name:Name of phenotype;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+
+ 
+ <xs:complexType name="Pharmacology">
+  <xs:annotation>
+   <xs:documentation>
+        A library of drug related data for the PK/PD model.
+      </xs:documentation>
+   <xs:appinfo>name:Pharmacology library;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="treatments">
+    <xs:annotation>
+     <xs:documentation>
+            A library of drug deployment schedules and dosages.
+          </xs:documentation>
+     <xs:appinfo>name:Treatments library;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="schedule" type="om:PKPDSchedule" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="dosages" type="om:PKPDDosages" minOccurs="1" maxOccurs="unbounded"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="drugs">
+    <xs:annotation>
+     <xs:documentation>
+            A library of drug PK/PD data.
+          </xs:documentation>
+     <xs:appinfo>name:Drug library;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="drug" type="om:PKPDDrug" minOccurs="1" maxOccurs="unbounded"/>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <!-- drug deployment params -->
+ <!--TODO: how to handle IV doses?
+   1) as now (caveats: qty is called mg but is actually mg/kg, a dosages table
+    must be given for treatment but is not actually relevant)
+   2) separate type of schedule
+   3) direct administration (no schedule)
+  -->
+ <xs:complexType name="PKPDSchedule">
+  <xs:annotation>
+   <xs:documentation>
+        A schedule for the administration of drugs in a course of treatment.
+        
+        Note that dose sizes are multiplied by some multiplier (see dosages)
+        and the times of all doses may be delayed.
+      </xs:documentation>
+   <xs:appinfo>name:Schedule of doses taken as a course of treatment;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="medicate" type="om:PKPDMedication" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name for referring to this deployment schedule
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="PKPDMedication">
+  <xs:attribute name="drug" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Abbreviated name of drug compound
+        </xs:documentation>
+    <xs:appinfo>name:drug;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="mg" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Quantity of drug compound in mg per *something*. A separate dosage
+          table must be used when medicating, which may specify multipliers of
+          this number based on patient age or weight.
+        </xs:documentation>
+    <xs:appinfo>units:mg per something;name:Drug dose (mg with multiplier);</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="hour" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+        Number of hours past start of timestep this drug dose is administered
+        at (first dose should be at hour 0).
+      </xs:documentation>
+    <xs:appinfo>units:Hours;min:0;name:Time of administration;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="PKPDDosages">
+  <xs:annotation>
+   <xs:documentation>
+        A table for selecting a dose size. There are several ways this can
+        work: using the patient's age or body mass in a look-up table to get a
+        multplier, or directly using body mass as the multiplier.
+        
+        The doses specified in &quot;mg&quot; in the treatment schedule are then
+        multiplied by this multiplier.
+      </xs:documentation>
+   <xs:appinfo>name:Dosage table;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:choice>
+    <xs:element name="age" type="om:PKPDDosageRange" maxOccurs="unbounded">
+     <xs:annotation>
+      <xs:documentation>
+              Select dose multiplier from a look-up table using the patient's age.
+            </xs:documentation>
+      <xs:appinfo>name:Look-up table (age);</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="bodymass" type="om:PKPDDosageRange" maxOccurs="unbounded">
+     <xs:annotation>
+      <xs:documentation>
+              Select dose multiplier from a look-up table using the patient's body mass.
+            </xs:documentation>
+      <xs:appinfo>name:Look-up table (weight);</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="multiply" maxOccurs="1">
+     <xs:annotation>
+      <xs:documentation>
+              Multiply the dose by some quantity, such as patient weight.
+            </xs:documentation>
+      <xs:appinfo>name:Multiply dose;</xs:appinfo>
+     </xs:annotation>
+     <xs:complexType>
+      <xs:attribute name="by" use="required">
+       <xs:annotation>
+        <xs:documentation>
+                  Quantity to multiply the dose by. Only option is &quot;kg&quot;
+                  (patient weight in kg).
+                </xs:documentation>
+        <xs:appinfo>name:By what?;</xs:appinfo>
+       </xs:annotation>
+       <xs:simpleType>
+        <xs:restriction base="xs:string">
+         <xs:enumeration value="kg"/>
+        </xs:restriction>
+       </xs:simpleType>
+      </xs:attribute>
+     </xs:complexType>
+    </xs:element>
+   </xs:choice>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name for referring to this dosage table
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="PKPDDosageRange">
+  <xs:annotation>
+   <xs:documentation>
+        A look-up table which uses patient age (in years) or weight (in kg) to
+        find a multiplier.
+      </xs:documentation>
+   <xs:appinfo>name:Age/weight range;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="lowerbound" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:appinfo>name:Lower bound (inclusive);min:0;units:years or kg;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="dose_mult" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The dose size given in the schedule (in &quot;mg&quot;) is multiplied by
+          this value for patients falling into this range when this
+          dosage table is used.
+        </xs:documentation>
+    <xs:appinfo>name:Dose multiplier;min:0;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <!-- drug intrinsic (PK/PD) params -->
+ <xs:complexType name="PKPDDrug">
+  <xs:annotation>
+   <xs:documentation>
+        A drug description with PK/PD parameters.
+      </xs:documentation>
+   <xs:appinfo>name:Drug parameters;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="PD">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="phenotype" type="om:Phenotype" minOccurs="1" maxOccurs="unbounded">
+       <xs:annotation>
+        <xs:documentation>
+                  Pharmaco-Dynamic parameters for some resistance phenotype.
+                  
+                  To model resistance to this drug, describe multiple infection
+                  phenotypes (with respect to these PD parameters) and list one
+                  or more &quot;restrict&quot; elements for each phenotype.
+                  
+                  Loci are specified elsewhere. Multiple loci may influence the
+                  action of a single drug and each locus may influence multiple
+                  drugs.
+                </xs:documentation>
+        <xs:appinfo>name:PD parameters for some allele / resistance phenotype;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:sequence>
+     <xs:attribute name="locus" type="xs:string" use="optional">
+      <xs:annotation>
+       <xs:documentation>
+                Optional; if present specifies the locus corresponding to this
+                drug's PD phenotypes: each phenotype must then match one of
+                that locus's alleles. Otherwise the drug should specify only
+                one phenotype.
+                
+                There is currently a one-to-many correspondance between loci
+                and drugs.
+              </xs:documentation>
+       <xs:appinfo>name:Locus;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="PK">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="negligible_concentration" type="xs:double">
+       <xs:annotation>
+        <xs:documentation>
+                    Concentration below which drug's effects are deemed negligible and can
+                    be removed from simulation.
+                  </xs:documentation>
+        <xs:appinfo>units:mg/l;min:0;name:Drug concentration considered negligible;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:choice>
+       <xs:element name="half_life" type="xs:double">
+        <xs:annotation>
+         <xs:documentation>
+                      Used to calculate elimination rate λ, calculated as
+                      λ = ln(2) / half_life. The basic form of decay is
+                      C(t) = C0 * exp(-λ*t).
+                      
+                      Alternatively, elimination rate can be specified via k
+                      and m_exponent.
+                    </xs:documentation>
+         <xs:appinfo>units:days;min:0;name:drug half-life;</xs:appinfo>
+        </xs:annotation>
+       </xs:element>
+       <xs:sequence>
+        <xs:element name="k" type="om:SampledValueLN">
+         <xs:annotation>
+          <xs:documentation>
+                      Constant used to calculate the elimination rate λ, which
+                      is calculated as λ = k / (body_mass ^ m_exponent), where
+                      body_mass is the patient's weight in kg and m_exponent is
+                      the next parameter. The basic form of decay is
+                      C(t) = C0 * exp(-λ*t).
+                      
+                      If CV &gt; 0, k is sampled per-human from the log-normal
+                      distribution: ln N( ln(mean) - σ^2 / 2, σ^2).
+                      
+                      Alternatively, elimination rate can be specified via half_life.
+                      </xs:documentation>
+          <xs:appinfo>units:day^-1;min:0;name:Constant associated with elimination rate (k);</xs:appinfo>
+         </xs:annotation>
+        </xs:element>
+        <xs:element name="m_exponent" type="xs:double">
+         <xs:annotation>
+          <xs:documentation>
+                      Constant used to calculate the elimination rate λ, which
+                      is calculated as λ = k / (body_mass ^ m_exponent), where
+                      body_mass is the patient's weight in kg and k is the
+                      previous parameter. The basic form of decay is
+                      C(t) = C0 * exp(-λ*t).
+                      
+                      Alternatively, elimination rate can be specified via half_life.
+                      
+                      Note that in the case of a conversion model, this applies
+                      to *both* the elimination and the conversion rates.
+                    </xs:documentation>
+          <xs:appinfo>units:day^-1;min:0;name:Constant associated with elimination rate (m_exponent);</xs:appinfo>
+         </xs:annotation>
+        </xs:element>
+       </xs:sequence>
+      </xs:choice>
+      <xs:element name="k_a" type="om:SampledValueLN" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                  Absorption rate parameter. Not allowed for one compartment
+                  models, but required for two and three compartment models and
+                  one compartment with conversion model (for the parent drug
+                  only).
+                </xs:documentation>
+        <xs:appinfo>name:Absorption rate constant (k_a);min:0;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="conversion" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                  Configures the parent drug in a conversion model.
+                  
+                  To use a conversion model, the parent drug should have this
+                  section defined as well as half-life or k (direct
+                  elimination; this may be zero) and k_a (absorption rate;
+                  this may be large).
+                  
+                  The metabolite drug should define half-life or k (elimination
+                  of metabolite), but not k_a (absorption rate) or this section
+                  (conversion). It is not possible for the metabolite to itself
+                  undergo conversion with the current models.
+                </xs:documentation>
+        <xs:appinfo>name:Conversion parameters (parent drug);</xs:appinfo>
+       </xs:annotation>
+       <xs:complexType>
+        <xs:all>
+         <xs:element name="metabolite" type="xs:string">
+          <xs:annotation>
+           <xs:documentation>
+                        The abbreviation of the metabolite drug (e.g. &quot;DHA&quot; or
+                        &quot;DHA_AR&quot;).
+                      </xs:documentation>
+           <xs:appinfo>name:Metabolite drug (abbreviation);</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+         <xs:element name="rate" type="om:SampledValueLN">
+          <xs:annotation>
+           <xs:documentation>
+                        Rate of conversion of parent drug to metabolite.
+                      </xs:documentation>
+           <xs:appinfo>name:Rate of conversion;unit:Per day;</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+         <xs:element name="molRatio" type="xs:double">
+          <xs:annotation>
+           <xs:documentation>
+                        Ratio of molecular weights: molecular weight of the
+                        metabolite divided by molecular weight of the parent.
+                      </xs:documentation>
+           <xs:appinfo>name:Molecular weight ratio;unit:unitless;</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+         <xs:element name="IC50_log_correlation" type="xs:double">
+          <xs:annotation>
+           <xs:documentation>
+                        The IC50 values of parent and metabolite drugs may be
+                        sampled from the log-normal distribution (if CV is greater than 0).
+                        This parameter controls correlation between these samples,
+                        measured in log-space.
+                        
+                        If this value is 1, samples are fully correlated: a single z-score is
+                        used to calculate both samples. If this is 0, two independent
+                        samples are used.
+                        
+                        Values between 0 and 1 (partial correlation) are supported;
+                        in this case IC50 values are sampled such that
+                        cor(log(x), log(y)) matches this value (where x, y are parent and
+                        metabolite IC50 values).
+                      </xs:documentation>
+           <xs:appinfo>name:IC50 log correlation;min:0;max:1;</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+        </xs:all>
+       </xs:complexType>
+      </xs:element>
+      <xs:element name="vol_dist" type="om:SampledValueLN">
+       <xs:annotation>
+        <xs:documentation>
+                    Volume of Distribution.
+                    
+                    If CV &gt; 0 this is sampled from a log-normal distribution.
+                  </xs:documentation>
+        <xs:appinfo>units:l/kg;min:0;name:Volume of Distribution (Vd);</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="compartment2" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                  Optional element specifying conversion parameters to- and
+                  from- a second compartment.
+                </xs:documentation>
+        <xs:appinfo>name:Second compartment parameters;</xs:appinfo>
+       </xs:annotation>
+       <xs:complexType>
+        <xs:all>
+         <xs:element name="k12" type="om:SampledValueLN">
+          <xs:annotation>
+           <xs:documentation>
+                          Absorption rate from the central compartment to the
+                          first periphery compartment (2).
+                          
+                          It is sampled per-patient when CV &gt; 0.
+                      </xs:documentation>
+           <xs:appinfo>units:day^-1;min:0;name:Absorption rate to compartment 2 (k12);</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+         <xs:element name="k21" type="om:SampledValueLN">
+          <xs:annotation>
+           <xs:documentation>
+                          Absorption rate from the first periphery compartment
+                          (2) to the central compartment.
+                          
+                          It is sampled per-patient when CV &gt; 0.
+                      </xs:documentation>
+           <xs:appinfo>units:day^-1;min:0;name:Absorption rate from compartment 2 (k21);</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+        </xs:all>
+       </xs:complexType>
+      </xs:element>
+      <xs:element name="compartment3" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>
+                  Optional element specifying conversion parameters to- and
+                  from- a third compartment.
+                </xs:documentation>
+        <xs:appinfo>name:Third compartment parameters;</xs:appinfo>
+       </xs:annotation>
+       <xs:complexType>
+        <xs:all>
+         <xs:element name="k13" type="om:SampledValueLN">
+          <xs:annotation>
+           <xs:documentation>
+                          Absorption rate from the central compartment to the
+                          second periphery compartment (3).
+                          
+                          It is sampled per-patient when CV &gt; 0.
+                      </xs:documentation>
+           <xs:appinfo>units:day^-1;min:0;name:Absorption rate to compartment 3 (k13);</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+         <xs:element name="k31" type="om:SampledValueLN">
+          <xs:annotation>
+           <xs:documentation>
+                          Absorption rate from the second periphery compartment
+                          (3) to the central compartment.
+                          
+                          It is sampled per-patient when CV &gt; 0.
+                      </xs:documentation>
+           <xs:appinfo>units:day^-1;min:0;name:Absorption rate from compartment 3 (k31);</xs:appinfo>
+          </xs:annotation>
+         </xs:element>
+        </xs:all>
+       </xs:complexType>
+      </xs:element>
+     </xs:sequence>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="abbrev" use="required" type="xs:string"/>
+ </xs:complexType>
+ <xs:complexType name="Phenotype">
+  <xs:sequence>
+   <xs:element name="restriction" minOccurs="0" maxOccurs="unbounded">
+    <xs:annotation>
+     <xs:documentation>
+            Specifies the mapping from genotype to phenotype. For each drug
+            type, if only one phenotype is present, restrictions need not be
+            specified, but otherwise restrictions must be specified.
+            
+            The set of loci affecting phenotypes of this drug's action must be
+            fixed for any drug type. Each phenotype must list, for each of
+            these loci, a restriction to one or more alleles under the locus.
+          </xs:documentation>
+     <xs:appinfo>name:Restrict phenotype applicability to certain alleles;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:attribute name="onLocus" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                A locus under which only a restricted set of alleles map to
+                this phenotype.
+              </xs:documentation>
+       <xs:appinfo>name:Locus relevant to the mapping of alleles to this phenotype;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="toAllele" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>
+                One allele of a locus upon which phenotype choice depends.
+                If multiple alleles under this locus should map to the same
+                phenotype, repeat the whole &quot;restriction onLocus...&quot; element.
+              </xs:documentation>
+       <xs:appinfo>name:Alleles mapping to this phenotype;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="max_killing_rate" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+              k1 — Maximal parasite killing rate.
+            </xs:documentation>
+     <xs:appinfo>units:1/days;min:0;name:Maximal parasite killing rate;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="IC50" type="om:SampledValueLN">
+    <xs:annotation>
+     <xs:documentation>
+            Half maximal effect concentration.
+            
+            If CV &gt; 0, the IC50 is sampled from a log-normal distribution.
+          </xs:documentation>
+     <xs:appinfo>units:mg/l;min:0;name:IC50;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+   <xs:element name="slope" type="xs:double">
+    <xs:annotation>
+     <xs:documentation>
+              n — Slope of the concentration effect curve
+            </xs:documentation>
+     <xs:appinfo>units:dimensionless;name:Slope of effect curve;</xs:appinfo>
+    </xs:annotation>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="name" use="optional" type="xs:string">
+   <xs:annotation>
+    <xs:documentation>
+          Name of the phenotype; for documentation use only.
+        </xs:documentation>
+    <xs:appinfo>name:Name of phenotype;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+
+ <!-- Component and TriggeredDeployments would be in interventions.xsd, except
+    that they are needed from healthSystem.xsd -->
+ <xs:complexType name="Component">
+  <xs:annotation>
+   <xs:documentation>
+        The list of components deployed to eligible humans.
+      </xs:documentation>
+   <xs:appinfo>name:Component to be deployed;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="id" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The identifier (short name) of a component.
+        </xs:documentation>
+    <xs:appinfo>name:Identifier;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="TriggeredDeployments">
+  <xs:annotation>
+   <xs:documentation>
+        Lists intervention components which are deployed according to some
+        external trigger (for example, screening with a negative patency
+        outcome or health-system treatment).
+        
+        Components are referenced from one or more sub-lists. Each of these
+        lists is deployed independently if and only if its age constraints are
+        met by the human host and a random sample with the given probability of
+        a positive outcome is positive.
+      </xs:documentation>
+   <xs:appinfo>name:Triggered intervention deployment;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="deploy" minOccurs="0" maxOccurs="unbounded">
+    <xs:complexType>
+     <xs:sequence>
+      <xs:element name="component" maxOccurs="unbounded" type="om:Component"/>
+     </xs:sequence>
+     <xs:attribute name="maxAge" type="xs:double" use="optional">
+      <xs:annotation>
+       <xs:documentation>
+                Maximum age of eligible humans (defaults to no limit).
+                
+                Input is rounded to the nearest time step.
+              </xs:documentation>
+       <xs:appinfo>units:Years;min:0;name:Maximum age of eligible humans;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="minAge" type="xs:double" default="0">
+      <xs:annotation>
+       <xs:documentation>
+                Minimum age of eligible humans (defaults to 0).
+                
+                Input is rounded to the nearest time step.
+              </xs:documentation>
+       <xs:appinfo>units:Years;min:0;name:Minimum age of eligible humans;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+     <xs:attribute name="p" type="xs:double" default="1">
+      <xs:annotation>
+       <xs:documentation>
+                Probability of this list of components being deployed, given
+                that other constraints are met.
+              </xs:documentation>
+       <xs:appinfo>units:dimensionless;min:0;max:1;name:Probability of delivery to eligible humans;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="OptionSet">
+  <xs:sequence>
+   <xs:element name="option" type="om:Option" minOccurs="0" maxOccurs="unbounded"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="Option">
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of an option (monitoring measure or model option).
+        </xs:documentation>
+    <xs:appinfo>name:Option name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="value" type="xs:boolean" default="true">
+   <xs:annotation>
+    <xs:documentation>
+          Option on/off switch (true/false). Specifying value=&quot;true&quot; is
+          the same as not specifying a value; specifying value=&quot;false&quot;
+          explicitly turns the option off. If an option is not mentioned
+          at all, it is left at its default value (normally off, but
+          in a few cases, such as some bug-fix options, on).
+        </xs:documentation>
+    <xs:appinfo>name:Indicator of whether option is required;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DoubleList">
+  <xs:sequence>
+   <xs:element name="item" maxOccurs="unbounded" type="xs:double"/>
+  </xs:sequence>
+ </xs:complexType>
+ <xs:complexType name="DecayFunction">
+  <xs:annotation>
+   <xs:documentation>
+        Specification of decay or survival of a parameter.
+      </xs:documentation>
+   <xs:appinfo>name:Decay or survival of a parameter</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence minOccurs="0" maxOccurs="unbounded">
+   <xs:element name="decay" type="om:DecayFunction"/>
+  </xs:sequence>
+  <xs:attribute name="function" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Determines which decay function to use. Available decay functions,
+          for age t in years:
+          
+          constant: 1
+          
+          step: 1 for t less than L, otherwise 0
+          
+          linear: 1 - t/L for t less than L, otherwise 0
+          
+          exponential: exp( - t/L * log(2) )
+          
+          weibull: exp( -(t/L)^k * log(2) )
+          
+          hill: 1 / (1 + (t/L)^k)
+          
+          smooth-compact: exp( k - k / (1 - (t/L)^2) ) for t less than L, otherwise 0
+        </xs:documentation>
+    <xs:appinfo>units:None;min:0;max:1;name:function;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="constant"/>
+     <xs:enumeration value="step"/>
+     <xs:enumeration value="linear"/>
+     <xs:enumeration value="exponential"/>
+     <xs:enumeration value="weibull"/>
+     <xs:enumeration value="hill"/>
+     <xs:enumeration value="smooth-compact"/>
+     <xs:enumeration value="plus"/>
+     <xs:enumeration value="minus"/>
+     <xs:enumeration value="divides"/>
+     <xs:enumeration value="multiplies"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="L" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          (Time) scale parameter of distribution: this is either the age of
+          complete decay (smooth-compact, step and linear functions) or the age
+          at which the parameter has decayed to half its original value
+          (exponential, weibull and hill). Not used when function=&quot;constant&quot;
+          (i.e. no decay).
+          
+          This value can be specified in years, days or steps (e.g. 2y, 180d or
+          100t). When the unit is not specified years are assumed. The value is
+          used without rounding except when sampling an age of decay, when the
+          rounding happens as late as possible.
+        </xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to years);min:0;name:L;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="k" type="xs:double" default="1.0">
+   <xs:annotation>
+    <xs:documentation>
+          Shape parameter of distribution. If not specified, default value of
+          1 is used. Meaning depends on function; not used in some cases.
+        </xs:documentation>
+    <xs:appinfo>min:0;name:k;units:none;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="CV" type="xs:double" default="0">
+   <xs:annotation>
+    <xs:documentation>
+        If CV is non-zero, heterogeneity of decay is introduced via a random
+        variable sampled from the log-normal distribution. This distribution is
+        parameterised with mean=1 and CV as given.
+        
+        The effective age of decay is the real age multiplied by this variable
+        (for decay functions with a half-life, this is equivalent to dividing
+        the half-life by the variable).
+        </xs:documentation>
+    <xs:appinfo>min:0;name:Coefficient of Variation;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="increasing" type="xs:boolean" default="false">
+   <xs:annotation>
+    <xs:documentation>
+          (Boolean) If True, this tells OpenMalaria to use the complement of the
+          DecayFunction defined as 1-f(x). This is useful to model increasing
+          functions that will &quot;decay&quot; to 1. This only works if f(x) is contained
+          between 0 and 1.
+</xs:documentation>
+    <xs:appinfo>units:User-defined (defaults to years);min:0;name:L;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="initialEfficacy" type="xs:double" use="optional" default="1">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: Efficacy between 0 and 1.
+        </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="rho" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: Proportion between 0 and 1, proportion of the response that is short-lived.</xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="halflife_short" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: halflife of short lived component (default to years).
+
+        </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="halflife_long" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          biphasic: halflife of long lived component (default to years).
+
+        </xs:documentation>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="SampledValueN">
+  <xs:annotation>
+   <xs:documentation>
+        A parameter with optional heterogeneity.
+        
+        Optionally, a distribution (&quot;distr&quot;) and standard of deviation (&quot;SD&quot;) may be specified.
+      </xs:documentation>
+   <xs:appinfo>name:Sampled value (normal);</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="mean" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The mean value.
+        </xs:documentation>
+    <xs:appinfo>name:mean;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="SD" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          The standard deviation of variates.
+        </xs:documentation>
+    <xs:appinfo>name:standard deviation;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="distr" use="optional" default="const">
+   <xs:annotation>
+    <xs:documentation>
+          To allow heterogeneity, a distribution must be specified.
+          
+          Valid options are as follows.
+          
+          &quot;const&quot;: no variation or sampling. Specifying distr=&quot;const&quot; has the
+          same effect as not specifying distr at all.
+          
+          &quot;normal&quot;: the parameter is sampled from a normal distribution.
+        </xs:documentation>
+    <xs:appinfo>name:Distribution;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="const"/>
+     <xs:enumeration value="normal"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="BetaMeanSample">
+  <xs:annotation>
+   <xs:documentation>
+        Parameters of a normal distribution, provided as mean and variance.
+        
+        Variates are sampled from Be(α,β) where α and β are determined from the
+        mean and variance as follows: let v be the variance and c=mean/(1-mean).
+        Then we set α=cβ and β=((c+1)²v - c)/((c+1)³v).
+      </xs:documentation>
+   <xs:appinfo>name:Log-normal parameters;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="mean" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The mean of the beta distribution (must be in the open range (0,1)).
+        </xs:documentation>
+    <xs:appinfo>units:none;name:mean;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="variance" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The standard deviation of variates.
+        </xs:documentation>
+    <xs:appinfo>units:none;name:variance;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="SampledValueCV">
+  <xs:annotation>
+   <xs:documentation>
+        A parameter with optional heterogeneity.
+        
+        The mean cannot be specified (unless this type is extended).
+        Optionally, a distribution (&quot;distr&quot;) and coefficient of variation (&quot;CV&quot;) may be specified.
+      </xs:documentation>
+   <xs:appinfo>name:Sampled value (log normal);</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="CV" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          The (linear) coefficient of variation.
+          
+          This value must be specified when a (non-constant) distribution is used. 
+          Note: since version 46, variance can be used instead.
+          
+          Note that specifying CV=&quot;0&quot; has the same effect as distr=&quot;const&quot; and
+          disables sampling of this parameter, even if distr is not &quot;const&quot;. 
+        </xs:documentation>
+    <xs:appinfo>name:Coefficient of variation;units:unitless;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="distr" use="optional" default="const">
+   <xs:annotation>
+    <xs:documentation>
+          To allow heterogeneity, a distribution must be specified.
+          
+          Valid options are as follows.
+          
+          &quot;const&quot;: no variation or sampling. Specifying distr=&quot;const&quot; has the
+          same effect as not specifying distr at all.
+          
+          &quot;lognormal&quot;: the parameter is sampled from a log-normal distribution.
+          Note that the &quot;mean&quot; and &quot;CV&quot; values are linear (arithmetic) properties
+          of the distribution and not log-space properties.
+        </xs:documentation>
+    <xs:appinfo>name:Distribution;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="const"/>
+     <xs:enumeration value="lognormal"/>
+     <xs:enumeration value="gamma"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="variance" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          The variance parameter of the distirbution.
+          
+          This value can be specified when a (non-constant) distribution is used.
+          
+          Note that specifying variance=&quot;0&quot; has the same effect as distr=&quot;const&quot; and
+          disables sampling of this parameter, even if distr is not &quot;const&quot;. 
+        </xs:documentation>
+    <xs:appinfo>name:Coefficient of variation;units:unitless;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="SampledValueLN">
+  <xs:annotation>
+   <xs:documentation>
+        A parameter with optional log-normal heterogeneity.
+        
+        The mean value must be specified. Optionally, a distribution (&quot;distr&quot;)
+        and coefficient of variation (&quot;CV&quot;) may be specified.
+      </xs:documentation>
+   <xs:appinfo>name:Sampled value;</xs:appinfo>
+  </xs:annotation>
+  <xs:complexContent>
+   <xs:extension base="om:SampledValueCV">
+    <xs:attribute name="mean" type="xs:double" use="required">
+     <xs:annotation>
+      <xs:documentation>
+              The (linear) mean value.
+            </xs:documentation>
+      <xs:appinfo>name:mean;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:complexContent>
+ </xs:complexType>
+ <xs:complexType name="WeibullSample">
+  <xs:annotation>
+   <xs:documentation>
+        Parameters of a Weibull distribution.
+      </xs:documentation>
+   <xs:appinfo>name:Weibull parameters;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="scale" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The Weibull scale parameter (λ).
+        </xs:documentation>
+    <xs:appinfo>name:Scale;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="shape" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          The Weibull shape parameter (k).
+        </xs:documentation>
+    <xs:appinfo>name:shape;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="distr" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          To allow heterogeneity, a distribution must be specified.
+          In this case, only &quot;weibull&quot; is allowed.
+        </xs:documentation>
+    <xs:appinfo>name:Distribution;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="weibull"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DoubleValue">
+  <xs:attribute name="value" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>A double-precision floating-point value.</xs:documentation>
+    <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="IntValue">
+  <xs:attribute name="value" type="xs:int" use="required">
+   <xs:annotation>
+    <xs:documentation>An integer value.</xs:documentation>
+    <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="BooleanValue">
+  <xs:attribute name="value" type="xs:boolean" use="required">
+   <xs:annotation>
+    <xs:documentation>A boolean value.</xs:documentation>
+    <xs:appinfo>name:Input parameter value;exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="AgeGroupValues">
+  <xs:sequence>
+   <xs:element maxOccurs="unbounded" name="group">
+    <xs:annotation>
+     <xs:documentation>
+            A series of values according to age groups, each specified with
+            a lower-bound and a value. The first lower-bound specified must be
+            zero; a final upper-bound of infinity is added to complete the last
+            age group. At least one age group is required. Normally these are
+            interpolated by a continuous function (see interpolation attribute).
+          </xs:documentation>
+     <xs:appinfo>name:age group;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:complexContent>
+      <xs:extension base="om:DoubleValue">
+       <xs:attribute name="lowerbound" type="xs:double" use="required">
+        <xs:annotation>
+         <xs:documentation>
+                    Lower bound of age group
+                  </xs:documentation>
+         <xs:appinfo>units:Years;min:0;max:100;name:Lower bound;</xs:appinfo>
+        </xs:annotation>
+       </xs:attribute>
+      </xs:extension>
+     </xs:complexContent>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <!-- NOTE: would specify default="linear" except for a possible bug in Code
+    Synthesis' XSD associated with creating blank AgeGroupValues elements -->
+  <xs:attribute name="interpolation" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          Interpolation algorithm. Normally it is desirable for age-based
+          values to be continuous w.r.t. age. By default linear interpolation
+          is used.
+          
+          With all algorithms except &quot;none&quot;, the age groups are converted to a
+          set of points centred within each age range. Extra
+          points are added at each end (zero and infinity) to keep value
+          constant at both ends of the function. A zero-length age group may
+          be used as a kind of barrier to adjust the distribution; e.g. with
+          age group boundaries at 15, 20 and 25 years, a (linear) spline would
+          be drawn between ages 17.5 and 22.5, whereas with boundaries at
+          15, 20 and 20 years, a spline would be drawn between ages 17.5 and 20
+          years (may be desired if individuals are assumed to reach adult size
+          at 20).
+          
+          Algorithms:
+          1. none: input values are used directly
+          2. linear: straight lines (on an age vs. value graph) are used to
+          interpolate data points.
+        </xs:documentation>
+    <xs:appinfo>name:interpolation;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="none"/>
+     <xs:enumeration value="linear"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+ </xs:complexType>
+
+  <!---HumanPopulationStructure-->
+  <xs:complexType name="Demography">
+    <xs:sequence>
+      <xs:element name="ageGroup" type="om:DemogAgeGroup">
+        <xs:annotation>
+          <xs:documentation>
+            list of age groups included in demography
+          </xs:documentation>
+          <xs:appinfo>name:Age groups;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Name of demography data
+        </xs:documentation>
+        <xs:appinfo>name:Name of demography data;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="popSize" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation>Population size</xs:documentation>
+        <xs:appinfo>units:Count;min:1;max:100000;name:Population size;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="maximumAgeYrs" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Maximum age of simulated humans in years
+        </xs:documentation>
+        <xs:appinfo>units:Years;min:0;max:100;name:Maximum age of simulated humans;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="growthRate" type="xs:double" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Growth rate of human population.
+            (we should be able to implement this with non-zero values)
+        </xs:documentation>
+        <xs:appinfo>units:Number;min:0;max:0;name:Growth rate of human population;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- ageGroup -->
+  <xs:complexType name="DemogAgeGroup">
+    <xs:annotation>
+      <xs:documentation>
+        list of age groups included in demography or surveys
+      </xs:documentation>
+      <xs:appinfo>name:list of age groups;</xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element maxOccurs="unbounded" name="group" type="om:DemogGroupBounds"/>
+    </xs:sequence>
+    <xs:attribute name="lowerbound" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Lower bound of age group
+        </xs:documentation>
+        <xs:appinfo>units:Years;min:0;max:100;name:Lower bound of age group</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="DemogGroupBounds">
+    <xs:attribute name="poppercent" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Percentage of human population in age group
+        </xs:documentation>
+        <xs:appinfo>units:Percentage;min:0;max:100;name:Percentage in age group</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="upperbound" type="xs:double" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          Upper bound of age group
+        </xs:documentation>
+        <xs:appinfo>units:Years;min:0;max:100;name:Upper bound of age group</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  
+  <xs:complexType name="Vivax">
+    <xs:all>
+      <xs:element name="probBloodStageInfectiousToMosq" type="om:DoubleValue">
+        <xs:annotation>
+          <xs:documentation>
+            The chance of a feeding mosquito becoming infected, given that the
+            host is patent. (This may be adjusted by transmission-blocking vaccines.)
+          </xs:documentation>
+          <xs:appinfo>name:Probability of mosquito infection;units:None;min:0;max:1;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="hypnozoiteRelease" type="om:HypnozoiteRelease">
+        <xs:annotation>
+          <xs:documentation>
+            Describes the number and times of hypnozoite releases.
+          </xs:documentation>
+          <xs:appinfo>name:Hypnozoite releases;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="bloodStageProtectionLatency" type="om:DoubleValue">
+        <xs:annotation>
+          <xs:documentation>
+            The length of time after expiry of a blood-stage infection during
+            which relapses from the same brood are supressed by the immune
+            system.
+            
+            This is rounded to the nearest time-step.
+          </xs:documentation>
+          <xs:appinfo>name:Blood stage protection latency;min:0;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="bloodStageLengthDays" type="om:WeibullSample">
+        <xs:annotation>
+          <xs:documentation>
+            Parameters used to sample the length of blood-stage infections from
+            a Weibull distribution (scale parameter lambda, shape parameter k).
+          </xs:documentation>
+          <xs:appinfo>name:Blood stage length;units:Days;</xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="clinicalEvents" type="om:ClinicalEvents"/>
+    </xs:all>
+  </xs:complexType>
+  <xs:complexType name="HypnozoiteRelease">
+    <xs:annotation>
+      <xs:documentation>
+        This element defines probabilites when and how many hypnozoites are released from the liverstage into the blood.
+
+        The gap between the start of a new brood of hypnozoites and its release are defined as follows:
+
+          latentP + latentRelapse + randomReleaseDelay
+
+        randomReleaseDelay is based on one or two lognormal distributions, which are defined in firstRelease and optionally secondRelease.
+
+        You can define 2 release distributions, which get added together and represent the probability of hypnozoites which get released before winter (first release) or after (second release).
+
+        You can omit the secondRelease element if no release to the blood happens after winter.
+      </xs:documentation>
+      <xs:appinfo>name:Hypnozoite release;</xs:appinfo>
+    </xs:annotation>
+    <xs:all>
+      <xs:element name="numberHypnozoites" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            numberHypnozoites calculates the number of hypnozoites in the liver stage based on a base which is between 0 and 1.
+
+            This number is random based on the following distribution and normalized:
+
+             max
+              ∑ (base ^ n)
+            n = 0
+          </xs:documentation>
+          <xs:appinfo>name:Number of Hypnozoites;</xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+          <xs:attribute type="xs:int" use="required" name="max"/>
+          <xs:attribute type="xs:double" use="required" name="base"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element type="om:HypnozoiteReleaseDistribution" name="firstReleaseDays" maxOccurs="1" minOccurs="1"/>
+      <xs:element type="om:HypnozoiteReleaseDistribution" name="secondReleaseDays" maxOccurs="1" minOccurs="0"/>
+    </xs:all>
+    <xs:attribute type="xs:double" name="pSecondRelease" default="0">
+      <xs:annotation>
+        <xs:documentation>
+        Probability of a second release. If undefined it is zero.
+        </xs:documentation>
+        <xs:appinfo>name:latent relapse days;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="HypnozoiteReleaseDistribution">
+    <xs:annotation>
+      <xs:documentation>
+        Hypnozoites are released after a delay, calculated as:
+        roundToTSFromDays(delay + latentRelapse)
+        
+        Here, roundToTSFromDays rounds the input (in days) to the nearest timestep,
+        delay is sampled from a log-normal, and latentRelapse is the
+        parameter specified here.
+        
+        The delay is sampled from a log-normal distribution, parameterised via
+        the (linear) mean and CV (coefficient of variation) given here.
+      </xs:documentation>
+      <xs:appinfo>name:Hypnozoite release delay;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="om:SampledValueLN">
+        <xs:attribute type="xs:double" use="required" name="latentRelapse">
+          <xs:annotation>
+            <xs:documentation>
+            Usually between 10 and 15 days.
+            </xs:documentation>
+            <xs:appinfo>name:latent relapse days;</xs:appinfo>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ClinicalEvents">
+    <xs:annotation>
+      <xs:documentation>
+        This elements holds all information about probabilites for clinical events from infections and relapses.
+      </xs:documentation>
+      <xs:appinfo>name:Vivax Clinical Events;</xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="pPrimaryInfection" type="om:ProbVivaxEvent"/>
+      <xs:element name="pRelapseOne" type="om:ProbVivaxEvent"/>
+      <xs:element name="pRelapseTwoPlus" type="om:ProbVivaxEvent"/>
+      <xs:element name="pEventIsSevere" type="om:DoubleValue"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ProbVivaxEvent">
+    <xs:attribute name="a" type="xs:double" use="required"/>
+    <xs:attribute name="b" type="xs:double" use="required"/>
+  </xs:complexType>
+  
+
+  
+  <xs:complexType name="Entomology">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="nonVector" type="om:NonVector">
+          <xs:annotation>
+            <xs:documentation>
+              Description of transmission setting for models without vector control interventions
+              (included for backward compatibility)
+            </xs:documentation>
+      <xs:appinfo>name:Transmission setting (vector control not enabled);</xs:appinfo>
+     </xs:annotation>
+    </xs:element>
+    <xs:element name="vector">
+     <xs:annotation>
+      <xs:documentation>Parameters of the transmission model</xs:documentation>
+      <xs:appinfo>name:Transmission setting (vector control enabled);</xs:appinfo>
+     </xs:annotation>
+     <xs:complexType>
+      <xs:sequence>
+       <xs:element maxOccurs="unbounded" minOccurs="1" name="anopheles" type="om:AnophelesParams"/>
+       <xs:element maxOccurs="unbounded" minOccurs="0" name="nonHumanHosts">
+        <xs:complexType>
+         <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+           <xs:documentation>
+                        Name of this species of non human hosts (must match up
+                        with those described per anopheles section).
+                      </xs:documentation>
+           <xs:appinfo>name:Species of alternative host;</xs:appinfo>
+          </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="number" type="xs:double" use="required">
+          <xs:annotation>
+           <xs:documentation>
+                        Population size of this non-human host.
+                        
+                        Note: the availability of the population of this type of non-human host is
+                        determined by mosqRelativeEntoAvailability and mosqHumanBloodIndex.
+                        NHHs are not modelled individually, thus this parameter is not used. It
+                        might be useful in the future if there is ever an intervention to change
+                        the number of non-human hosts.
+                      </xs:documentation>
+           <xs:appinfo>units:Animals;name:Population size of non-human host species;</xs:appinfo>
+          </xs:annotation>
+         </xs:attribute>
+        </xs:complexType>
+       </xs:element>
+      </xs:sequence>
+     </xs:complexType>
+    </xs:element>
+   </xs:choice>
+  </xs:sequence>
+  <xs:attribute name="name" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>
+          Name of entomology data
+        </xs:documentation>
+    <xs:appinfo>name:Entomology dataset name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="mode" use="required">
+   <xs:annotation>
+    <xs:documentation>
+        Transmission simulation mode: may be forced (in which case interventions
+        and changes to human infectiousness cannot affect EIR) or dynamic (in
+        which the above can affect EIR). The full vector model is only used in
+        dynamic mode. This can not be changed by interventions, except for the
+        changeEIR intervention for the non-vector model which replaces the EIR
+        with a new description (used in forced mode).
+        </xs:documentation>
+    <xs:appinfo>name:Transmission model mode;</xs:appinfo>
+   </xs:annotation>
+   <xs:simpleType>
+    <xs:restriction base="xs:string">
+     <xs:enumeration value="forced"/>
+     <xs:enumeration value="dynamic"/>
+    </xs:restriction>
+   </xs:simpleType>
+  </xs:attribute>
+  <xs:attribute name="scaledAnnualEIR" type="xs:double" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          If set, the annual EIR (for all species of vector) is scaled to this
+          level; can be omitted if not needed.
+        </xs:documentation>
+    <xs:appinfo>units:Infectious bites per adult per year;name:Override annual EIR;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="NonVector">
+  <xs:sequence>
+   <xs:element minOccurs="1" maxOccurs="unbounded" name="EIRDaily" type="om:EIRDaily"/>
+  </xs:sequence>
+  <xs:attribute name="eipDuration" type="xs:int" use="required">
+   <xs:annotation>
+    <xs:documentation>The duration of sporogony in days</xs:documentation>
+    <xs:appinfo>units:Days;name:Duration of sporogony;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="EIRDaily">
+  <xs:annotation>
+   <xs:documentation>
+      In the non-vector model, EIR is input as a sequence of daily values.
+      There must be at least one years' worth of entries (365), and if there
+      are more, values are wrapped and averaged (i.e. value for first day
+      of year is taken as the mean of values for days 0, 365+0, 2*365+0,
+      etc.).
+      </xs:documentation>
+   <xs:appinfo>units:Infectious bites per adult per day;name:Daily Entomological Inoculation Rate;exposed:false;</xs:appinfo>
+  </xs:annotation>
+  <xs:simpleContent>
+   <xs:extension base="xs:double">
+    <xs:attribute name="origin" type="xs:string" use="optional">
+     <xs:annotation>
+      <xs:documentation/>
+      <xs:appinfo>name:Time origin of EIR sequence;exposed:false;</xs:appinfo>
+     </xs:annotation>
+    </xs:attribute>
+   </xs:extension>
+  </xs:simpleContent>
+ </xs:complexType>
+ <xs:complexType name="AnophelesParams">
+  <xs:annotation>
+   <xs:documentation>Description of input EIR for
+       one specific vector species in terms of a Fourier approximation
+       to the ln of the EIR during the burn in period</xs:documentation>
+   <xs:appinfo>name:Description of input EIR for one vector;</xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+   <xs:element name="seasonality">
+    <xs:annotation>
+     <xs:documentation>Specifies the seasonality of transmission
+          and optionally the level of annual transmission.</xs:documentation>
+     <xs:appinfo>name:Seasonality of transmission;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:sequence>
+      <xs:choice>
+       <xs:element name="fourierSeries">
+        <xs:annotation>
+         <xs:documentation>
+                    Seasonality is reproduced from the exponential of a fourier
+                    series specified by the following coefficients. Note that
+                    the a0 term is not needed; the annualEIR attribute of the
+                    seasonality element should be used to scale EIR instead.
+                  </xs:documentation>
+         <xs:appinfo>units:Infectious bites per adult per day;name:Fourier approximation to pre-intervention EIR;</xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+         <xs:sequence>
+          <xs:element name="coeffic" minOccurs="0" maxOccurs="unbounded">
+           <xs:annotation>
+            <xs:documentation>
+                          A pair of Fourier series coefficients. The first element
+                          specifies a1 and b1, the second a2 and b2, etc. Any number
+                          (from 0 up) of pairs may be given.
+                        </xs:documentation>
+            <xs:appinfo>name:Pair of Fourier coefficients;</xs:appinfo>
+           </xs:annotation>
+           <xs:complexType>
+            <xs:attribute name="a" type="xs:double" use="required">
+             <xs:annotation>
+              <xs:documentation>
+                              a_n parameter of Fourier approximation to ln(EIR) for
+                              some natural number n.
+                            </xs:documentation>
+              <xs:appinfo>name:a_n parameter of Fourier approximation to ln(EIR);</xs:appinfo>
+             </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="b" type="xs:double" use="required">
+             <xs:annotation>
+              <xs:documentation>
+                              b_n parameter of Fourier approximation to ln(EIR) for
+                              some natural number n.
+                            </xs:documentation>
+              <xs:appinfo>name:b_n parameter of Fourier approximation to ln(EIR);</xs:appinfo>
+             </xs:annotation>
+            </xs:attribute>
+           </xs:complexType>
+          </xs:element>
+         </xs:sequence>
+         <xs:attribute name="EIRRotateAngle" type="xs:double" use="required">
+          <xs:annotation>
+           <xs:documentation>
+                        Rotation angle defining the origin of the Fourier approximation to ln (EIR)
+                      </xs:documentation>
+           <xs:appinfo>units:Radians;name:Rotation angle defining the origin of the Fourier approximation to ln (EIR);</xs:appinfo>
+          </xs:annotation>
+         </xs:attribute>
+        </xs:complexType>
+       </xs:element>
+       <xs:element name="monthlyValues">
+        <xs:annotation>
+         <xs:documentation>
+                    Description of seasonality from monthly values. Multiple
+                    smoothing methods are possible (see smoothing attribute).
+                    
+                    List should contain twelve entries: January to December.
+                  </xs:documentation>
+         <xs:appinfo>name:List of monthly values;</xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+         <xs:sequence>
+          <xs:element name="value" minOccurs="12" maxOccurs="12" type="xs:double">
+           <xs:annotation>
+            <xs:documentation>
+                          Monthly value
+                        </xs:documentation>
+            <xs:appinfo>units:(see &quot;seasonality input&quot; parameter);name:Monthly value;</xs:appinfo>
+           </xs:annotation>
+          </xs:element>
+         </xs:sequence>
+         <xs:attribute name="smoothing" use="required">
+          <xs:annotation>
+           <xs:documentation>
+                        How the monthly values are converted into a daily
+                        sequence of values:
+                        
+                        1) none: no smoothing (step function)
+                        
+                        2) Fourier: a Fourier series (with terms up to a2/b2)
+                        is fit to the sequence of monthly values and used to
+                        generate a smoothed list of daily values.
+                      </xs:documentation>
+           <xs:appinfo>name:Smoothing function;</xs:appinfo>
+          </xs:annotation>
+          <xs:simpleType>
+           <xs:restriction base="xs:string">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="fourier"/>
+           </xs:restriction>
+          </xs:simpleType>
+         </xs:attribute>
+        </xs:complexType>
+       </xs:element>
+       <xs:element name="dailyValues">
+        <xs:annotation>
+         <xs:documentation>
+                    Description of seasonality from daily values.
+                    
+                    List should contain 365 entries: 1st January to 31st December.
+                  </xs:documentation>
+         <xs:appinfo>name:List of daily values;</xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+         <xs:sequence>
+          <xs:element name="value" minOccurs="1" maxOccurs="unbounded" type="xs:double">
+           <xs:annotation>
+            <xs:documentation>
+                          Daily value
+                        </xs:documentation>
+            <xs:appinfo>units:(see &quot;seasonality input&quot; parameter);name:Daily value;</xs:appinfo>
+           </xs:annotation>
+          </xs:element>
+         </xs:sequence>
+        </xs:complexType>
+       </xs:element>
+      </xs:choice>
+     </xs:sequence>
+     <xs:attribute name="input" use="required">
+      <xs:annotation>
+       <xs:documentation>Specify what seasonality measure is given.
+              
+              At the moment, only EIR is supported, but in the future, all the
+              below should be supported.
+              
+              EIR: seasonality of entomological inoculations is input.
+              Units: entomological inoculations per adult per annum.
+              
+              hostSeeking: seasonality of densities of flying host-seeking
+              mosquitoes is input (in the model this is notated N_v).
+              Units: mosquitoes.
+              
+              emergence: seasonality of emergence pupa into adults.
+              Units: mosquitoes.
+              
+              larvalResources: seasonality of larval resources. Units: X.
+              </xs:documentation>
+       <xs:appinfo>name:Seasonality input;</xs:appinfo>
+      </xs:annotation>
+      <xs:simpleType>
+       <xs:restriction base="xs:string">
+        <xs:enumeration value="EIR"/>
+       </xs:restriction>
+      </xs:simpleType>
+     </xs:attribute>
+     <xs:attribute name="annualEIR" type="xs:double" use="optional">
+      <xs:annotation>
+       <xs:documentation>If this attribute is included, EIR for this
+              species is scaled to this level. Note that if the scaledAnnualEIR
+              attribute of the entomology element is also used, EIR is scaled
+              again, making this attribute the EIR relative to other species.
+              
+              With some seasonality inputs, this attribute is optional, in which
+              case (if scaledAnnualEIR is also not specified) transmission depends
+              on all parameters of the vector. With some seasonality inputs,
+              however, this parameter must be specified.</xs:documentation>
+       <xs:appinfo>name:Annual EIR;units:Inoculations per adult per annum;min:0;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="mosq">
+    <xs:annotation>
+     <xs:documentation>Parameters describing the feeding cycle and human
+          mosquito interaction of a single species of anopheles mosquito.
+          </xs:documentation>
+     <xs:appinfo>name:Mosquito feeding cycle parameters;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:all>
+      <xs:element name="mosqRestDuration" type="om:IntValue">
+       <xs:annotation>
+        <xs:documentation>name:Duration of the resting period of the vector (days);</xs:documentation>
+        <xs:appinfo>units:Days;name:Duration of the resting period of the vector;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="extrinsicIncubationPeriod" type="om:IntValue">
+       <xs:annotation>
+        <xs:documentation>name:Extrinsic incubation period (days)</xs:documentation>
+        <xs:appinfo>units:Days;name:Extrinsic incubation period;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqLaidEggsSameDayProportion" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>Proportion of mosquitoes host seeking on same day as ovipositing</xs:documentation>
+        <xs:appinfo>units:Proportion;name:Proportion of mosquitoes host seeking on same day as ovipositing;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqSeekingDuration" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>Duration of the host-seeking period of the vector (days)</xs:documentation>
+        <xs:appinfo>units:Days;name:Duration of the host-seeking period of the vector;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqSurvivalFeedingCycleProbability" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>Probability that the mosquito survives the feeding cycle</xs:documentation>
+        <xs:appinfo>units:Proportion;name:Probability that the mosquito survives the feeding cycle;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="availability" type="om:SampledValueCV">
+       <xs:annotation>
+        <xs:documentation>
+                  Optionally, entomological availability rate may be sampled per-human from a
+                  distribution. The distribution and coefficient of variability may be set here.
+                  The mean rate is calculated based on other parameters and not set directly.
+                  
+                  If no attributes are specified or distr=&quot;const&quot; or CV=&quot;0&quot; then there will be
+                  no heterogeneity.
+                </xs:documentation>
+        <xs:appinfo>name:Human availability rate heterogeneity</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqProbBiting" type="om:BetaMeanSample">
+       <xs:annotation>
+        <xs:documentation>Probability that the mosquito succesfully bites chosen host</xs:documentation>
+        <xs:appinfo>name:Probability that the mosquito succesfully bites chosen host;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqProbFindRestSite" type="om:BetaMeanSample">
+       <xs:annotation>
+        <xs:documentation>Probability that the mosquito escapes host and finds a resting place after biting</xs:documentation>
+        <xs:appinfo>name:Probability that the mosquito escapes host and finds a resting place after biting;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqProbResting" type="om:BetaMeanSample">
+       <xs:annotation>
+        <xs:documentation>Probability of mosquito successfully resting after finding a resting site</xs:documentation>
+        <xs:appinfo>name:Probability of mosquito successfully resting after finding a resting site;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqProbOvipositing" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>Probability of a mosquito successfully laying eggs given that it has rested</xs:documentation>
+        <xs:appinfo>name:Probability of a mosquito successfully laying eggs given that it has rested;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqHumanBloodIndex" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>The proportion of resting mosquitoes which fed on human blood during the last feed.</xs:documentation>
+        <xs:appinfo>units:Proportion;name:Human blood index;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:all>
+     <xs:attribute name="minInfectedThreshold" type="xs:double" use="required">
+      <xs:annotation>
+       <xs:documentation>If less than this many mosquitoes remain infected, transmission is interrupted.</xs:documentation>
+       <xs:appinfo>name:Mininum infected threshold for mosquitos;min:0;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="lifeCycle" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Parameters describing the life-cycle of this species of mosquito
+          </xs:documentation>
+     <xs:appinfo>name:Mosquito life cycle parameters;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:all>
+      <xs:element name="eggStage" type="om:MosqStage">
+       <xs:annotation>
+        <xs:documentation>
+                  Parameters for the egg stage of development
+                </xs:documentation>
+        <xs:appinfo>name:Egg stage;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="larvalStage">
+       <xs:complexType>
+        <xs:complexContent>
+         <xs:extension base="om:MosqStage">
+          <xs:annotation>
+           <xs:documentation>
+                        Parameters for the larval stage of development
+                      </xs:documentation>
+           <xs:appinfo>name:Larval stage;</xs:appinfo>
+          </xs:annotation>
+          <xs:sequence>
+           <xs:element name="daily" maxOccurs="unbounded">
+            <xs:annotation>
+             <xs:documentation>
+                            List of parameters which apply during the larval
+                            stage of development. List length must equal stage
+                            duration, with first item corresponding to first
+                            24 hours after hatching, second item to hours
+                            24-48, and so on.
+                          </xs:documentation>
+             <xs:appinfo>name:Daily development;</xs:appinfo>
+            </xs:annotation>
+            <xs:complexType>
+             <xs:attribute name="resourceUsage" type="xs:double" use="required">
+              <xs:annotation>
+               <xs:documentation>
+                                Resource usage during larval stage of development.
+                                Units are arbitrary.
+                              </xs:documentation>
+               <xs:appinfo>name:Resource usage;units:X;</xs:appinfo>
+              </xs:annotation>
+             </xs:attribute>
+             <xs:attribute name="effectCompetition" type="xs:double" use="required">
+              <xs:annotation>
+               <xs:documentation>
+                                Effect of competition over resources on development.
+                              </xs:documentation>
+               <xs:appinfo>name:Effect of competition;units:none;</xs:appinfo>
+              </xs:annotation>
+             </xs:attribute>
+            </xs:complexType>
+           </xs:element>
+          </xs:sequence>
+         </xs:extension>
+        </xs:complexContent>
+       </xs:complexType>
+      </xs:element>
+      <xs:element name="pupalStage" type="om:MosqStage">
+       <xs:annotation>
+        <xs:documentation>
+                  Parameters for the pupal stage of development
+                </xs:documentation>
+        <xs:appinfo>name:Pupal stage;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="femaleEggsLaidByOviposit" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>
+                  The total number of female eggs laid by a female mosquito at
+                  the conclusion to a feeding cycle, after feeding on an
+                  unprotected human (non-human hosts and protected humans
+                  use a multiplication factor to adjust this number for
+                  mosquitoes feeding on them).
+                </xs:documentation>
+        <xs:appinfo> units: Eggs per feeding cycle; name:Eggs laid by ovipositing mosquito;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:all>
+     <xs:attribute name="estimatedLarvalResources" type="xs:double" default="1e8">
+      <xs:annotation>
+       <xs:documentation>
+                An estimate of mean annual availability of resources to larvae.
+                Used to get the resource usage fitting algorithm going; if the
+                algorithm fails to fit the resource availability then tweaking
+                this parameter may help. In other cases tweaking this parameter
+                shouldn't be necessary.
+                
+                Default value is 10⁸ (1e8). Units are arbitrary but must be the same as
+                those used by the resourceUsage parameter.
+              </xs:documentation>
+       <xs:appinfo>units: see resourceUsage;name:Estimate of larval resources;units:X</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="simpleMPD" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>
+            Parameters describing the simple mosquito population dynamics model.
+            
+            This is a simpler version of the life-cycle model, requiring less
+            parameters and with much simpler initialisation.
+          </xs:documentation>
+     <xs:appinfo>name:Simple Mosq-Pop-Dynamics parameters;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:all>
+      <xs:element name="developmentDuration" type="om:IntValue">
+       <xs:annotation>
+        <xs:documentation>
+                Duration from egg laying to emergence in days.
+                </xs:documentation>
+        <xs:appinfo> units: Days; name:Duration; min:1;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="developmentSurvival" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>
+                Probability that mosquito survives from the egg being laid to emergence,
+                given no resouce limitations (no density constraints).
+                </xs:documentation>
+        <xs:appinfo> units:Proportion; name:Probability of survival; min:0; max:1;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="femaleEggsLaidByOviposit" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>
+                  The total number of female eggs laid by a female
+                  mosquito at the conclusion to a feeding cycle.
+                </xs:documentation>
+        <xs:appinfo> units: Eggs per feeding cycle; name:Eggs laid by ovipositing mosquito;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:all>
+    </xs:complexType>
+   </xs:element>
+   <xs:element name="nonHumanHosts" maxOccurs="unbounded" minOccurs="0">
+    <xs:annotation>
+     <xs:documentation>Non human host parameters, per type of host (must
+          match up with non-species-specific parameters).</xs:documentation>
+     <xs:appinfo>min:0; name:Alternative (non-human) host paramters;</xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+     <xs:all>
+      <xs:element name="mosqRelativeEntoAvailability" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>
+                  Relative availability of the population of non-human hosts of
+                  type i to other non-human hosts; the sum of this across all
+                  non-human hosts must be 1.
+                </xs:documentation>
+        <xs:appinfo>units:Proportion; name:Relative availability of non-human host (ξ_i);</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqProbBiting" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>Probability of mosquito successfully biting host</xs:documentation>
+        <xs:appinfo>units:Proportion;name:Probability of mosquito successfully biting host;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqProbFindRestSite" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>Probability that the mosquito escapes host and finds a resting place after biting</xs:documentation>
+        <xs:appinfo>units:Proportion;name:Probability that the mosquito escapes host and finds a resting place after biting;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="mosqProbResting" type="om:DoubleValue">
+       <xs:annotation>
+        <xs:documentation>Probability of mosquito successfully resting after finding a resting site</xs:documentation>
+        <xs:appinfo>units:Proportion;name:Probability of mosquito successfully resting after finding a resting site;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+      <xs:element name="hostFecundityFactor" type="om:DoubleValue" minOccurs="0">
+       <xs:annotation>
+        <xs:documentation>Multiplicative factor for the number of fertile eggs laid by a
+                  mosquito after biting this type of host, relative to an unprotected human.
+                </xs:documentation>
+        <xs:appinfo>units:Proportion;name:Relative fecundity of biting mosquitoes;</xs:appinfo>
+       </xs:annotation>
+      </xs:element>
+     </xs:all>
+     <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+       <xs:documentation>Identifier for this category of non-human hosts</xs:documentation>
+       <xs:appinfo>name:Identifier for this category of non-human hosts;</xs:appinfo>
+      </xs:annotation>
+     </xs:attribute>
+    </xs:complexType>
+   </xs:element>
+  </xs:sequence>
+  <xs:attribute name="mosquito" type="xs:string" use="required">
+   <xs:annotation>
+    <xs:documentation>Identifier for this anopheles species</xs:documentation>
+    <xs:appinfo>name:Identifier for this anopheles species;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="propInfected" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>Initial guess of the proportion of mosquitoes which are infected, o: O_v(t) = o*N_v(t). Only used as a starting value.</xs:documentation>
+    <xs:appinfo>units:Proportion;min:0;max:1;name:Initial estimate of proportion of mosquitoes infected (ρ_O);exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="propInfectious" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>Initial estimate of the proportion of mosquitoes which are infectious, s: S_v(t) = s*N_v(t). Used as a starting value and then fit.</xs:documentation>
+    <xs:appinfo>units:Proportion;min:0;max:1;name:Initial estimate of proportion of mosquitoes infectious (ρ_S);exposed:false;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="MosqStage">
+  <xs:annotation>
+   <xs:documentation>
+      Parameters associated with a mosquito development stage.
+      </xs:documentation>
+   <xs:appinfo>name:Mosquito development-stage parameters;</xs:appinfo>
+  </xs:annotation>
+  <xs:attribute name="duration" type="xs:int" use="required">
+   <xs:annotation>
+    <xs:documentation>
+        Duration of the stage (i.e. length of time mosquito is an
+        egg/larva/pupa).
+        </xs:documentation>
+    <xs:appinfo> units: Days; name:Duration;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+  <xs:attribute name="survival" type="xs:double" use="required">
+   <xs:annotation>
+    <xs:documentation>
+        Probability that mosquito survives this size (probability of egg
+        hatching, a larva becoming a pupa or a pupa emerging as an adult,
+        at the start of that stage).
+        </xs:documentation>
+    <xs:appinfo> units:Proportion; name:Probability of survival;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+</xs:schema>

--- a/schema/util.xsd
+++ b/schema/util.xsd
@@ -3,7 +3,7 @@
 Copyright © 2005-2011 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
 <!-- standard types used -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46" xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47" xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xs="http://www.w3.org/2001/XMLSchema">
  <!-- Component and TriggeredDeployments would be in interventions.xsd, except
     that they are needed from healthSystem.xsd -->
  <xs:complexType name="Component">

--- a/schema/vivax.xsd
+++ b/schema/vivax.xsd
@@ -3,8 +3,8 @@
 Copyright © 2005-2019 Swiss Tropical Institute and Liverpool School Of Tropical Medicine
 Licence: GNU General Public Licence version 2 or later (see COPYING) -->
 <!-- standard types used -->
-<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_46"
-           xmlns:om="http://openmalaria.org/schema/scenario_46"
+<xs:schema targetNamespace="http://openmalaria.org/schema/scenario_47"
+           xmlns:om="http://openmalaria.org/schema/scenario_47"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:include schemaLocation="util.xsd"/>
   <xs:complexType name="Vivax">

--- a/test/scenario1.xml
+++ b/test/scenario1.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="test D94" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="test D94" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="80" name="test" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario10.xml
+++ b/test/scenario10.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="49" name="Idete Incidence" schemaVersion="46" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="49" name="Idete Incidence" schemaVersion="47" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="6.0" name="Ifakara" popSize="300">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario11.xml
+++ b/test/scenario11.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="90" name="triple correlated heterogeneity" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="90" name="triple correlated heterogeneity" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="200">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario12.xml
+++ b/test/scenario12.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="30" name="Matsari Intervention" schemaVersion="46" wuID="12345" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="30" name="Matsari Intervention" schemaVersion="47" wuID="12345" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="80.389041096" name="Ifakara" popSize="500">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario12a.xml
+++ b/test/scenario12a.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="30" name="Matsari Intervention" schemaVersion="46" wuID="12345" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="30" name="Matsari Intervention" schemaVersion="47" wuID="12345" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="80.389041096" name="Ifakara" popSize="500">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario2ITNs.xml
+++ b/test/scenario2ITNs.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="test usage of multiple independent ITN descriptions alongside other vector interventions" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="test usage of multiple independent ITN descriptions alongside other vector interventions" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Rachuonyo" popSize="979">
     <ageGroup lowerbound="0">
       <group poppercent="2.6" upperbound="1"/>

--- a/test/scenario4.xml
+++ b/test/scenario4.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="46" wuID="5630539" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="47" wuID="5630539" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="500">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario5.xml
+++ b/test/scenario5.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="99" name="Vacc with EIRDaily factor=1.0 with halfLifeYrs value=0.5" schemaVersion="46" wuID="53630539" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="99" name="Vacc with EIRDaily factor=1.0 with halfLifeYrs value=0.5" schemaVersion="47" wuID="53630539" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario6.xml
+++ b/test/scenario6.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Vacc with EIRDaily factor=1.0 with halfLifeYrs value=0.5" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Vacc with EIRDaily factor=1.0 with halfLifeYrs value=0.5" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenario9.xml
+++ b/test/scenario9.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="49" name="Idete Incidence" schemaVersion="46" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="49" name="Idete Incidence" schemaVersion="47" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="6.0" name="Ifakara" popSize="300">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioAvailabilityHeterogeneity.xml
+++ b/test/scenarioAvailabilityHeterogeneity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="example" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="example" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
     <!-- This is an example scenario.
     More information is available in the official documentation: https://swisstph.github.io/openmalaria/schema-latest.html
     And in the wiki: https://github.com/SwissTPH/openmalaria/wiki 

--- a/test/scenarioBSV.xml
+++ b/test/scenarioBSV.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
     <demography maximumAgeYrs="90" name="Zambia 2010 census_Southern province " popSize="600">
         <ageGroup lowerbound="0">
             <group poppercent="3.6" upperbound="1"/> 

--- a/test/scenarioCohort.xml
+++ b/test/scenarioCohort.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="Do" schemaVersion="46" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="Do" schemaVersion="47" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioDecisionTree5DayDielmo.xml
+++ b/test/scenarioDecisionTree5DayDielmo.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Dielmo Calibration" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Dielmo Calibration" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="400">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1" />

--- a/test/scenarioESTS.xml
+++ b/test/scenarioESTS.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="cut down version of VC's treatment seeking test scenario" schemaVersion="46" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="cut down version of VC's treatment seeking test scenario" schemaVersion="47" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioEffectiveDrug.xml
+++ b/test/scenarioEffectiveDrug.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="46" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="47" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="250">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioEmpirical.xml
+++ b/test/scenarioEmpirical.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="46" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="47" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="200">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioGenotypes.xml
+++ b/test/scenarioGenotypes.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Do" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Do" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="1000">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioHetVecDailyEIR.xml
+++ b/test/scenarioHetVecDailyEIR.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Ifakara Vector Model with daily values" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Ifakara Vector Model with daily values" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="500">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1" />

--- a/test/scenarioIRS30.xml
+++ b/test/scenarioIRS30.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="Rachuonyo 5-day Intervention cohort" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="Rachuonyo 5-day Intervention cohort" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Rachuonyo" popSize="979">
     <ageGroup lowerbound="0">
       <group poppercent="2.6" upperbound="1"/>

--- a/test/scenarioKK_20150612.xml
+++ b/test/scenarioKK_20150612.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:om="http://openmalaria.org/schema/scenario_46" name="Do" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:om="http://openmalaria.org/schema/scenario_47" name="Do" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioLifeNet1.xml
+++ b/test/scenarioLifeNet1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wuITNIRS2_10.xml,cohort_coverage:cohort_coverage04,importedInfectionsrate:importedInfectionsrate11,LLINbrand:LLINbrandLifeNet,models:base,mosqHumanBloodIndex:mosqHumanBloodIndex0001,pSeekOfficialCareUncomplicated:pSeekOfficialCareUncomplicated44,scaledAnnualEIR:scaledAnnualEIR1.000,species:flavirostris,start:start04,seed:1" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wuITNIRS2_10.xml,cohort_coverage:cohort_coverage04,importedInfectionsrate:importedInfectionsrate11,LLINbrand:LLINbrandLifeNet,models:base,mosqHumanBloodIndex:mosqHumanBloodIndex0001,pSeekOfficialCareUncomplicated:pSeekOfficialCareUncomplicated44,scaledAnnualEIR:scaledAnnualEIR1.000,species:flavirostris,start:start04,seed:1" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="500">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioLifeNet2.xml
+++ b/test/scenarioLifeNet2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wuITNIRS2_10.xml,cohort_coverage:cohort_coverage04,importedInfectionsrate:importedInfectionsrate11,LLINbrand:LLINbrandLifeNet,models:base,mosqHumanBloodIndex:mosqHumanBloodIndex0001,pSeekOfficialCareUncomplicated:pSeekOfficialCareUncomplicated44,scaledAnnualEIR:scaledAnnualEIR1.000,species:flavirostris,start:start04,seed:1" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="wuITNIRS2_10.xml,cohort_coverage:cohort_coverage04,importedInfectionsrate:importedInfectionsrate11,LLINbrand:LLINbrandLifeNet,models:base,mosqHumanBloodIndex:mosqHumanBloodIndex0001,pSeekOfficialCareUncomplicated:pSeekOfficialCareUncomplicated44,scaledAnnualEIR:scaledAnnualEIR1.000,species:flavirostris,start:start04,seed:1" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="500">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioMSAT.xml
+++ b/test/scenarioMSAT.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Mass screen-and-treat and ITNs" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Mass screen-and-treat and ITNs" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioMSAT_HRP2.xml
+++ b/test/scenarioMSAT_HRP2.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Mass screen-and-treat with HRP2 deletions" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Mass screen-and-treat with HRP2 deletions" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="200">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioMolPairwise.xml
+++ b/test/scenarioMolPairwise.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Do" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Do" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioMolineaux.xml
+++ b/test/scenarioMolineaux.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Do" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Do" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioNamawalaArabiensis.xml
+++ b/test/scenarioNamawalaArabiensis.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="100">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioNoInterv.xml
+++ b/test/scenarioNoInterv.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="No interventions — a useful base" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="No interventions — a useful base" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioNoMPDLarviciding.xml
+++ b/test/scenarioNoMPDLarviciding.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="larviciding" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="larviciding" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="100">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioNonHumanHosts.xml
+++ b/test/scenarioNonHumanHosts.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             name="Vector traps test" schemaVersion="46"
-             xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_46.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             name="Vector traps test" schemaVersion="47"
+             xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
     <demography maximumAgeYrs="90" name="Rachuonyo" popSize="800">
         <ageGroup lowerbound="0">
             <group poppercent="2.6" upperbound="1"/>

--- a/test/scenarioPEV.xml
+++ b/test/scenarioPEV.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
     <demography maximumAgeYrs="90" name="Zambia 2010 census_Southern province " popSize="600">
         <ageGroup lowerbound="0">
             <group poppercent="3.6" upperbound="1"/> 

--- a/test/scenarioPenny.xml
+++ b/test/scenarioPenny.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="Do" schemaVersion="46" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="Do" schemaVersion="47" wuID="536305339" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="500">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioRach5IC.xml
+++ b/test/scenarioRach5IC.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="Rachuonyo 5-day Intervention cohort" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="Rachuonyo 5-day Intervention cohort" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Rachuonyo" popSize="979">
     <ageGroup lowerbound="0">
       <group poppercent="2.6" upperbound="1"/>

--- a/test/scenarioSimpleMPDLarviciding.xml
+++ b/test/scenarioSimpleMPDLarviciding.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="larviciding" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="0" name="larviciding" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="200">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioSimpleMPDTest.xml
+++ b/test/scenarioSimpleMPDTest.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="100">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioSubPopRemoval.xml
+++ b/test/scenarioSubPopRemoval.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="subPopRemoval Test" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="subPopRemoval Test" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="200">
     <ageGroup lowerbound="0">
      <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioTBV.xml
+++ b/test/scenarioTBV.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
     <demography maximumAgeYrs="90" name="Zambia 2010 census_Southern province " popSize="600">
         <ageGroup lowerbound="0">
             <group poppercent="3.6" upperbound="1"/> 

--- a/test/scenarioTrapTest.xml
+++ b/test/scenarioTrapTest.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Vector traps test" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Vector traps test" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <!--
 I would suggest that there are two steps here- getting something running in v35 for testing, and then adjusting it for simulating Rusinga.
 We need to include the full-life cycle model since there is clearly an effect on emergence rates at least for funestus, and this might be a good test of this as well as of the new v35 functionality.

--- a/test/scenarioTriggeredMSAT.xml
+++ b/test/scenarioTriggeredMSAT.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="99" name="Vacc with EIRDaily factor=1.0 with halfLifeYrs value=0.5" schemaVersion="46" wuID="53630539" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="99" name="Vacc with EIRDaily factor=1.0 with halfLifeYrs value=0.5" schemaVersion="47" wuID="53630539" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="200">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioVecFullTest.xml
+++ b/test/scenarioVecFullTest.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Full set of interventions" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="150">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioVecMonthly.xml
+++ b/test/scenarioVecMonthly.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="simple test of EIR input as monthly values" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="simple test of EIR input as monthly values" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="100">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioVecTest.xml
+++ b/test/scenarioVecTest.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="46" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" analysisNo="233" name="test D94" schemaVersion="47" wuID="0" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="test" popSize="100">
     <ageGroup lowerbound="0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/test/scenarioVivax.xml
+++ b/test/scenarioVivax.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Vivax test" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_current.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Vivax test" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_current.xsd">
   <demography maximumAgeYrs="90" name="Ifakara" popSize="500">
     <ageGroup lowerbound="0.0">
       <group poppercent="3.474714994" upperbound="1"/>

--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_46" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="example" schemaVersion="46" xsi:schemaLocation="http://openmalaria.org/schema/scenario_46 scenario_46.xsd">
+<om:scenario xmlns:om="http://openmalaria.org/schema/scenario_47" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="example" schemaVersion="47" xsi:schemaLocation="http://openmalaria.org/schema/scenario_47 scenario_47.xsd">
     <!-- This is an example scenario.
     More information is available in the official documentation: https://swisstph.github.io/openmalaria/schema-latest.html
     And in the wiki: https://github.com/SwissTPH/openmalaria/wiki 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-schema-46.0
+schema-47.0


### PR DESCRIPTION
Update version to 47.0.

New Elimination model, see: #384

The following model option is now needed to run the base model:
<option name="HEALTH_SYSTEM_MEMORY_FIX" value="false"/>

Github CI workflow updated to run on:
- MacOS 12, 13, 14
- Ubuntu 22.04, 24.04

Example scenario updated with DecisionTree5day firstLine/secondLine example, correct model options and latentp parameter.

DecisonTree5Day updated:
- New `<severe>` 
- New `<cohort component="id">`
- `<fever loopBack="5d">` changed to `<uncomplicated memory="5d">` (Note that the memory must be smaller than the healthSystemMemory parameter, but is now independent from it otherwise).

Change CMake minimum version to 3.5 to avoid warnings during compilation.