### PR TITLE
CI: remove macos-12 and add macos-15

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -50,14 +50,14 @@ jobs:
           - os: ubuntu-22.04
             compiler: g++
             target: Linux
+
+          - os: macos-15
+            compiler: clang
           
           - os: macos-14
             compiler: clang
 
           - os: macos-13
-            compiler: clang
-          
-          - os: macos-12
             compiler: clang
           
     steps:


### PR DESCRIPTION
macos-12 is now deprecated and won't run in the github action workflow.
macos-15 has been added.