### PR TITLE
Fix: Upgrade Ubuntu version used by GitHub pages action to a supported version.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Problem 

A check for https://github.com/SwissTPH/openmalaria/pull/410 failed since the ["GitHub Pages / deploy (pull_request)" action failed.](https://github.com/SwissTPH/openmalaria/actions/runs/14745335543/job/41391484308?pr=410)

The action failed because [Ubuntu 20.04 is no longer supported for GitHub Actions workflows](https://github.com/actions/runner-images/issues/11101).

## Solution

GitHub's own recommendation is that "Workflows using the ubuntu-20.04 image label should be updated to ubuntu-latest, ubuntu-22.04, ubuntu-24.04 ."

Somewhat arbitrarily, I've chosen to change the OS version used to the newest, fixed version supported by GitHub Actions.

## Testing

The result of the "GitHub Pages / deploy (pull_request)" check on this pull request will indicate whether the new OS version is compatible with our workflow.