### PR TITLE
Fix cohort update time condition

### DIFF
--- a/model/Host/Human.cpp
+++ b/model/Host/Human.cpp
@@ -144,7 +144,7 @@ void Human::removeFirstEvent(interventions::SubPopRemove::RemoveAtCode code )
     for( auto it = removeAtList.begin(), end = removeAtList.end(); it != end; ++it ){
         auto expIt = subPopExp.find( *it );
         if( expIt != subPopExp.end() ){
-            if( expIt->second > sim::nowOrTs0() ){
+            if( expIt->second >= sim::nowOrTs0() ){
                 // removeFirstEvent() is used for onFirstBout, onFirstTreatment
                 // and onFirstInfection cohort options. Health system memory must
                 // be reset for this to work properly; in theory the memory should

--- a/model/Host/Human.h
+++ b/model/Host/Human.h
@@ -164,7 +164,7 @@ inline SimTime Human::age( SimTime time ) const {
 inline bool Human::isInSubPop( interventions::ComponentId id ) const {
     auto it = subPopExp.find( id );
     if( it == subPopExp.end() ) return false;   // no history of membership
-    else return it->second > sim::nowOrTs0();   // added: has expired?
+    else return it->second >= sim::nowOrTs0();   // added: has expired?
 }
 
 inline uint32_t Human::getCohortSet() const { 


### PR DESCRIPTION
Human cohort membership is tested and updated in 3 places:

`Human::isInSubPop()` mostly used during the deployment of interventions, just before the beginning of the time-step

`Human::updateCohortSet()` used during the Clinical model update, at the beginning of `Human::update()`

`Human::removeFirstEvent()` used during the Clinical model update and and just after a survey.

However, `updateCohortSet()`  used the following condition:
```
if( duration >= sim::nowOrTs0() )
```
while `isInSubPop()` and `removeFirstEvent()` used:
```
if( duration > sim::nowOrTs0() )
```

Given that all of these tests are done in the same time-frame (after a survey, before the end of the time-step), they must use the same condition.

**Old time-line example:**

* Cohort created at time t with duration 2
  * Time-step update
  * Cohort update: t + 2 >= t: nothing to do
* Cohort deployment with isInSubPop: t + 2 > t + 1: nothing to do
  * Time-step update
  * Cohort update: t + 2 >= t + 1: nothing to do
* Cohort deployment with isInSubPop: t + 2 > t + 2: nothing to do
  * Time-step update
  * Cohort update: t + 2 >= t + 2: human removed from cohort

**New time-line example:**

* Cohort created at time t with duration 2
  * Time-step update
  * Cohort update: t + 2 >= t: nothing to do
* Cohort deployment with isInSubPop: t + 2 >= t + 1: nothing to do
  * Time-step update
  * Cohort update: t + 2 >= t + 1: nothing to do
* Cohort deployment with isInSubPop: t + 2 >= t + 2: human no longer in the cohort
  * Time-step update
  * Cohort update: t + 2 >= t + 2: human removed from cohort

Note that the change has no effect on the tests. This only affect intervention deployment conditional on cohort membership, when duration is finite, wihich is a specific case that is not part of the test suite yet.