### PR TITLE
Doc: Fix link to XML schema docs in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also find our code on zenodo, with DOI-references:
 
 
 Schema documentation for the XML input files can be found
-[on this website](https://swisstph.github.io/openmalaria/intro.html)
+[on this website](https://swisstph.github.io/openmalaria/)
 or in the `schema` folder (both past releases and development version).
 
 You can download the latest build here:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Also find our code on zenodo, with DOI-references:
 
 
 Schema documentation for the XML input files can be found
-[on the wiki](https://github.com/SwissTPH/openmalaria/wiki/schema-Index)
+[on this website](https://swisstph.github.io/openmalaria/intro.html)
 or in the `schema` folder (both past releases and development version).
 
 You can download the latest build here:

--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -272,6 +272,7 @@
         <ModelOptions>
             <option name="INNATE_MAX_DENS" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
             <option name="INDIRECT_MORTALITY_FIX" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
+            <option name="MAX_DENS_CORRECTION" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
             <option name="HEALTH_SYSTEM_MEMORY_FIX" value="false"/> <!-- MANDATORY WITH THE BASE MODEL DO NOT REMOVE -->
         </ModelOptions>
 


### PR DESCRIPTION
## Problem

The hyperlink in the repo's readme to the XML schema documentation is broken.

Following the link takes the user to a "Create new page" page.

![image](https://github.com/user-attachments/assets/cb21a7be-79bf-45ea-bfa1-d8255d5475a7)

## Solution

I changed the hyperlink to target what I think is currently the most reasonable source of XML schema documentation.

I also considered pointing the link to the page for the latest schema version i.e. https://swisstph.github.io/openmalaria/schema-latest.html

But the site's intro page offers a bit more context, so I chose that.

## Testing

- I tested the new hyperlink works.
- The GitHub pages deployment check [failed for this PR when it ran originally](https://github.com/SwissTPH/openmalaria/actions/runs/14745335543/job/41391484308?pr=410).  This is because it's configured to use a [an OS version that is now unsupported by GitHub actions.](https://github.com/actions/runner-images/issues/11101).  I've created another pull request to address that issue https://github.com/SwissTPH/openmalaria/pull/411.