### PR TITLE
Fix infection origin: remove unnecessary UC check

### DIFF
--- a/model/Clinical/CMDecisionTree.cpp
+++ b/model/Clinical/CMDecisionTree.cpp
@@ -714,9 +714,6 @@ const CMDecisionTree& CMDTCaseType::create( const scnXml::DTCaseType& node, bool
 }
 
 const CMDecisionTree& CMDTInfectionOrigin::create( const scnXml::DTInfectionOrigin& node, bool isUC ){
-    if( !isUC ){
-        throw util::xml_scenario_error( "decision tree: caseType can only be used for uncomplicated cases" );
-    }
     return save_decision( new CMDTInfectionOrigin(
         CMDecisionTree::create( node.getImported(), isUC ),
         CMDecisionTree::create( node.getIntroduced(), isUC ),


### PR DESCRIPTION
Fix related to: https://github.com/SwissTPH/openmalaria/pull/402

The UC check is not necessary for InfectionOrigin. This can be used both inside an intervention and for Uncomplicated Care in the health system.