### PR TITLE
add <infectionOrigin> to the DecisionTree

### DIFF
--- a/model/Clinical/CMDecisionTree.cpp
+++ b/model/Clinical/CMDecisionTree.cpp
@@ -121,6 +121,44 @@ private:
 };
 
 /**
+ * Should the patient recieve a different treatment based on its infection type?
+ */
+class CMDTInfectionOrigin : public CMDecisionTree {
+public:
+    static const CMDecisionTree& create( const ::scnXml::DTInfectionOrigin& node, bool isUC );
+    
+protected:
+    virtual bool operator==( const CMDecisionTree& that ) const{
+        if( this == &that ) return true; // short cut: same object thus equivalent
+        const CMDTInfectionOrigin* p = dynamic_cast<const CMDTInfectionOrigin*>( &that );
+        if( p == 0 ) return false;      // different type of node
+        if( imported != p->imported ) return false;
+        if( introduced != p->introduced ) return false;
+        if( indigenous != p->indigenous ) return false;
+        return true;    // no tests failed; must be the same
+    }
+    
+    virtual CMDTOut exec( CMHostData hostData ) const{
+        WithinHost::InfectionOrigin InfectionOrigin = hostData.withinHost().getInfectionType();
+        if(InfectionOrigin == WithinHost::InfectionOrigin::Imported)
+            return imported.exec( hostData );
+        else if (InfectionOrigin == WithinHost::InfectionOrigin::Introduced)
+            return introduced.exec( hostData );
+        else
+            return indigenous.exec( hostData );
+    }
+    
+private:
+    CMDTInfectionOrigin( const CMDecisionTree& imported,
+                  const CMDecisionTree& introduced,
+                  const CMDecisionTree& indigenous ) :
+                  imported(imported), introduced(introduced), indigenous(indigenous)
+                  {}
+    
+    const CMDecisionTree& imported, &introduced, &indigenous;
+};
+
+/**
  * Use a diagnostic, and call another decision tree based on the outcome.
  */
 class CMDTDiagnostic : public CMDecisionTree {
@@ -603,6 +641,7 @@ const CMDecisionTree& CMDecisionTree::create( const scnXml::DecisionTree& node, 
     if( node.getMultiple().present() ) return CMDTMultiple::create( node.getMultiple().get(), isUC);
     // branching nodes
     if( node.getCaseType().present() ) return CMDTCaseType::create( node.getCaseType().get(), isUC);
+    if( node.getInfectionOrigin().present() ) return CMDTInfectionOrigin::create( node.getInfectionOrigin().get(), isUC);
     if( node.getDiagnostic().present() ) return CMDTDiagnostic::create( node.getDiagnostic().get(), isUC);
     if( node.getUncomplicated().present() ) return CMDTUncomplicated::create( node.getUncomplicated().get(), isUC);
     if( node.getSevere().present() ) return CMDTSevere::create( node.getSevere().get(), true);
@@ -627,6 +666,9 @@ const CMDecisionTree& CMDTMultiple::create( const scnXml::DTMultiple& node, bool
     CMDTMultiple* self = new CMDTMultiple();
     for( const scnXml::DTCaseType& sn : node.getCaseType() ){
         self->children.push_back( &CMDTCaseType::create(sn, isUC) );
+    }
+    for( const scnXml::DTInfectionOrigin& sn : node.getInfectionOrigin() ){
+        self->children.push_back( &CMDTInfectionOrigin::create(sn, isUC) );
     }
     for( const scnXml::DTDiagnostic& sn : node.getDiagnostic() ){
         self->children.push_back( &CMDTDiagnostic::create(sn, isUC) );
@@ -668,6 +710,17 @@ const CMDecisionTree& CMDTCaseType::create( const scnXml::DTCaseType& node, bool
     return save_decision( new CMDTCaseType(
         CMDecisionTree::create( node.getFirstLine(), isUC ),
         CMDecisionTree::create( node.getSecondLine(), isUC )
+    ) );
+}
+
+const CMDecisionTree& CMDTInfectionOrigin::create( const scnXml::DTInfectionOrigin& node, bool isUC ){
+    if( !isUC ){
+        throw util::xml_scenario_error( "decision tree: caseType can only be used for uncomplicated cases" );
+    }
+    return save_decision( new CMDTInfectionOrigin(
+        CMDecisionTree::create( node.getImported(), isUC ),
+        CMDecisionTree::create( node.getIntroduced(), isUC ),
+        CMDecisionTree::create( node.getIndigenous(), isUC )
     ) );
 }
 

--- a/model/Clinical/CMDecisionTree.cpp
+++ b/model/Clinical/CMDecisionTree.cpp
@@ -139,7 +139,7 @@ protected:
     }
     
     virtual CMDTOut exec( CMHostData hostData ) const{
-        WithinHost::InfectionOrigin InfectionOrigin = hostData.withinHost().getInfectionType();
+        WithinHost::InfectionOrigin InfectionOrigin = hostData.withinHost().getInfectionOrigin();
         if(InfectionOrigin == WithinHost::InfectionOrigin::Imported)
             return imported.exec( hostData );
         else if (InfectionOrigin == WithinHost::InfectionOrigin::Introduced)

--- a/model/Clinical/Episode.cpp
+++ b/model/Clinical/Episode.cpp
@@ -48,7 +48,7 @@ void Episode::update (const Host::Human& human, Episode::State newState)
         toReport = true;
 
     if(toReport) {
-        infectionType = human.withinHostModel->getInfectionType();
+        infectionType = human.withinHostModel->getInfectionOrigin();
 
         report ();
 

--- a/model/Host/WithinHost/CommonWithinHost.h
+++ b/model/Host/WithinHost/CommonWithinHost.h
@@ -66,6 +66,8 @@ public:
     static CommonInfection* (* createInfection) (LocalRng& rng, uint32_t protID, int origin);
     static CommonInfection* (* checkpointedInfection) (istream& stream);
     //@}
+
+    virtual InfectionOrigin getInfectionOrigin() const;
     
     virtual bool summarize( Host::Human& human )const;
     

--- a/model/Host/WithinHost/DescriptiveWithinHost.h
+++ b/model/Host/WithinHost/DescriptiveWithinHost.h
@@ -52,7 +52,9 @@ public:
     virtual void update(Host::Human &human, LocalRng& rng, int &nNewInfs_i, int &nNewInfs_l, 
         vector<double>& genotype_weights_i, vector<double>& genotype_weights_l, double ageInYears);
     
-    virtual bool summarize( Host::Human& human )const;
+    virtual InfectionOrigin getInfectionOrigin() const;
+
+    virtual bool summarize( Host::Human& human ) const;
     
 protected:
     virtual void clearInfections( Treatments::Stages stage );
@@ -67,7 +69,7 @@ protected:
      * 
      * Since infection models and within host models are very much intertwined,
      * the idea is that each WithinHostModel has its own list of infections. */
-     std::list<DescriptiveInfection> infections;
+     std::list<DescriptiveInfection*> infections;
 
      bool opt_vaccine_genotype = false;
 };

--- a/model/Host/WithinHost/Infection/Infection.h
+++ b/model/Host/WithinHost/Infection/Infection.h
@@ -154,5 +154,31 @@ protected:
     friend class ::UnittestUtil;
 };
 
+template <typename T>
+InfectionOrigin get_infection_origin(const std::list<T*> &infections)
+{
+    if(infections.empty())
+        return InfectionOrigin::Indigenous;
+
+    int nImported = 0, nIntroduced = 0, nIndigenous = 0;
+    for( auto inf = infections.begin(); inf != infections.end(); ++inf )
+    {
+        if((*inf)->origin() == InfectionOrigin::Indigenous) nIndigenous++;
+        else if((*inf)->origin() == InfectionOrigin::Introduced) nIntroduced++;
+        else nImported++;
+    }
+
+    /* The rules are:
+    - Imported only if all infections are imported
+    - Introduced if at least one Introduced
+    - Indigenous otherwise (Imported + Indigenous or just Indigenous infections) */
+    if(nIntroduced > 0)
+        return InfectionOrigin::Introduced;
+    else if(nIndigenous > 0)
+        return InfectionOrigin::Indigenous;
+    else
+        return InfectionOrigin::Imported;
+}
+
 } }
 #endif

--- a/model/Host/WithinHost/WHFalciparum.h
+++ b/model/Host/WithinHost/WHFalciparum.h
@@ -70,10 +70,6 @@ public:
     
     virtual Pathogenesis::StatePair determineMorbidity( Host::Human& human, double ageYears, bool isDoomed );
 
-    virtual InfectionOrigin getInfectionType() const {
-        return infectionType;
-    }
-
     inline double getCumulative_h() const {
         return m_cumulative_h;
     }
@@ -141,8 +137,6 @@ protected:
     /// End of step on which treatment expires = start of first step after expiry
     SimTime treatExpiryLiver, treatExpiryBlood;
 
-    InfectionOrigin infectionType = InfectionOrigin::Indigenous;
-    
     virtual void checkpoint (istream& stream);
     virtual void checkpoint (ostream& stream);
 

--- a/model/Host/WithinHost/WHInterface.h
+++ b/model/Host/WithinHost/WHInterface.h
@@ -194,7 +194,7 @@ public:
     virtual double getCumulative_h() const =0;
     virtual double getCumulative_Y() const =0;
 
-    virtual InfectionOrigin getInfectionType() const =0;
+    virtual InfectionOrigin getInfectionOrigin() const =0;
 
     /** The maximum number of infections a human can have. The only real reason
      * for this limit is to prevent incase bad input from causing the number of

--- a/model/Host/WithinHost/WHVivax.h
+++ b/model/Host/WithinHost/WHVivax.h
@@ -167,7 +167,7 @@ public:
     
     virtual void clearImmunity();
 	
-    virtual InfectionOrigin getInfectionType() const {
+    virtual InfectionOrigin getInfectionOrigin() const {
         return InfectionOrigin::Indigenous;
     }
 

--- a/schema/healthSystem.xsd
+++ b/schema/healthSystem.xsd
@@ -672,6 +672,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
    <xs:element name="multiple" type="om:DTMultiple"/>
    <!-- branching points -->
    <xs:element name="caseType" type="om:DTCaseType"/>
+   <xs:element name="infectionOrigin" type="om:DTInfectionOrigin"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic"/>
    <xs:element name="uncomplicated" type="om:DTUncomplicated"/>
    <xs:element name="severe" type="om:DTSevere"/>
@@ -712,6 +713,7 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
   <xs:choice minOccurs="0" maxOccurs="unbounded">
    <!-- branching points -->
    <xs:element name="caseType" type="om:DTCaseType" minOccurs="0" maxOccurs="unbounded"/>
+   <xs:element name="infectionOrigin" type="om:DTInfectionOrigin" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="diagnostic" type="om:DTDiagnostic" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="uncomplicated" type="om:DTUncomplicated" minOccurs="0" maxOccurs="unbounded"/>
    <xs:element name="severe" type="om:DTSevere" minOccurs="0" maxOccurs="unbounded"/>
@@ -746,6 +748,33 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
   <xs:all>
    <xs:element name="firstLine" type="om:DecisionTree"/>
    <xs:element name="secondLine" type="om:DecisionTree"/>
+  </xs:all>
+  <xs:attribute name="name" type="xs:string" use="optional">
+   <xs:annotation>
+    <xs:documentation>
+          An optional piece of documentation attached to this node.
+        </xs:documentation>
+    <xs:appinfo>name:Name;</xs:appinfo>
+   </xs:annotation>
+  </xs:attribute>
+ </xs:complexType>
+ <xs:complexType name="DTInfectionOrigin">
+  <xs:annotation>
+   <xs:documentation>
+        A switch which choses a branch deterministically, based on whether the
+        patient has an imported, introduced or indigenous infection.
+        
+        If the patient is not infected, this will execute the indigenous branch by 
+        default. You must use a diagnostic test first to find out if the patient is infected.
+
+        If there are no imported cases, all infections will appear indigenous.
+      </xs:documentation>
+   <xs:appinfo>name:Switch (imported, introduced, indigenous);</xs:appinfo>
+  </xs:annotation>
+  <xs:all>
+   <xs:element name="imported" type="om:DecisionTree"/>
+   <xs:element name="introduced" type="om:DecisionTree"/>
+   <xs:element name="indigenous" type="om:DecisionTree"/>
   </xs:all>
   <xs:attribute name="name" type="xs:string" use="optional">
    <xs:annotation>

--- a/unittest/WHMock.cpp
+++ b/unittest/WHMock.cpp
@@ -94,7 +94,7 @@ double WHMock::getCumulative_Y() const{
     throw util::unimplemented_exception( "not needed in unit test" );
 }
 
-InfectionOrigin WHMock::getInfectionType() const{
+InfectionOrigin WHMock::getInfectionOrigin() const{
     return InfectionOrigin::Indigenous;
 }
 

--- a/unittest/WHMock.h
+++ b/unittest/WHMock.h
@@ -59,7 +59,7 @@ public:
     virtual void clearImmunity();
     virtual double getCumulative_h() const;
     virtual double getCumulative_Y() const;
-    virtual InfectionOrigin getInfectionType() const;
+    virtual InfectionOrigin getInfectionOrigin() const;
 
     // This mock class does not have actual infections. Just set this as you please.
     double totalDensity;


### PR DESCRIPTION
Add `<infectionOrigin>` together with `<imported>`, `<introduced>` and `<indigenous>` branches to the DecisionTree.

Users can apply different treatments or deploy different interventions depending on if the host classifies as  "imported", "introduced" or "indigenous" based on the origin of its current infection(s). 

If the DecisionTree is used in an intervention, or if NonMalariaFevers are enabled in the healthSystem, then the user should also do a diagnostic to ensure that the host is infected before using the <infectionOrigin> node. If the host is not infected, the node will always execute the <indigenous> branch as this is the default infection origin.

Note that imported and introduced cases only exist when imported infections are enabled. This is done via the `<importedInfections>` intervention, for example:

```xml
<importedInfections name="5 infections per individuals per year">
<timed>
  <rate time="0" value="5000"/> <!-- infections per 1000 individuals per year -->
</timed>
</importedInfections>
```

Example of healthSystem:
```xml
<!-- The more flexible DecisionTree5Day replaces the older ImmediateOutcomes. 
The probabilities below are greatly affected by the presence (or the absence) of a clinic or hospital on site -->
<DecisionTree5Day name="example name">
    <pSeekOfficialCareUncomplicated1 value="0.04"/><!-- 5-day probability that a patient uncomplicated case seeks official care -->
    <pSelfTreatUncomplicated value="0.0"/><!-- 5-day probability that a patient with uncomplicated case will self-treat -->
    <pSeekOfficialCareUncomplicated2 value="0.04"/><!-- 5-day probability that a patient with recurrence seeks official care -->
    <pSeekOfficialCareSevere value="0.48"/><!-- 5-day probability that a patient with severe case seeks official care -->
    <treeUCOfficial>
        <caseType>
            <firstLine>
                <infectionOrigin>
                    <imported>
                         <treatSimple durationLiver="0" durationBlood="1t"/>
                    </imported>
                    <introduced>
                         <treatSimple durationLiver="0" durationBlood="1t"/>
                    </introduced>
                    <indigenous>
                         <treatSimple durationLiver="0" durationBlood="1t"/>
                    </indigenous>
                </infectionOrigin>
            </firstLine>
            <secondLine>
                <infectionOrigin>
                    <imported>
                         <treatSimple durationLiver="0" durationBlood="1t"/>
                    </imported>
                    <introduced>
                         <treatSimple durationLiver="0" durationBlood="1t"/>
                    </introduced>
                    <indigenous>
                         <treatSimple durationLiver="0" durationBlood="1t"/>
                    </indigenous>
                </infectionOrigin>
            </secondLine>
        </caseType>
    </treeUCOfficial>
    <treeUCSelfTreat>
        <noTreatment/>
    </treeUCSelfTreat>
    <cureRateSevere value="1.0"/>
    <treatmentSevere>
        <clearInfections stage="blood" timesteps="1t"/>
    </treatmentSevere>
</DecisionTree5Day>
```

Example of DecisionTree used in an intervention, with a diagnostic:
```xml
<component id="MSAT">
  <decisionTree>
    <diagnostic diagnostic="deterministic">
      <positive>
        <infectionOrigin>
            <imported>
                 <treatSimple durationLiver="0" durationBlood="1t"/>
            </imported>
            <introduced>
                 <treatSimple durationLiver="0" durationBlood="1t"/>
            </introduced>
            <indigenous>
                 <treatSimple durationLiver="0" durationBlood="1t"/>
            </indigenous>
        </infectionOrigin>
      </positive>
      <negative>
        <noTreatment/>
      </negative>
    </diagnostic>
  </decisionTree>
</component>
```