### PR TITLE
fix memory leak from missing destructor in Sampler

### DIFF
--- a/model/Transmission/PerHost.h
+++ b/model/Transmission/PerHost.h
@@ -45,11 +45,16 @@ class HumanVectorInterventionComponent;
  * Parameters are read from XML, and the availability rate is adjusted. */
 class PerHostAnophParams {
 public:
-    static inline void initReserve (size_t numSpecies) {
-        params.reserve (numSpecies);
-    }
+    PerHostAnophParams (const scnXml::Mosq& mosq);
+
+    PerHostAnophParams(PerHostAnophParams&&) noexcept = default;
+    PerHostAnophParams& operator=(PerHostAnophParams&&) noexcept = default;
+
+    PerHostAnophParams(const PerHostAnophParams&) = delete;
+    PerHostAnophParams& operator=(const PerHostAnophParams&) = delete;
+
     static inline void init (const scnXml::Mosq& mosq) {
-        params.push_back(PerHostAnophParams{ mosq });
+        params.emplace_back(mosq);
     }
     
     /// Get the number of vector species
@@ -133,8 +138,6 @@ public:
     //@}
     
 private:
-    PerHostAnophParams (const scnXml::Mosq& mosq);
-
     static vector<PerHostAnophParams> params;
     static vector<double> entoAvailabilityPercentiles;
 

--- a/model/Transmission/transmission.h
+++ b/model/Transmission/transmission.h
@@ -334,8 +334,6 @@ inline VectorModel *createVectorModel(const scnXml::Entomology &entoData, int po
     // Sort Anopheles by Decreasing EIR
     sort(anophelesList.begin(), anophelesList.end(), anophelesCompare);
 
-    PerHostAnophParams::initReserve(numSpecies);
-
     for (size_t i = 0; i < numSpecies; ++i)
     {
         auto anoph = anophelesList[i];

--- a/model/util/sampler.h
+++ b/model/util/sampler.h
@@ -32,6 +32,7 @@ namespace OM { namespace util {
     class Sampler
     {
     public:
+        virtual ~Sampler() = default;
         virtual double sample(LocalRng& rng) const = 0;
         virtual void scaleMean( double scalar ) = 0;
         virtual double mean() const = 0;


### PR DESCRIPTION
This fixes a small memory leak that happened at the end of the program.
This leak had no impact on the simulation or on available memory.