### PR TITLE
fix using sim::ts0 instead of sim::now in CMDecisionTree

### DIFF
--- a/model/Clinical/CMDecisionTree.cpp
+++ b/model/Clinical/CMDecisionTree.cpp
@@ -183,7 +183,7 @@ protected:
 
         if ( ((hostData.pgState & Episode::SICK) && !(hostData.pgState & Episode::COMPLICATED)) || (hostData.pgState & Episode::MALARIA) )
         {
-            if (latest.time + memory >= sim::ts0())
+            if (latest.time + memory >= sim::now())
                 return positive.exec( hostData );
             else
                 return negative.exec( hostData );


### PR DESCRIPTION
Fix a bug where sim::ts0() is used instead of sim::now() in CMDecisionTree.cpp