### PR TITLE
cleanup: Remove include attribute for <parameter> elements in XML schema.

### DIFF
--- a/schema/scenario.xsd
+++ b/schema/scenario.xsd
@@ -191,15 +191,6 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
         <xs:appinfo>units:Number;min:0;name:Parameter value;sweepable:true;</xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="include" type="xs:boolean" use="optional">
-      <xs:annotation>
-        <xs:documentation>
-          True if parameter is to be sampled in optimization
-          runs. Not used in simulator app.
-        </xs:documentation>
-        <xs:appinfo>units:Number;min:0;max:1;name:Sampling indicator;exposed:false;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
   </xs:complexType>
   <xs:complexType name="Parameters">
     <xs:sequence>

--- a/test/scenario1.xml
+++ b/test/scenario1.xml
@@ -1102,36 +1102,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="15d">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="No Use 1" number="16" value="1"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario10.xml
+++ b/test/scenario10.xml
@@ -1008,38 +1008,38 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="0" latentp="3">
-      <parameter include="false" name="         '-ln(1-Sinf)'    " number="1" value="0.050736"/>
-      <parameter include="false" name="         Estar    " number="2" value="0.03247"/>
-      <parameter include="false" name="         Simm     " number="3" value="0.157325"/>
-      <parameter include="false" name="         Xstar_p  " number="4" value="2393.949859"/>
-      <parameter include="false" name="         gamma_p  " number="5" value="1.979441"/>
-      <parameter include="false" name="         sigma2i  " number="6" value="9.525457"/>
-      <parameter include="false" name="         CumulativeYstar  " number="7" value="151465400.748812"/>
-      <parameter include="false" name="         CumulativeHstar  " number="8" value="70.526914"/>
-      <parameter include="false" name="         '-ln(1-alpha_m)'         " number="9" value="2.349838"/>
-      <parameter include="false" name="         decay_m  " number="10" value="2.372811"/>
-      <parameter include="false" name="         sigma2_0         " number="11" value="0.657622"/>
-      <parameter include="false" name="         Xstar_v  " number="12" value="0.922477"/>
-      <parameter include="false" name="         Ystar2   " number="13" value="10004.145044"/>
-      <parameter include="false" name="         alpha    " number="14" value="141306.48626"/>
-      <parameter include="false" name="         Density bias (non Garki)         " number="15" value="0.156321"/>
-      <parameter include="false" name="         No Use 1         " number="16" value="1"/>
-      <parameter include="false" name="         log oddsr CF community   " number="17" value="0.712956"/>
-      <parameter include="false" name="         Indirect risk cofactor   " number="18" value="0.013118"/>
-      <parameter include="false" name="         Non-malaria infant mortality     " number="19" value="60.798982"/>
-      <parameter include="false" name="         Density bias (Garki)     " number="20" value="5.561993"/>
-      <parameter include="false" name="         Severe Malaria Threshhold        " number="21" value="374899.564569"/>
-      <parameter include="false" name="         Immunity Penalty         " number="22" value="1"/>
-      <parameter include="false" name=" Immune effector decay " number="23" value="0"/>
-      <parameter include="false" name="         comorbidity intercept    " number="24" value="0.091105"/>
-      <parameter include="false" name="         Ystar half life  " number="25" value="0.281908"/>
-      <parameter include="false" name="         Ystar1   " number="26" value="0.602292"/>
-      <parameter include="false" name=" Asex immune decay " number="27" value="9.5e-05"/>
-      <parameter include="false" name="         Ystar0   " number="28" value="541.4835"/>
-      <parameter include="false" name="         Idete multiplier         " number="29" value="2.83077"/>
-      <parameter include="false" name="         critical age for comorbidity     " number="30" value="0.105099"/>
-      <parameter include="false" name="Mueller dummy 1" number="31" value="2.797523626"/>
-      <parameter include="false" name="Mueller dummy 2" number="32" value="0.117383"/>
+      <parameter name="         '-ln(1-Sinf)'    " number="1" value="0.050736"/>
+      <parameter name="         Estar    " number="2" value="0.03247"/>
+      <parameter name="         Simm     " number="3" value="0.157325"/>
+      <parameter name="         Xstar_p  " number="4" value="2393.949859"/>
+      <parameter name="         gamma_p  " number="5" value="1.979441"/>
+      <parameter name="         sigma2i  " number="6" value="9.525457"/>
+      <parameter name="         CumulativeYstar  " number="7" value="151465400.748812"/>
+      <parameter name="         CumulativeHstar  " number="8" value="70.526914"/>
+      <parameter name="         '-ln(1-alpha_m)'         " number="9" value="2.349838"/>
+      <parameter name="         decay_m  " number="10" value="2.372811"/>
+      <parameter name="         sigma2_0         " number="11" value="0.657622"/>
+      <parameter name="         Xstar_v  " number="12" value="0.922477"/>
+      <parameter name="         Ystar2   " number="13" value="10004.145044"/>
+      <parameter name="         alpha    " number="14" value="141306.48626"/>
+      <parameter name="         Density bias (non Garki)         " number="15" value="0.156321"/>
+      <parameter name="         No Use 1         " number="16" value="1"/>
+      <parameter name="         log oddsr CF community   " number="17" value="0.712956"/>
+      <parameter name="         Indirect risk cofactor   " number="18" value="0.013118"/>
+      <parameter name="         Non-malaria infant mortality     " number="19" value="60.798982"/>
+      <parameter name="         Density bias (Garki)     " number="20" value="5.561993"/>
+      <parameter name="         Severe Malaria Threshhold        " number="21" value="374899.564569"/>
+      <parameter name="         Immunity Penalty         " number="22" value="1"/>
+      <parameter name=" Immune effector decay " number="23" value="0"/>
+      <parameter name="         comorbidity intercept    " number="24" value="0.091105"/>
+      <parameter name="         Ystar half life  " number="25" value="0.281908"/>
+      <parameter name="         Ystar1   " number="26" value="0.602292"/>
+      <parameter name=" Asex immune decay " number="27" value="9.5e-05"/>
+      <parameter name="         Ystar0   " number="28" value="541.4835"/>
+      <parameter name="         Idete multiplier         " number="29" value="2.83077"/>
+      <parameter name="         critical age for comorbidity     " number="30" value="0.105099"/>
+      <parameter name="Mueller dummy 1" number="31" value="2.797523626"/>
+      <parameter name="Mueller dummy 2" number="32" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario11.xml
+++ b/test/scenario11.xml
@@ -638,36 +638,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="10" latentp="3">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.1447"/>
-      <parameter include="1" name="Xstar_p" number="4" value="2801.485664"/>
-      <parameter include="1" name="gamma_p" number="5" value="2.061137"/>
-      <parameter include="1" name="sigma2i" number="6" value="9.569774"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="137595256.939881"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="97.798358"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.306627"/>
-      <parameter include="1" name="decay_m" number="10" value="2.587184"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.656515"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.918108"/>
-      <parameter include="1" name="Ystar2" number="13" value="9696.340451"/>
-      <parameter include="1" name="alpha" number="14" value="157086.1001"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.172355"/>
-      <parameter include="0" name="No Use 1" number="16" value="1"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="0.729208"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.017543"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="50.648162"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="4.784096"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="346545.4089"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="0" name="Decay of risk of indirect mortality" number="23" value="0.1"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.098975"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.278909"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.600517"/>
-      <parameter include="0" name="Asexual decay" number="27" value="0"/>
-      <parameter include="1" name="Ystar0" number="28" value="328.056605"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="2.78614"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="0.115906"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.1447"/>
+      <parameter name="Xstar_p" number="4" value="2801.485664"/>
+      <parameter name="gamma_p" number="5" value="2.061137"/>
+      <parameter name="sigma2i" number="6" value="9.569774"/>
+      <parameter name="CumulativeYstar" number="7" value="137595256.939881"/>
+      <parameter name="CumulativeHstar" number="8" value="97.798358"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.306627"/>
+      <parameter name="decay_m" number="10" value="2.587184"/>
+      <parameter name="sigma2_0" number="11" value="0.656515"/>
+      <parameter name="Xstar_v" number="12" value="0.918108"/>
+      <parameter name="Ystar2" number="13" value="9696.340451"/>
+      <parameter name="alpha" number="14" value="157086.1001"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.172355"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="0.729208"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.017543"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="50.648162"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.784096"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="346545.4089"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Decay of risk of indirect mortality" number="23" value="0.1"/>
+      <parameter name="comorbidity intercept" number="24" value="0.098975"/>
+      <parameter name="Ystar half life" number="25" value="0.278909"/>
+      <parameter name="Ystar1" number="26" value="0.600517"/>
+      <parameter name="Asexual decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="328.056605"/>
+      <parameter name="Idete multiplier" number="29" value="2.78614"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.115906"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario12.xml
+++ b/test/scenario12.xml
@@ -1235,36 +1235,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3t">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="No Use 1" number="16" value="1"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario12a.xml
+++ b/test/scenario12a.xml
@@ -1241,36 +1241,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3t">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="No Use 1" number="16" value="1"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario2ITNs.xml
+++ b/test/scenario2ITNs.xml
@@ -317,36 +317,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="2" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario4.xml
+++ b/test/scenario4.xml
@@ -1072,36 +1072,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="No Use 1" number="16" value="1"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario5.xml
+++ b/test/scenario5.xml
@@ -563,36 +563,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="0" latentp="3">
-      <parameter include="false" name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
-      <parameter include="false" name="        Estar   " number="2" value="0.03247"/>
-      <parameter include="false" name="        Simm    " number="3" value="0.1447"/>
-      <parameter include="false" name="        Xstar_p " number="4" value="2801.485664"/>
-      <parameter include="false" name="        gamma_p " number="5" value="2.061137"/>
-      <parameter include="false" name="        sigma2i " number="6" value="9.569774"/>
-      <parameter include="false" name="        CumulativeYstar " number="7" value="137595256.939881"/>
-      <parameter include="false" name="        CumulativeHstar " number="8" value="97.798358"/>
-      <parameter include="false" name="        '-ln(1-alpha_m)'        " number="9" value="2.306627"/>
-      <parameter include="false" name="        decay_m " number="10" value="2.587184"/>
-      <parameter include="false" name="        sigma2_0        " number="11" value="0.656515"/>
-      <parameter include="false" name="        Xstar_v " number="12" value="0.918108"/>
-      <parameter include="false" name="        Ystar2  " number="13" value="9696.340451"/>
-      <parameter include="false" name="        alpha   " number="14" value="157086.100088"/>
-      <parameter include="false" name="        Density bias (non Garki)        " number="15" value="0.172355"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="        log oddsr CF community  " number="17" value="0.729208"/>
-      <parameter include="false" name="        Indirect risk cofactor  " number="18" value="0.017543"/>
-      <parameter include="false" name="        Non-malaria infant mortality    " number="19" value="50.648162"/>
-      <parameter include="false" name="        Density bias (Garki)    " number="20" value="4.784096"/>
-      <parameter include="false" name="        Severe Malaria Threshhold       " number="21" value="346545.408899"/>
-      <parameter include="false" name="        Immunity Penalty        " number="22" value="1"/>
-      <parameter include="false" name="        Immune effector decay     " number="23" value="0"/>
-      <parameter include="false" name="        comorbidity intercept   " number="24" value="0.098975"/>
-      <parameter include="false" name="        Ystar half life " number="25" value="0.278909"/>
-      <parameter include="false" name="        Ystar1  " number="26" value="0.600517"/>
-      <parameter include="false" name="        asex immune decay      " number="27" value="0"/>
-      <parameter include="false" name="        Ystar0  " number="28" value="328.056605"/>
-      <parameter include="false" name="        Idete multiplier        " number="29" value="2.78614"/>
-      <parameter include="false" name="        critical age for comorbidity    " number="30" value="0.115906"/>
+      <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
+      <parameter name="        Estar   " number="2" value="0.03247"/>
+      <parameter name="        Simm    " number="3" value="0.1447"/>
+      <parameter name="        Xstar_p " number="4" value="2801.485664"/>
+      <parameter name="        gamma_p " number="5" value="2.061137"/>
+      <parameter name="        sigma2i " number="6" value="9.569774"/>
+      <parameter name="        CumulativeYstar " number="7" value="137595256.939881"/>
+      <parameter name="        CumulativeHstar " number="8" value="97.798358"/>
+      <parameter name="        '-ln(1-alpha_m)'        " number="9" value="2.306627"/>
+      <parameter name="        decay_m " number="10" value="2.587184"/>
+      <parameter name="        sigma2_0        " number="11" value="0.656515"/>
+      <parameter name="        Xstar_v " number="12" value="0.918108"/>
+      <parameter name="        Ystar2  " number="13" value="9696.340451"/>
+      <parameter name="        alpha   " number="14" value="157086.100088"/>
+      <parameter name="        Density bias (non Garki)        " number="15" value="0.172355"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="        log oddsr CF community  " number="17" value="0.729208"/>
+      <parameter name="        Indirect risk cofactor  " number="18" value="0.017543"/>
+      <parameter name="        Non-malaria infant mortality    " number="19" value="50.648162"/>
+      <parameter name="        Density bias (Garki)    " number="20" value="4.784096"/>
+      <parameter name="        Severe Malaria Threshhold       " number="21" value="346545.408899"/>
+      <parameter name="        Immunity Penalty        " number="22" value="1"/>
+      <parameter name="        Immune effector decay     " number="23" value="0"/>
+      <parameter name="        comorbidity intercept   " number="24" value="0.098975"/>
+      <parameter name="        Ystar half life " number="25" value="0.278909"/>
+      <parameter name="        Ystar1  " number="26" value="0.600517"/>
+      <parameter name="        asex immune decay      " number="27" value="0"/>
+      <parameter name="        Ystar0  " number="28" value="328.056605"/>
+      <parameter name="        Idete multiplier        " number="29" value="2.78614"/>
+      <parameter name="        critical age for comorbidity    " number="30" value="0.115906"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario6.xml
+++ b/test/scenario6.xml
@@ -563,36 +563,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="0" latentp="3t">
-      <parameter include="false" name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
-      <parameter include="false" name="        Estar   " number="2" value="0.03247"/>
-      <parameter include="false" name="        Simm    " number="3" value="0.1447"/>
-      <parameter include="false" name="        Xstar_p " number="4" value="2801.485664"/>
-      <parameter include="false" name="        gamma_p " number="5" value="2.061137"/>
-      <parameter include="false" name="        sigma2i " number="6" value="9.569774"/>
-      <parameter include="false" name="        CumulativeYstar " number="7" value="137595256.939881"/>
-      <parameter include="false" name="        CumulativeHstar " number="8" value="97.798358"/>
-      <parameter include="false" name="        '-ln(1-alpha_m)'        " number="9" value="2.306627"/>
-      <parameter include="false" name="        decay_m " number="10" value="2.587184"/>
-      <parameter include="false" name="        sigma2_0        " number="11" value="0.656515"/>
-      <parameter include="false" name="        Xstar_v " number="12" value="0.918108"/>
-      <parameter include="false" name="        Ystar2  " number="13" value="9696.340451"/>
-      <parameter include="false" name="        alpha   " number="14" value="157086.100088"/>
-      <parameter include="false" name="        Density bias (non Garki)        " number="15" value="0.172355"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="        log oddsr CF community  " number="17" value="0.729208"/>
-      <parameter include="false" name="        Indirect risk cofactor  " number="18" value="0.017543"/>
-      <parameter include="false" name="        Non-malaria infant mortality    " number="19" value="50.648162"/>
-      <parameter include="false" name="        Density bias (Garki)    " number="20" value="4.784096"/>
-      <parameter include="false" name="        Severe Malaria Threshhold       " number="21" value="346545.408899"/>
-      <parameter include="false" name="        Immunity Penalty        " number="22" value="1"/>
-      <parameter include="false" name="        Immune effector decay     " number="23" value="0"/>
-      <parameter include="false" name="        comorbidity intercept   " number="24" value="0.098975"/>
-      <parameter include="false" name="        Ystar half life " number="25" value="0.278909"/>
-      <parameter include="false" name="        Ystar1  " number="26" value="0.600517"/>
-      <parameter include="false" name="        asex immune decay      " number="27" value="0"/>
-      <parameter include="false" name="        Ystar0  " number="28" value="328.056605"/>
-      <parameter include="false" name="        Idete multiplier        " number="29" value="2.78614"/>
-      <parameter include="false" name="        critical age for comorbidity    " number="30" value="0.115906"/>
+      <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
+      <parameter name="        Estar   " number="2" value="0.03247"/>
+      <parameter name="        Simm    " number="3" value="0.1447"/>
+      <parameter name="        Xstar_p " number="4" value="2801.485664"/>
+      <parameter name="        gamma_p " number="5" value="2.061137"/>
+      <parameter name="        sigma2i " number="6" value="9.569774"/>
+      <parameter name="        CumulativeYstar " number="7" value="137595256.939881"/>
+      <parameter name="        CumulativeHstar " number="8" value="97.798358"/>
+      <parameter name="        '-ln(1-alpha_m)'        " number="9" value="2.306627"/>
+      <parameter name="        decay_m " number="10" value="2.587184"/>
+      <parameter name="        sigma2_0        " number="11" value="0.656515"/>
+      <parameter name="        Xstar_v " number="12" value="0.918108"/>
+      <parameter name="        Ystar2  " number="13" value="9696.340451"/>
+      <parameter name="        alpha   " number="14" value="157086.100088"/>
+      <parameter name="        Density bias (non Garki)        " number="15" value="0.172355"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="        log oddsr CF community  " number="17" value="0.729208"/>
+      <parameter name="        Indirect risk cofactor  " number="18" value="0.017543"/>
+      <parameter name="        Non-malaria infant mortality    " number="19" value="50.648162"/>
+      <parameter name="        Density bias (Garki)    " number="20" value="4.784096"/>
+      <parameter name="        Severe Malaria Threshhold       " number="21" value="346545.408899"/>
+      <parameter name="        Immunity Penalty        " number="22" value="1"/>
+      <parameter name="        Immune effector decay     " number="23" value="0"/>
+      <parameter name="        comorbidity intercept   " number="24" value="0.098975"/>
+      <parameter name="        Ystar half life " number="25" value="0.278909"/>
+      <parameter name="        Ystar1  " number="26" value="0.600517"/>
+      <parameter name="        asex immune decay      " number="27" value="0"/>
+      <parameter name="        Ystar0  " number="28" value="328.056605"/>
+      <parameter name="        Idete multiplier        " number="29" value="2.78614"/>
+      <parameter name="        critical age for comorbidity    " number="30" value="0.115906"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenario9.xml
+++ b/test/scenario9.xml
@@ -1007,36 +1007,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="0" latentp="3t">
-      <parameter include="false" name="         '-ln(1-Sinf)'    " number="1" value="0.050736"/>
-      <parameter include="false" name="         Estar    " number="2" value="0.03247"/>
-      <parameter include="false" name="         Simm     " number="3" value="0.157325"/>
-      <parameter include="false" name="         Xstar_p  " number="4" value="2393.949859"/>
-      <parameter include="false" name="         gamma_p  " number="5" value="1.979441"/>
-      <parameter include="false" name="         sigma2i  " number="6" value="9.525457"/>
-      <parameter include="false" name="         CumulativeYstar  " number="7" value="151465400.748812"/>
-      <parameter include="false" name="         CumulativeHstar  " number="8" value="70.526914"/>
-      <parameter include="false" name="         '-ln(1-alpha_m)'         " number="9" value="2.349838"/>
-      <parameter include="false" name="         decay_m  " number="10" value="2.372811"/>
-      <parameter include="false" name="         sigma2_0         " number="11" value="0.657622"/>
-      <parameter include="false" name="         Xstar_v  " number="12" value="0.922477"/>
-      <parameter include="false" name="         Ystar2   " number="13" value="10004.145044"/>
-      <parameter include="false" name="         alpha    " number="14" value="141306.48626"/>
-      <parameter include="false" name="         Density bias (non Garki)         " number="15" value="0.156321"/>
-      <parameter include="false" name="         No Use 1         " number="16" value="1"/>
-      <parameter include="false" name="         log oddsr CF community   " number="17" value="0.712956"/>
-      <parameter include="false" name="         Indirect risk cofactor   " number="18" value="0.013118"/>
-      <parameter include="false" name="         Non-malaria infant mortality     " number="19" value="60.798982"/>
-      <parameter include="false" name="         Density bias (Garki)     " number="20" value="5.561993"/>
-      <parameter include="false" name="         Severe Malaria Threshhold        " number="21" value="374899.564569"/>
-      <parameter include="false" name="         Immunity Penalty         " number="22" value="1"/>
-      <parameter include="false" name=" Immune effector decay " number="23" value="0"/>
-      <parameter include="false" name="         comorbidity intercept    " number="24" value="0.091105"/>
-      <parameter include="false" name="         Ystar half life  " number="25" value="0.281908"/>
-      <parameter include="false" name="         Ystar1   " number="26" value="0.602292"/>
-      <parameter include="false" name=" Asex immune decay " number="27" value="9.5e-05"/>
-      <parameter include="false" name="         Ystar0   " number="28" value="541.4835"/>
-      <parameter include="false" name="         Idete multiplier         " number="29" value="2.83077"/>
-      <parameter include="false" name="         critical age for comorbidity     " number="30" value="0.105099"/>
+      <parameter name="         '-ln(1-Sinf)'    " number="1" value="0.050736"/>
+      <parameter name="         Estar    " number="2" value="0.03247"/>
+      <parameter name="         Simm     " number="3" value="0.157325"/>
+      <parameter name="         Xstar_p  " number="4" value="2393.949859"/>
+      <parameter name="         gamma_p  " number="5" value="1.979441"/>
+      <parameter name="         sigma2i  " number="6" value="9.525457"/>
+      <parameter name="         CumulativeYstar  " number="7" value="151465400.748812"/>
+      <parameter name="         CumulativeHstar  " number="8" value="70.526914"/>
+      <parameter name="         '-ln(1-alpha_m)'         " number="9" value="2.349838"/>
+      <parameter name="         decay_m  " number="10" value="2.372811"/>
+      <parameter name="         sigma2_0         " number="11" value="0.657622"/>
+      <parameter name="         Xstar_v  " number="12" value="0.922477"/>
+      <parameter name="         Ystar2   " number="13" value="10004.145044"/>
+      <parameter name="         alpha    " number="14" value="141306.48626"/>
+      <parameter name="         Density bias (non Garki)         " number="15" value="0.156321"/>
+      <parameter name="         No Use 1         " number="16" value="1"/>
+      <parameter name="         log oddsr CF community   " number="17" value="0.712956"/>
+      <parameter name="         Indirect risk cofactor   " number="18" value="0.013118"/>
+      <parameter name="         Non-malaria infant mortality     " number="19" value="60.798982"/>
+      <parameter name="         Density bias (Garki)     " number="20" value="5.561993"/>
+      <parameter name="         Severe Malaria Threshhold        " number="21" value="374899.564569"/>
+      <parameter name="         Immunity Penalty         " number="22" value="1"/>
+      <parameter name=" Immune effector decay " number="23" value="0"/>
+      <parameter name="         comorbidity intercept    " number="24" value="0.091105"/>
+      <parameter name="         Ystar half life  " number="25" value="0.281908"/>
+      <parameter name="         Ystar1   " number="26" value="0.602292"/>
+      <parameter name=" Asex immune decay " number="27" value="9.5e-05"/>
+      <parameter name="         Ystar0   " number="28" value="541.4835"/>
+      <parameter name="         Idete multiplier         " number="29" value="2.83077"/>
+      <parameter name="         critical age for comorbidity     " number="30" value="0.105099"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioAvailabilityHeterogeneity.xml
+++ b/test/scenarioAvailabilityHeterogeneity.xml
@@ -310,36 +310,36 @@
 
         <!-- DO NOT CHANGE THE MODEL PARAMETERS BELOW -->
         <parameters interval="5" iseed="1" latentp="3d">
-           <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-           <parameter include="0" name="Estar" number="2" value="0.03247"/>
-           <parameter include="0" name="Simm" number="3" value="0.138161050830301"/>
-           <parameter include="0" name="Xstar_p" number="4" value="1514.385853233699891"/>
-           <parameter include="0" name="gamma_p" number="5" value="2.03692533424484"/>
-           <parameter include="0" name="sigma2i" number="6" value="10.173598698525799"/>
-           <parameter include="0" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-           <parameter include="0" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-           <parameter include="0" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-           <parameter include="0" name="decay_m" number="10" value="2.53106547375805"/>
-           <parameter include="0" name="sigma2_0" number="11" value="0.655747311168152"/>
-           <parameter include="0" name="Xstar_v" number="12" value="0.916181104713054"/>
-           <parameter include="0" name="Ystar2" number="13" value="6502.26335600001039"/>
-           <parameter include="0" name="alpha" number="14" value="142601.912520000012591"/>
-           <parameter include="0" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-           <parameter include="0" name=" sigma2 " number="16" value="1.0"/>
-           <parameter include="0" name="log oddsr CF community" number="17" value="0.736202"/>
-           <parameter include="0" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-           <parameter include="0" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-           <parameter include="0" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-           <parameter include="0" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-           <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
-           <parameter include="0" name="Immune effector decay" number="23" value="0"/>
-           <parameter include="0" name="comorbidity intercept" number="24" value="0.0968"/>
-           <parameter include="0" name="Ystar half life" number="25" value="0.275437402"/>
-           <parameter include="0" name="Ystar1" number="26" value="0.596539864"/>
-           <parameter include="0" name="Asexual immunity decay" number="27" value="0"/>
-           <parameter include="0" name="Ystar0" number="28" value="296.302437899999973"/>
-           <parameter include="0" name="Idete multiplier" number="29" value="2.797523626"/>
-           <parameter include="0" name="critical age for comorbidity" number="30" value="0.117383"/>
+           <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+           <parameter name="Estar" number="2" value="0.03247"/>
+           <parameter name="Simm" number="3" value="0.138161050830301"/>
+           <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+           <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+           <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+           <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+           <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+           <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+           <parameter name="decay_m" number="10" value="2.53106547375805"/>
+           <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+           <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+           <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+           <parameter name="alpha" number="14" value="142601.912520000012591"/>
+           <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+           <parameter name=" sigma2 " number="16" value="1.0"/>
+           <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+           <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+           <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+           <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+           <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+           <parameter name="Immunity Penalty" number="22" value="1"/>
+           <parameter name="Immune effector decay" number="23" value="0"/>
+           <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+           <parameter name="Ystar half life" number="25" value="0.275437402"/>
+           <parameter name="Ystar1" number="26" value="0.596539864"/>
+           <parameter name="Asexual immunity decay" number="27" value="0"/>
+           <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+           <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+           <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
        </parameters>
    </model>
 </om:scenario>

--- a/test/scenarioBSV.xml
+++ b/test/scenarioBSV.xml
@@ -316,33 +316,33 @@
             </weight>
         </human>
         <parameters interval="5" iseed="1" latentp="3">
-            <parameter include="0" name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
-            <parameter include="0" name="Estar    " number="2" value="0.03247"/>
-            <parameter include="1" name="Simm     " number="3" value="0.153741"/>
-            <parameter include="1" name="Xstar_p  " number="4" value="1609.836243"/>
-            <parameter include="1" name="gamma_p  " number="5" value="1.650241"/>
-            <parameter include="1" name="sigma2i  " number="6" value="1.082696"/>
-            <parameter include="1" name="CumulativeYstar  " number="7" value="1865464.660703"/>
-            <parameter include="1" name="CumulativeHstar  " number="8" value="1765.283962"/>
-            <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
-            <parameter include="1" name="decay_m  " number="10" value="1.526271"/>
-            <parameter include="1" name="Ystar2   " number="13" value="4259.530005"/>
-            <parameter include="1" name="alpha    " number="14" value="553373.45094"/>
-            <parameter include="1" name="Density bias (non Garki)" number="15" value="0.510558"/>
-            <parameter include="0" name="No Use 1" number="16" value="0.05"/>
-            <parameter include="1" name="log oddsr CF community   " number="17" value="0.548263"/>
-            <parameter include="1" name="Indirect risk cofactor   " number="18" value="0.007721"/>
-            <parameter include="1" name="Non-malaria infant mortality     " number="19" value="47.967295"/>
-            <parameter include="1" name="Density bias (Garki)     " number="20" value="2.601878"/>
-            <parameter include="1" name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
-            <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
-            <parameter include="0" name=" Immune effector decay " number="23" value="0"/>
-            <parameter include="1" name="comorbidity intercept    " number="24" value="0.011939"/>
-            <parameter include="1" name="Ystar half life  " number="25" value="0.401293"/>
-            <parameter include="1" name="Ystar1   " number="26" value="0.796334"/>
-            <parameter include="0" name=" Asex immune decay " number="27" value="0"/>
-            <parameter include="1" name="Ystar0   " number="28" value="28.120561"/>
-            <parameter include="1" name="critical age for comorbidity     " number="30" value="0.151984"/>
+            <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
+            <parameter name="Estar    " number="2" value="0.03247"/>
+            <parameter name="Simm     " number="3" value="0.153741"/>
+            <parameter name="Xstar_p  " number="4" value="1609.836243"/>
+            <parameter name="gamma_p  " number="5" value="1.650241"/>
+            <parameter name="sigma2i  " number="6" value="1.082696"/>
+            <parameter name="CumulativeYstar  " number="7" value="1865464.660703"/>
+            <parameter name="CumulativeHstar  " number="8" value="1765.283962"/>
+            <parameter name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
+            <parameter name="decay_m  " number="10" value="1.526271"/>
+            <parameter name="Ystar2   " number="13" value="4259.530005"/>
+            <parameter name="alpha    " number="14" value="553373.45094"/>
+            <parameter name="Density bias (non Garki)" number="15" value="0.510558"/>
+            <parameter name="No Use 1" number="16" value="0.05"/>
+            <parameter name="log oddsr CF community   " number="17" value="0.548263"/>
+            <parameter name="Indirect risk cofactor   " number="18" value="0.007721"/>
+            <parameter name="Non-malaria infant mortality     " number="19" value="47.967295"/>
+            <parameter name="Density bias (Garki)     " number="20" value="2.601878"/>
+            <parameter name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
+            <parameter name="Immunity Penalty" number="22" value="1"/>
+            <parameter name=" Immune effector decay " number="23" value="0"/>
+            <parameter name="comorbidity intercept    " number="24" value="0.011939"/>
+            <parameter name="Ystar half life  " number="25" value="0.401293"/>
+            <parameter name="Ystar1   " number="26" value="0.796334"/>
+            <parameter name=" Asex immune decay " number="27" value="0"/>
+            <parameter name="Ystar0   " number="28" value="28.120561"/>
+            <parameter name="critical age for comorbidity     " number="30" value="0.151984"/>
         </parameters>
     </model>
 </om:scenario>

--- a/test/scenarioCohort.xml
+++ b/test/scenarioCohort.xml
@@ -1292,42 +1292,42 @@
       </weight>
     </human>
     <parameters interval="1" iseed="1" latentp="15t">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="0"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="500000000.0"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="700.0"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="No Use 1" number="16" value="1"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="1.5"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
-      <parameter include="false" name="v in 'Case Fatality Rate proposal'" number="33" value="0.00008"/>
-      <parameter include="false" name="Molineaux first local max density mean" number="34" value="4.0"/>
-      <parameter include="false" name="Molineaux first local max density sd" number="35" value="0.1"/>
-      <parameter include="false" name="Diff positive days mean" number="36" value="1.57"/>
-      <parameter include="false" name="Diff positive days sd" number="37" value="0.15"/>
-      <parameter include="false" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.916290731874155"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="0"/>
+      <parameter name="CumulativeYstar" number="7" value="500000000.0"/>
+      <parameter name="CumulativeHstar" number="8" value="700.0"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="1.5"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.00008"/>
+      <parameter name="Molineaux first local max density mean" number="34" value="4.0"/>
+      <parameter name="Molineaux first local max density sd" number="35" value="0.1"/>
+      <parameter name="Diff positive days mean" number="36" value="1.57"/>
+      <parameter name="Diff positive days sd" number="37" value="0.15"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.916290731874155"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioDecisionTree5DayDielmo.xml
+++ b/test/scenarioDecisionTree5DayDielmo.xml
@@ -241,36 +241,36 @@
               </availabilityToMosquitoes>
             </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioESTS.xml
+++ b/test/scenarioESTS.xml
@@ -1511,42 +1511,42 @@
       </weight>
     </human>
     <parameters interval="1" iseed="0" latentp="15d">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.267285"/>
-      <parameter include="1" name="Xstar_p" number="4" value="759.314477"/>
-      <parameter include="1" name="gamma_p" number="5" value="1.708485"/>
-      <parameter include="0" name="sigma2i" number="6" value="0.0"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="54813976.2486"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="1699.033941"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.222015"/>
-      <parameter include="1" name="decay_m" number="10" value="2.240491"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.615029"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.938506"/>
-      <parameter include="1" name="Ystar2" number="13" value="5329.731586"/>
-      <parameter include="1" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.256318"/>
-      <parameter include="0" name="No Use 1" number="16" value="1.0"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="1.581369"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.01767"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="51.904524"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="3.826913"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="112390457.143"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1.0"/>
-      <parameter include="0" name="Immune effector decay" number="23" value="0.0"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.00425"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.342198"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.521995"/>
-      <parameter include="0" name="Asex immune decay" number="27" value="0.0"/>
-      <parameter include="1" name="Ystar0" number="28" value="546.452498"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="3.209994"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="0.005745"/>
-      <parameter include="1" name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
-      <parameter include="1" name="Molineaux first local max density mean" number="34" value="4.671987"/>
-      <parameter include="1" name="Molineaux first local max density sd" number="35" value="0.059724"/>
-      <parameter include="1" name="Diff positive days mean" number="36" value="2.013458"/>
-      <parameter include="1" name="Diff positive days sd" number="37" value="0.179451"/>
-      <parameter include="1" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.937431"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.267285"/>
+      <parameter name="Xstar_p" number="4" value="759.314477"/>
+      <parameter name="gamma_p" number="5" value="1.708485"/>
+      <parameter name="sigma2i" number="6" value="0.0"/>
+      <parameter name="CumulativeYstar" number="7" value="54813976.2486"/>
+      <parameter name="CumulativeHstar" number="8" value="1699.033941"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.222015"/>
+      <parameter name="decay_m" number="10" value="2.240491"/>
+      <parameter name="sigma2_0" number="11" value="0.615029"/>
+      <parameter name="Xstar_v" number="12" value="0.938506"/>
+      <parameter name="Ystar2" number="13" value="5329.731586"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.256318"/>
+      <parameter name="No Use 1" number="16" value="1.0"/>
+      <parameter name="log oddsr CF community" number="17" value="1.581369"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.01767"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="51.904524"/>
+      <parameter name="Density bias (Garki)" number="20" value="3.826913"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="112390457.143"/>
+      <parameter name="Immunity Penalty" number="22" value="1.0"/>
+      <parameter name="Immune effector decay" number="23" value="0.0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.00425"/>
+      <parameter name="Ystar half life" number="25" value="0.342198"/>
+      <parameter name="Ystar1" number="26" value="0.521995"/>
+      <parameter name="Asex immune decay" number="27" value="0.0"/>
+      <parameter name="Ystar0" number="28" value="546.452498"/>
+      <parameter name="Idete multiplier" number="29" value="3.209994"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.005745"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
+      <parameter name="Molineaux first local max density mean" number="34" value="4.671987"/>
+      <parameter name="Molineaux first local max density sd" number="35" value="0.059724"/>
+      <parameter name="Diff positive days mean" number="36" value="2.013458"/>
+      <parameter name="Diff positive days sd" number="37" value="0.179451"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.937431"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioEffectiveDrug.xml
+++ b/test/scenarioEffectiveDrug.xml
@@ -1079,38 +1079,38 @@
       </weight>
     </human>
     <parameters interval="1" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="No Use 1" number="16" value="1"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
-      <parameter include="false" name="v in 'Case Fatality Rate proposal'" number="33" value="0.01"/>
-      <parameter include="false" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.916290731874155"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.01"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.916290731874155"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioEmpirical.xml
+++ b/test/scenarioEmpirical.xml
@@ -1216,38 +1216,38 @@
       </weight>
     </human>
     <parameters interval="1" iseed="1" latentp="0">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="No Use 1" number="16" value="1"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
-      <parameter include="false" name="v in 'Case Fatality Rate proposal'" number="33" value="0.01"/>
-      <parameter include="false" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.916290731874155"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="No Use 1" number="16" value="1"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.01"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.916290731874155"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioGenotypes.xml
+++ b/test/scenarioGenotypes.xml
@@ -321,38 +321,38 @@
     </human>
     <!-- run id=898 parameterization id=265074 sampling date=2011-02-23 00:09:18 lossfunction=68.507534 -->
     <parameters interval="5" iseed="0" latentp="15d">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.198704"/>
-      <parameter include="1" name="Xstar_p" number="4" value="585.023074"/>
-      <parameter include="1" name="gamma_p" number="5" value="2.090617"/>
-      <parameter include="0" name="sigma2i" number="6" value="0.0"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="119458790.84"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="6456.791146"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="1.946307"/>
-      <parameter include="1" name="decay_m" number="10" value="2.519874"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.450179"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.914409"/>
-      <parameter include="1" name="Ystar2" number="13" value="2541.51055"/>
-      <parameter include="1" name="alpha" number="14" value="42785.290409"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.155481"/>
-      <parameter include="0" name="No Use 1" number="16" value="1.0"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="1.482122"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.00878"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="65.154738"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="5.358463"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="232109531.928"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1.0"/>
-      <parameter include="0" name="Immune effector decay" number="23" value="0.0"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.001243"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.396409"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.453994"/>
-      <parameter include="0" name="Asex immune decay" number="27" value="0.0"/>
-      <parameter include="1" name="Ystar0" number="28" value="635.109128"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="3.060171"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="5.5e-05"/>
-      <parameter include="1" name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
-      <parameter include="1" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.935351"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.198704"/>
+      <parameter name="Xstar_p" number="4" value="585.023074"/>
+      <parameter name="gamma_p" number="5" value="2.090617"/>
+      <parameter name="sigma2i" number="6" value="0.0"/>
+      <parameter name="CumulativeYstar" number="7" value="119458790.84"/>
+      <parameter name="CumulativeHstar" number="8" value="6456.791146"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="1.946307"/>
+      <parameter name="decay_m" number="10" value="2.519874"/>
+      <parameter name="sigma2_0" number="11" value="0.450179"/>
+      <parameter name="Xstar_v" number="12" value="0.914409"/>
+      <parameter name="Ystar2" number="13" value="2541.51055"/>
+      <parameter name="alpha" number="14" value="42785.290409"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.155481"/>
+      <parameter name="No Use 1" number="16" value="1.0"/>
+      <parameter name="log oddsr CF community" number="17" value="1.482122"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.00878"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="65.154738"/>
+      <parameter name="Density bias (Garki)" number="20" value="5.358463"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="232109531.928"/>
+      <parameter name="Immunity Penalty" number="22" value="1.0"/>
+      <parameter name="Immune effector decay" number="23" value="0.0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.001243"/>
+      <parameter name="Ystar half life" number="25" value="0.396409"/>
+      <parameter name="Ystar1" number="26" value="0.453994"/>
+      <parameter name="Asex immune decay" number="27" value="0.0"/>
+      <parameter name="Ystar0" number="28" value="635.109128"/>
+      <parameter name="Idete multiplier" number="29" value="3.060171"/>
+      <parameter name="critical age for comorbidity" number="30" value="5.5e-05"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.935351"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioHetVecDailyEIR.xml
+++ b/test/scenarioHetVecDailyEIR.xml
@@ -526,36 +526,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioIRS30.xml
+++ b/test/scenarioIRS30.xml
@@ -278,36 +278,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="2" latentp="15d">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioKK_20150612.xml
+++ b/test/scenarioKK_20150612.xml
@@ -409,33 +409,33 @@
     <!-- parameters: created_time: 2015-05-14 01:15:37, lossfunction (residual sum of squares): 102.422953 (log-likelyhood): 114.261551 run_id: 4301
      -->
     <parameters interval="5" iseed="0" latentp="3">
-      <parameter include="0" name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
-      <parameter include="0" name="Estar    " number="2" value="0.03247"/>
-      <parameter include="1" name="Simm     " number="3" value="0.153741"/>
-      <parameter include="1" name="Xstar_p  " number="4" value="1609.836243"/>
-      <parameter include="1" name="gamma_p  " number="5" value="1.650241"/>
-      <parameter include="1" name="sigma2i  " number="6" value="1.082696"/>
-      <parameter include="1" name="CumulativeYstar  " number="7" value="1865464.660703"/>
-      <parameter include="1" name="CumulativeHstar  " number="8" value="1765.283962"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
-      <parameter include="1" name="decay_m  " number="10" value="1.526271"/>
-      <parameter include="1" name="Ystar2   " number="13" value="4259.530005"/>
-      <parameter include="1" name="alpha    " number="14" value="553373.45094"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.510558"/>
-      <parameter include="0" name="No Use 1" number="16" value="0.05"/>
-      <parameter include="1" name="log oddsr CF community   " number="17" value="0.548263"/>
-      <parameter include="1" name="Indirect risk cofactor   " number="18" value="0.007721"/>
-      <parameter include="1" name="Non-malaria infant mortality     " number="19" value="47.967295"/>
-      <parameter include="1" name="Density bias (Garki)     " number="20" value="2.601878"/>
-      <parameter include="1" name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="0" name=" Immune effector decay " number="23" value="0"/>
-      <parameter include="1" name="comorbidity intercept    " number="24" value="0.011939"/>
-      <parameter include="1" name="Ystar half life  " number="25" value="0.401293"/>
-      <parameter include="1" name="Ystar1   " number="26" value="0.796334"/>
-      <parameter include="0" name=" Asex immune decay " number="27" value="0"/>
-      <parameter include="1" name="Ystar0   " number="28" value="28.120561"/>
-      <parameter include="1" name="critical age for comorbidity     " number="30" value="0.151984"/>
+      <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
+      <parameter name="Estar    " number="2" value="0.03247"/>
+      <parameter name="Simm     " number="3" value="0.153741"/>
+      <parameter name="Xstar_p  " number="4" value="1609.836243"/>
+      <parameter name="gamma_p  " number="5" value="1.650241"/>
+      <parameter name="sigma2i  " number="6" value="1.082696"/>
+      <parameter name="CumulativeYstar  " number="7" value="1865464.660703"/>
+      <parameter name="CumulativeHstar  " number="8" value="1765.283962"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
+      <parameter name="decay_m  " number="10" value="1.526271"/>
+      <parameter name="Ystar2   " number="13" value="4259.530005"/>
+      <parameter name="alpha    " number="14" value="553373.45094"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.510558"/>
+      <parameter name="No Use 1" number="16" value="0.05"/>
+      <parameter name="log oddsr CF community   " number="17" value="0.548263"/>
+      <parameter name="Indirect risk cofactor   " number="18" value="0.007721"/>
+      <parameter name="Non-malaria infant mortality     " number="19" value="47.967295"/>
+      <parameter name="Density bias (Garki)     " number="20" value="2.601878"/>
+      <parameter name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name=" Immune effector decay " number="23" value="0"/>
+      <parameter name="comorbidity intercept    " number="24" value="0.011939"/>
+      <parameter name="Ystar half life  " number="25" value="0.401293"/>
+      <parameter name="Ystar1   " number="26" value="0.796334"/>
+      <parameter name=" Asex immune decay " number="27" value="0"/>
+      <parameter name="Ystar0   " number="28" value="28.120561"/>
+      <parameter name="critical age for comorbidity     " number="30" value="0.151984"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioLifeNet1.xml
+++ b/test/scenarioLifeNet1.xml
@@ -284,36 +284,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="11" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioLifeNet2.xml
+++ b/test/scenarioLifeNet2.xml
@@ -285,36 +285,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="11" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioMSAT.xml
+++ b/test/scenarioMSAT.xml
@@ -618,42 +618,42 @@
       </weight>
     </human>
     <parameters interval="1" iseed="1" latentp="15">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.267285"/>
-      <parameter include="1" name="Xstar_p" number="4" value="759.314477"/>
-      <parameter include="1" name="gamma_p" number="5" value="1.708485"/>
-      <parameter include="0" name="sigma2i" number="6" value="0.0"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="54813976.2486"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="1699.033941"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.222015"/>
-      <parameter include="1" name="decay_m" number="10" value="2.240491"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.615029"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.938506"/>
-      <parameter include="1" name="Ystar2" number="13" value="5329.731586"/>
-      <parameter include="1" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.256318"/>
-      <parameter include="0" name="No Use 1" number="16" value="1.0"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="1.581369"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.01767"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="51.904524"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="3.826913"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="112390457.143"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1.0"/>
-      <parameter include="0" name="Immune effector decay" number="23" value="0.0"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.00425"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.342198"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.521995"/>
-      <parameter include="0" name="Asex immune decay" number="27" value="0.0"/>
-      <parameter include="1" name="Ystar0" number="28" value="546.452498"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="3.209994"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="0.005745"/>
-      <parameter include="1" name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
-      <parameter include="1" name="Molineaux first local max density mean" number="34" value="4.671987"/>
-      <parameter include="1" name="Molineaux first local max density sd" number="35" value="0.059724"/>
-      <parameter include="1" name="Diff positive days mean" number="36" value="2.013458"/>
-      <parameter include="1" name="Diff positive days sd" number="37" value="0.179451"/>
-      <parameter include="1" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.937431"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.267285"/>
+      <parameter name="Xstar_p" number="4" value="759.314477"/>
+      <parameter name="gamma_p" number="5" value="1.708485"/>
+      <parameter name="sigma2i" number="6" value="0.0"/>
+      <parameter name="CumulativeYstar" number="7" value="54813976.2486"/>
+      <parameter name="CumulativeHstar" number="8" value="1699.033941"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.222015"/>
+      <parameter name="decay_m" number="10" value="2.240491"/>
+      <parameter name="sigma2_0" number="11" value="0.615029"/>
+      <parameter name="Xstar_v" number="12" value="0.938506"/>
+      <parameter name="Ystar2" number="13" value="5329.731586"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.256318"/>
+      <parameter name="No Use 1" number="16" value="1.0"/>
+      <parameter name="log oddsr CF community" number="17" value="1.581369"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.01767"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="51.904524"/>
+      <parameter name="Density bias (Garki)" number="20" value="3.826913"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="112390457.143"/>
+      <parameter name="Immunity Penalty" number="22" value="1.0"/>
+      <parameter name="Immune effector decay" number="23" value="0.0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.00425"/>
+      <parameter name="Ystar half life" number="25" value="0.342198"/>
+      <parameter name="Ystar1" number="26" value="0.521995"/>
+      <parameter name="Asex immune decay" number="27" value="0.0"/>
+      <parameter name="Ystar0" number="28" value="546.452498"/>
+      <parameter name="Idete multiplier" number="29" value="3.209994"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.005745"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
+      <parameter name="Molineaux first local max density mean" number="34" value="4.671987"/>
+      <parameter name="Molineaux first local max density sd" number="35" value="0.059724"/>
+      <parameter name="Diff positive days mean" number="36" value="2.013458"/>
+      <parameter name="Diff positive days sd" number="37" value="0.179451"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.937431"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioMSAT_HRP2.xml
+++ b/test/scenarioMSAT_HRP2.xml
@@ -547,42 +547,42 @@
       </weight>
     </human>
     <parameters interval="1" iseed="1" latentp="15d">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.267285"/>
-      <parameter include="1" name="Xstar_p" number="4" value="759.314477"/>
-      <parameter include="1" name="gamma_p" number="5" value="1.708485"/>
-      <parameter include="0" name="sigma2i" number="6" value="0.0"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="54813976.2486"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="1699.033941"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.222015"/>
-      <parameter include="1" name="decay_m" number="10" value="2.240491"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.615029"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.938506"/>
-      <parameter include="1" name="Ystar2" number="13" value="5329.731586"/>
-      <parameter include="1" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.256318"/>
-      <parameter include="0" name="No Use 1" number="16" value="1.0"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="1.581369"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.01767"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="51.904524"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="3.826913"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="112390457.143"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1.0"/>
-      <parameter include="0" name="Immune effector decay" number="23" value="0.0"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.00425"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.342198"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.521995"/>
-      <parameter include="0" name="Asex immune decay" number="27" value="0.0"/>
-      <parameter include="1" name="Ystar0" number="28" value="546.452498"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="3.209994"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="0.005745"/>
-      <parameter include="1" name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
-      <parameter include="1" name="Molineaux first local max density mean" number="34" value="4.671987"/>
-      <parameter include="1" name="Molineaux first local max density sd" number="35" value="0.059724"/>
-      <parameter include="1" name="Diff positive days mean" number="36" value="2.013458"/>
-      <parameter include="1" name="Diff positive days sd" number="37" value="0.179451"/>
-      <parameter include="1" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.937431"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.267285"/>
+      <parameter name="Xstar_p" number="4" value="759.314477"/>
+      <parameter name="gamma_p" number="5" value="1.708485"/>
+      <parameter name="sigma2i" number="6" value="0.0"/>
+      <parameter name="CumulativeYstar" number="7" value="54813976.2486"/>
+      <parameter name="CumulativeHstar" number="8" value="1699.033941"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.222015"/>
+      <parameter name="decay_m" number="10" value="2.240491"/>
+      <parameter name="sigma2_0" number="11" value="0.615029"/>
+      <parameter name="Xstar_v" number="12" value="0.938506"/>
+      <parameter name="Ystar2" number="13" value="5329.731586"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.256318"/>
+      <parameter name="No Use 1" number="16" value="1.0"/>
+      <parameter name="log oddsr CF community" number="17" value="1.581369"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.01767"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="51.904524"/>
+      <parameter name="Density bias (Garki)" number="20" value="3.826913"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="112390457.143"/>
+      <parameter name="Immunity Penalty" number="22" value="1.0"/>
+      <parameter name="Immune effector decay" number="23" value="0.0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.00425"/>
+      <parameter name="Ystar half life" number="25" value="0.342198"/>
+      <parameter name="Ystar1" number="26" value="0.521995"/>
+      <parameter name="Asex immune decay" number="27" value="0.0"/>
+      <parameter name="Ystar0" number="28" value="546.452498"/>
+      <parameter name="Idete multiplier" number="29" value="3.209994"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.005745"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
+      <parameter name="Molineaux first local max density mean" number="34" value="4.671987"/>
+      <parameter name="Molineaux first local max density sd" number="35" value="0.059724"/>
+      <parameter name="Diff positive days mean" number="36" value="2.013458"/>
+      <parameter name="Diff positive days sd" number="37" value="0.179451"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.937431"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioMolPairwise.xml
+++ b/test/scenarioMolPairwise.xml
@@ -565,38 +565,38 @@
     </human>
     <!-- run id=898 parameterization id=265074 sampling date=2011-02-23 00:09:18 lossfunction=68.507534 -->
     <parameters interval="5" iseed="0" latentp="15d">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.198704"/>
-      <parameter include="1" name="Xstar_p" number="4" value="585.023074"/>
-      <parameter include="1" name="gamma_p" number="5" value="2.090617"/>
-      <parameter include="0" name="sigma2i" number="6" value="0.0"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="119458790.84"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="6456.791146"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="1.946307"/>
-      <parameter include="1" name="decay_m" number="10" value="2.519874"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.450179"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.914409"/>
-      <parameter include="1" name="Ystar2" number="13" value="2541.51055"/>
-      <parameter include="1" name="alpha" number="14" value="42785.290409"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.155481"/>
-      <parameter include="0" name="No Use 1" number="16" value="1.0"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="1.482122"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.00878"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="65.154738"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="5.358463"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="232109531.928"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1.0"/>
-      <parameter include="0" name="Immune effector decay" number="23" value="0.0"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.001243"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.396409"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.453994"/>
-      <parameter include="0" name="Asex immune decay" number="27" value="0.0"/>
-      <parameter include="1" name="Ystar0" number="28" value="635.109128"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="3.060171"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="5.5e-05"/>
-      <parameter include="1" name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
-      <parameter include="1" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.935351"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.198704"/>
+      <parameter name="Xstar_p" number="4" value="585.023074"/>
+      <parameter name="gamma_p" number="5" value="2.090617"/>
+      <parameter name="sigma2i" number="6" value="0.0"/>
+      <parameter name="CumulativeYstar" number="7" value="119458790.84"/>
+      <parameter name="CumulativeHstar" number="8" value="6456.791146"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="1.946307"/>
+      <parameter name="decay_m" number="10" value="2.519874"/>
+      <parameter name="sigma2_0" number="11" value="0.450179"/>
+      <parameter name="Xstar_v" number="12" value="0.914409"/>
+      <parameter name="Ystar2" number="13" value="2541.51055"/>
+      <parameter name="alpha" number="14" value="42785.290409"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.155481"/>
+      <parameter name="No Use 1" number="16" value="1.0"/>
+      <parameter name="log oddsr CF community" number="17" value="1.482122"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.00878"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="65.154738"/>
+      <parameter name="Density bias (Garki)" number="20" value="5.358463"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="232109531.928"/>
+      <parameter name="Immunity Penalty" number="22" value="1.0"/>
+      <parameter name="Immune effector decay" number="23" value="0.0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.001243"/>
+      <parameter name="Ystar half life" number="25" value="0.396409"/>
+      <parameter name="Ystar1" number="26" value="0.453994"/>
+      <parameter name="Asex immune decay" number="27" value="0.0"/>
+      <parameter name="Ystar0" number="28" value="635.109128"/>
+      <parameter name="Idete multiplier" number="29" value="3.060171"/>
+      <parameter name="critical age for comorbidity" number="30" value="5.5e-05"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.935351"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioMolineaux.xml
+++ b/test/scenarioMolineaux.xml
@@ -1058,42 +1058,42 @@
     </human>
     <!-- run id=898 parameterization id=265074 sampling date=2011-02-23 00:09:18 lossfunction=68.507534 -->
     <parameters interval="1" iseed="0" latentp="15d">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.198704"/>
-      <parameter include="1" name="Xstar_p" number="4" value="585.023074"/>
-      <parameter include="1" name="gamma_p" number="5" value="2.090617"/>
-      <parameter include="0" name="sigma2i" number="6" value="0.0"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="119458790.84"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="6456.791146"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="1.946307"/>
-      <parameter include="1" name="decay_m" number="10" value="2.519874"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.450179"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.914409"/>
-      <parameter include="1" name="Ystar2" number="13" value="2541.51055"/>
-      <parameter include="1" name="alpha" number="14" value="42785.290409"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.155481"/>
-      <parameter include="0" name="No Use 1" number="16" value="1.0"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="1.482122"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.00878"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="65.154738"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="5.358463"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="232109531.928"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1.0"/>
-      <parameter include="0" name="Immune effector decay" number="23" value="0.0"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.001243"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.396409"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.453994"/>
-      <parameter include="0" name="Asex immune decay" number="27" value="0.0"/>
-      <parameter include="1" name="Ystar0" number="28" value="635.109128"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="3.060171"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="5.5e-05"/>
-      <parameter include="1" name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
-      <parameter include="0" name="Molineaux first local max density mean" number="34" value="4.7601"/>
-      <parameter include="0" name="Molineaux first local max density sd" number="35" value="0.5008"/>
-      <parameter include="0" name="Diff positive days mean" number="36" value="2.2736"/>
-      <parameter include="0" name="Diff positive days sd" number="37" value="0.2315"/>
-      <parameter include="1" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.935351"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.198704"/>
+      <parameter name="Xstar_p" number="4" value="585.023074"/>
+      <parameter name="gamma_p" number="5" value="2.090617"/>
+      <parameter name="sigma2i" number="6" value="0.0"/>
+      <parameter name="CumulativeYstar" number="7" value="119458790.84"/>
+      <parameter name="CumulativeHstar" number="8" value="6456.791146"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="1.946307"/>
+      <parameter name="decay_m" number="10" value="2.519874"/>
+      <parameter name="sigma2_0" number="11" value="0.450179"/>
+      <parameter name="Xstar_v" number="12" value="0.914409"/>
+      <parameter name="Ystar2" number="13" value="2541.51055"/>
+      <parameter name="alpha" number="14" value="42785.290409"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.155481"/>
+      <parameter name="No Use 1" number="16" value="1.0"/>
+      <parameter name="log oddsr CF community" number="17" value="1.482122"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.00878"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="65.154738"/>
+      <parameter name="Density bias (Garki)" number="20" value="5.358463"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="232109531.928"/>
+      <parameter name="Immunity Penalty" number="22" value="1.0"/>
+      <parameter name="Immune effector decay" number="23" value="0.0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.001243"/>
+      <parameter name="Ystar half life" number="25" value="0.396409"/>
+      <parameter name="Ystar1" number="26" value="0.453994"/>
+      <parameter name="Asex immune decay" number="27" value="0.0"/>
+      <parameter name="Ystar0" number="28" value="635.109128"/>
+      <parameter name="Idete multiplier" number="29" value="3.060171"/>
+      <parameter name="critical age for comorbidity" number="30" value="5.5e-05"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
+      <parameter name="Molineaux first local max density mean" number="34" value="4.7601"/>
+      <parameter name="Molineaux first local max density sd" number="35" value="0.5008"/>
+      <parameter name="Diff positive days mean" number="36" value="2.2736"/>
+      <parameter name="Diff positive days sd" number="37" value="0.2315"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.935351"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioNamawalaArabiensis.xml
+++ b/test/scenarioNamawalaArabiensis.xml
@@ -178,36 +178,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="15d">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioNoInterv.xml
+++ b/test/scenarioNoInterv.xml
@@ -233,36 +233,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioNoMPDLarviciding.xml
+++ b/test/scenarioNoMPDLarviciding.xml
@@ -308,36 +308,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioNonHumanHosts.xml
+++ b/test/scenarioNonHumanHosts.xml
@@ -417,36 +417,36 @@
             </availabilityToMosquitoes>
         </human>
         <parameters interval="5" iseed="2" latentp="3">
-            <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-            <parameter include="false" name="Estar" number="2" value="0.03247"/>
-            <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-            <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-            <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-            <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-            <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-            <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-            <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-            <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-            <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-            <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-            <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-            <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-            <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-            <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-            <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-            <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-            <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-            <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-            <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-            <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-            <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-            <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-            <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-            <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-            <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-            <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-            <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-            <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+            <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+            <parameter name="Estar" number="2" value="0.03247"/>
+            <parameter name="Simm" number="3" value="0.138161050830301"/>
+            <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+            <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+            <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+            <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+            <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+            <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+            <parameter name="decay_m" number="10" value="2.53106547375805"/>
+            <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+            <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+            <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+            <parameter name="alpha" number="14" value="142601.912520000012591"/>
+            <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+            <parameter name="        sigma2        " number="16" value="0.05"/>
+            <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+            <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+            <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+            <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+            <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+            <parameter name="Immunity Penalty" number="22" value="1"/>
+            <parameter name="Immune effector decay" number="23" value="0"/>
+            <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+            <parameter name="Ystar half life" number="25" value="0.275437402"/>
+            <parameter name="Ystar1" number="26" value="0.596539864"/>
+            <parameter name="Asexual immunity decay" number="27" value="0"/>
+            <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+            <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+            <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
         </parameters>
     </model>
 </om:scenario>

--- a/test/scenarioPEV.xml
+++ b/test/scenarioPEV.xml
@@ -316,33 +316,33 @@
             </weight>
         </human>
         <parameters interval="5" iseed="1" latentp="3">
-            <parameter include="0" name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
-            <parameter include="0" name="Estar    " number="2" value="0.03247"/>
-            <parameter include="1" name="Simm     " number="3" value="0.153741"/>
-            <parameter include="1" name="Xstar_p  " number="4" value="1609.836243"/>
-            <parameter include="1" name="gamma_p  " number="5" value="1.650241"/>
-            <parameter include="1" name="sigma2i  " number="6" value="1.082696"/>
-            <parameter include="1" name="CumulativeYstar  " number="7" value="1865464.660703"/>
-            <parameter include="1" name="CumulativeHstar  " number="8" value="1765.283962"/>
-            <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
-            <parameter include="1" name="decay_m  " number="10" value="1.526271"/>
-            <parameter include="1" name="Ystar2   " number="13" value="4259.530005"/>
-            <parameter include="1" name="alpha    " number="14" value="553373.45094"/>
-            <parameter include="1" name="Density bias (non Garki)" number="15" value="0.510558"/>
-            <parameter include="0" name="No Use 1" number="16" value="0.05"/>
-            <parameter include="1" name="log oddsr CF community   " number="17" value="0.548263"/>
-            <parameter include="1" name="Indirect risk cofactor   " number="18" value="0.007721"/>
-            <parameter include="1" name="Non-malaria infant mortality     " number="19" value="47.967295"/>
-            <parameter include="1" name="Density bias (Garki)     " number="20" value="2.601878"/>
-            <parameter include="1" name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
-            <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
-            <parameter include="0" name=" Immune effector decay " number="23" value="0"/>
-            <parameter include="1" name="comorbidity intercept    " number="24" value="0.011939"/>
-            <parameter include="1" name="Ystar half life  " number="25" value="0.401293"/>
-            <parameter include="1" name="Ystar1   " number="26" value="0.796334"/>
-            <parameter include="0" name=" Asex immune decay " number="27" value="0"/>
-            <parameter include="1" name="Ystar0   " number="28" value="28.120561"/>
-            <parameter include="1" name="critical age for comorbidity     " number="30" value="0.151984"/>
+            <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
+            <parameter name="Estar    " number="2" value="0.03247"/>
+            <parameter name="Simm     " number="3" value="0.153741"/>
+            <parameter name="Xstar_p  " number="4" value="1609.836243"/>
+            <parameter name="gamma_p  " number="5" value="1.650241"/>
+            <parameter name="sigma2i  " number="6" value="1.082696"/>
+            <parameter name="CumulativeYstar  " number="7" value="1865464.660703"/>
+            <parameter name="CumulativeHstar  " number="8" value="1765.283962"/>
+            <parameter name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
+            <parameter name="decay_m  " number="10" value="1.526271"/>
+            <parameter name="Ystar2   " number="13" value="4259.530005"/>
+            <parameter name="alpha    " number="14" value="553373.45094"/>
+            <parameter name="Density bias (non Garki)" number="15" value="0.510558"/>
+            <parameter name="No Use 1" number="16" value="0.05"/>
+            <parameter name="log oddsr CF community   " number="17" value="0.548263"/>
+            <parameter name="Indirect risk cofactor   " number="18" value="0.007721"/>
+            <parameter name="Non-malaria infant mortality     " number="19" value="47.967295"/>
+            <parameter name="Density bias (Garki)     " number="20" value="2.601878"/>
+            <parameter name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
+            <parameter name="Immunity Penalty" number="22" value="1"/>
+            <parameter name=" Immune effector decay " number="23" value="0"/>
+            <parameter name="comorbidity intercept    " number="24" value="0.011939"/>
+            <parameter name="Ystar half life  " number="25" value="0.401293"/>
+            <parameter name="Ystar1   " number="26" value="0.796334"/>
+            <parameter name=" Asex immune decay " number="27" value="0"/>
+            <parameter name="Ystar0   " number="28" value="28.120561"/>
+            <parameter name="critical age for comorbidity     " number="30" value="0.151984"/>
         </parameters>
     </model>
 </om:scenario>

--- a/test/scenarioPenny.xml
+++ b/test/scenarioPenny.xml
@@ -1011,42 +1011,42 @@
     </human>
     <!-- run id=1101 parameterization id=220288 sampling date=2011-04-10 13:58:03 lossfunction=4699975.42996 -->
     <parameters interval="1" iseed="0" latentp="15">
-      <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="0" name="Estar" number="2" value="0.03247"/>
-      <parameter include="1" name="Simm" number="3" value="0.184877"/>
-      <parameter include="1" name="Xstar_p" number="4" value="612.012574"/>
-      <parameter include="1" name="gamma_p" number="5" value="2.046664"/>
-      <parameter include="0" name="sigma2i" number="6" value="0.0"/>
-      <parameter include="1" name="CumulativeYstar" number="7" value="28354970.5539"/>
-      <parameter include="1" name="CumulativeHstar" number="8" value="1451.502427"/>
-      <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.519506"/>
-      <parameter include="1" name="decay_m" number="10" value="2.252497"/>
-      <parameter include="1" name="sigma2_0" number="11" value="0.592265"/>
-      <parameter include="1" name="Xstar_v" number="12" value="0.952878"/>
-      <parameter include="1" name="Ystar2" number="13" value="4003.131282"/>
-      <parameter include="1" name="alpha" number="14" value="75456.396726"/>
-      <parameter include="1" name="Density bias (non Garki)" number="15" value="0.184058"/>
-      <parameter include="0" name="No Use 1" number="16" value="1.0"/>
-      <parameter include="1" name="log oddsr CF community" number="17" value="1.537648"/>
-      <parameter include="1" name="Indirect risk cofactor" number="18" value="0.009016"/>
-      <parameter include="1" name="Non-malaria infant mortality" number="19" value="90.909964"/>
-      <parameter include="1" name="Density bias (Garki)" number="20" value="6.479123"/>
-      <parameter include="1" name="Severe Malaria Threshhold" number="21" value="250844182.688"/>
-      <parameter include="0" name="Immunity Penalty" number="22" value="1.0"/>
-      <parameter include="0" name="Immune effector decay" number="23" value="0.0"/>
-      <parameter include="1" name="comorbidity intercept" number="24" value="0.001396"/>
-      <parameter include="1" name="Ystar half life" number="25" value="0.313304"/>
-      <parameter include="1" name="Ystar1" number="26" value="0.457107"/>
-      <parameter include="0" name="Asex immune decay" number="27" value="0.0"/>
-      <parameter include="1" name="Ystar0" number="28" value="781.931486"/>
-      <parameter include="1" name="Idete multiplier" number="29" value="2.997404"/>
-      <parameter include="1" name="critical age for comorbidity" number="30" value="0.001183"/>
-      <parameter include="1" name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
-      <parameter include="0" name="Molineaux first local max density mean" number="34" value="4.7601"/>
-      <parameter include="0" name="Molineaux first local max density sd" number="35" value="0.5008"/>
-      <parameter include="0" name="Diff positive days mean" number="36" value="2.2736"/>
-      <parameter include="0" name="Diff positive days sd" number="37" value="0.2315"/>
-      <parameter include="1" name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.940524"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.184877"/>
+      <parameter name="Xstar_p" number="4" value="612.012574"/>
+      <parameter name="gamma_p" number="5" value="2.046664"/>
+      <parameter name="sigma2i" number="6" value="0.0"/>
+      <parameter name="CumulativeYstar" number="7" value="28354970.5539"/>
+      <parameter name="CumulativeHstar" number="8" value="1451.502427"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.519506"/>
+      <parameter name="decay_m" number="10" value="2.252497"/>
+      <parameter name="sigma2_0" number="11" value="0.592265"/>
+      <parameter name="Xstar_v" number="12" value="0.952878"/>
+      <parameter name="Ystar2" number="13" value="4003.131282"/>
+      <parameter name="alpha" number="14" value="75456.396726"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.184058"/>
+      <parameter name="No Use 1" number="16" value="1.0"/>
+      <parameter name="log oddsr CF community" number="17" value="1.537648"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.009016"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="90.909964"/>
+      <parameter name="Density bias (Garki)" number="20" value="6.479123"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="250844182.688"/>
+      <parameter name="Immunity Penalty" number="22" value="1.0"/>
+      <parameter name="Immune effector decay" number="23" value="0.0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.001396"/>
+      <parameter name="Ystar half life" number="25" value="0.313304"/>
+      <parameter name="Ystar1" number="26" value="0.457107"/>
+      <parameter name="Asex immune decay" number="27" value="0.0"/>
+      <parameter name="Ystar0" number="28" value="781.931486"/>
+      <parameter name="Idete multiplier" number="29" value="2.997404"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.001183"/>
+      <parameter name="v in 'Case Fatality Rate proposal'" number="33" value="0.0"/>
+      <parameter name="Molineaux first local max density mean" number="34" value="4.7601"/>
+      <parameter name="Molineaux first local max density sd" number="35" value="0.5008"/>
+      <parameter name="Diff positive days mean" number="36" value="2.2736"/>
+      <parameter name="Diff positive days sd" number="37" value="0.2315"/>
+      <parameter name="-log(alpha) in 'Case Fatality Rate proposal'" number="38" value="0.940524"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioRach5IC.xml
+++ b/test/scenarioRach5IC.xml
@@ -287,36 +287,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="2" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioSimpleMPDLarviciding.xml
+++ b/test/scenarioSimpleMPDLarviciding.xml
@@ -304,36 +304,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioSimpleMPDTest.xml
+++ b/test/scenarioSimpleMPDTest.xml
@@ -206,36 +206,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3t">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioSubPopRemoval.xml
+++ b/test/scenarioSubPopRemoval.xml
@@ -174,36 +174,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="61321" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.0502"/>
-      <parameter include="false" name="Estar" number="2" value="0.032"/>
-      <parameter include="false" name="Simm" number="3" value="0.0809506710366894"/>
-      <parameter include="false" name="Xstar_p" number="4" value="5301.79729516512"/>
-      <parameter include="false" name="gamma_p" number="5" value="0.867641953418309"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.2"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="131250823.718489"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="150.118765348471"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="3.30642361247272"/>
-      <parameter include="false" name="decay_m" number="10" value="1.3115653955642"/>
-      <parameter include="false" name="sigma2_0" number="11" value="1.02918598519619"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.243544416255358"/>
-      <parameter include="false" name="Ystar2" number="13" value="6637.12420015078"/>
-      <parameter include="false" name="alpha" number="14" value="175013.800903478"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.18"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.737"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.019"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.8"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784000.0"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.092"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.27471760030155"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.228063096434434"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="1.17905916371677"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.0502"/>
+      <parameter name="Estar" number="2" value="0.032"/>
+      <parameter name="Simm" number="3" value="0.0809506710366894"/>
+      <parameter name="Xstar_p" number="4" value="5301.79729516512"/>
+      <parameter name="gamma_p" number="5" value="0.867641953418309"/>
+      <parameter name="sigma2i" number="6" value="10.2"/>
+      <parameter name="CumulativeYstar" number="7" value="131250823.718489"/>
+      <parameter name="CumulativeHstar" number="8" value="150.118765348471"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="3.30642361247272"/>
+      <parameter name="decay_m" number="10" value="1.3115653955642"/>
+      <parameter name="sigma2_0" number="11" value="1.02918598519619"/>
+      <parameter name="Xstar_v" number="12" value="0.243544416255358"/>
+      <parameter name="Ystar2" number="13" value="6637.12420015078"/>
+      <parameter name="alpha" number="14" value="175013.800903478"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.18"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.737"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.019"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.8"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784000.0"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.092"/>
+      <parameter name="Ystar half life" number="25" value="0.27471760030155"/>
+      <parameter name="Ystar1" number="26" value="0.228063096434434"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="1.17905916371677"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioTBV.xml
+++ b/test/scenarioTBV.xml
@@ -316,33 +316,33 @@
             </weight>
         </human>
         <parameters interval="5" iseed="1" latentp="3">
-            <parameter include="0" name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
-            <parameter include="0" name="Estar    " number="2" value="0.03247"/>
-            <parameter include="1" name="Simm     " number="3" value="0.153741"/>
-            <parameter include="1" name="Xstar_p  " number="4" value="1609.836243"/>
-            <parameter include="1" name="gamma_p  " number="5" value="1.650241"/>
-            <parameter include="1" name="sigma2i  " number="6" value="1.082696"/>
-            <parameter include="1" name="CumulativeYstar  " number="7" value="1865464.660703"/>
-            <parameter include="1" name="CumulativeHstar  " number="8" value="1765.283962"/>
-            <parameter include="1" name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
-            <parameter include="1" name="decay_m  " number="10" value="1.526271"/>
-            <parameter include="1" name="Ystar2   " number="13" value="4259.530005"/>
-            <parameter include="1" name="alpha    " number="14" value="553373.45094"/>
-            <parameter include="1" name="Density bias (non Garki)" number="15" value="0.510558"/>
-            <parameter include="0" name="No Use 1" number="16" value="0.05"/>
-            <parameter include="1" name="log oddsr CF community   " number="17" value="0.548263"/>
-            <parameter include="1" name="Indirect risk cofactor   " number="18" value="0.007721"/>
-            <parameter include="1" name="Non-malaria infant mortality     " number="19" value="47.967295"/>
-            <parameter include="1" name="Density bias (Garki)     " number="20" value="2.601878"/>
-            <parameter include="1" name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
-            <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
-            <parameter include="0" name=" Immune effector decay " number="23" value="0"/>
-            <parameter include="1" name="comorbidity intercept    " number="24" value="0.011939"/>
-            <parameter include="1" name="Ystar half life  " number="25" value="0.401293"/>
-            <parameter include="1" name="Ystar1   " number="26" value="0.796334"/>
-            <parameter include="0" name=" Asex immune decay " number="27" value="0"/>
-            <parameter include="1" name="Ystar0   " number="28" value="28.120561"/>
-            <parameter include="1" name="critical age for comorbidity     " number="30" value="0.151984"/>
+            <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
+            <parameter name="Estar    " number="2" value="0.03247"/>
+            <parameter name="Simm     " number="3" value="0.153741"/>
+            <parameter name="Xstar_p  " number="4" value="1609.836243"/>
+            <parameter name="gamma_p  " number="5" value="1.650241"/>
+            <parameter name="sigma2i  " number="6" value="1.082696"/>
+            <parameter name="CumulativeYstar  " number="7" value="1865464.660703"/>
+            <parameter name="CumulativeHstar  " number="8" value="1765.283962"/>
+            <parameter name="'-ln(1-alpha_m)'" number="9" value="2.702352"/>
+            <parameter name="decay_m  " number="10" value="1.526271"/>
+            <parameter name="Ystar2   " number="13" value="4259.530005"/>
+            <parameter name="alpha    " number="14" value="553373.45094"/>
+            <parameter name="Density bias (non Garki)" number="15" value="0.510558"/>
+            <parameter name="No Use 1" number="16" value="0.05"/>
+            <parameter name="log oddsr CF community   " number="17" value="0.548263"/>
+            <parameter name="Indirect risk cofactor   " number="18" value="0.007721"/>
+            <parameter name="Non-malaria infant mortality     " number="19" value="47.967295"/>
+            <parameter name="Density bias (Garki)     " number="20" value="2.601878"/>
+            <parameter name="Severe Malaria Threshhold        " number="21" value="3411970.636451"/>
+            <parameter name="Immunity Penalty" number="22" value="1"/>
+            <parameter name=" Immune effector decay " number="23" value="0"/>
+            <parameter name="comorbidity intercept    " number="24" value="0.011939"/>
+            <parameter name="Ystar half life  " number="25" value="0.401293"/>
+            <parameter name="Ystar1   " number="26" value="0.796334"/>
+            <parameter name=" Asex immune decay " number="27" value="0"/>
+            <parameter name="Ystar0   " number="28" value="28.120561"/>
+            <parameter name="critical age for comorbidity     " number="30" value="0.151984"/>
         </parameters>
     </model>
 </om:scenario>

--- a/test/scenarioTrapTest.xml
+++ b/test/scenarioTrapTest.xml
@@ -265,36 +265,36 @@ For simulating Rusinga
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="15d">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioTriggeredMSAT.xml
+++ b/test/scenarioTriggeredMSAT.xml
@@ -554,36 +554,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="0" latentp="15d">
-      <parameter include="false" name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
-      <parameter include="false" name="        Estar   " number="2" value="0.03247"/>
-      <parameter include="false" name="        Simm    " number="3" value="0.1447"/>
-      <parameter include="false" name="        Xstar_p " number="4" value="2801.485664"/>
-      <parameter include="false" name="        gamma_p " number="5" value="2.061137"/>
-      <parameter include="false" name="        sigma2i " number="6" value="9.569774"/>
-      <parameter include="false" name="        CumulativeYstar " number="7" value="137595256.939881"/>
-      <parameter include="false" name="        CumulativeHstar " number="8" value="97.798358"/>
-      <parameter include="false" name="        '-ln(1-alpha_m)'        " number="9" value="2.306627"/>
-      <parameter include="false" name="        decay_m " number="10" value="2.587184"/>
-      <parameter include="false" name="        sigma2_0        " number="11" value="0.656515"/>
-      <parameter include="false" name="        Xstar_v " number="12" value="0.918108"/>
-      <parameter include="false" name="        Ystar2  " number="13" value="9696.340451"/>
-      <parameter include="false" name="        alpha   " number="14" value="157086.100088"/>
-      <parameter include="false" name="        Density bias (non Garki)        " number="15" value="0.172355"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="        log oddsr CF community  " number="17" value="0.729208"/>
-      <parameter include="false" name="        Indirect risk cofactor  " number="18" value="0.017543"/>
-      <parameter include="false" name="        Non-malaria infant mortality    " number="19" value="50.648162"/>
-      <parameter include="false" name="        Density bias (Garki)    " number="20" value="4.784096"/>
-      <parameter include="false" name="        Severe Malaria Threshhold       " number="21" value="346545.408899"/>
-      <parameter include="false" name="        Immunity Penalty        " number="22" value="1"/>
-      <parameter include="false" name="        Immune effector decay     " number="23" value="0"/>
-      <parameter include="false" name="        comorbidity intercept   " number="24" value="0.098975"/>
-      <parameter include="false" name="        Ystar half life " number="25" value="0.278909"/>
-      <parameter include="false" name="        Ystar1  " number="26" value="0.600517"/>
-      <parameter include="false" name="        asex immune decay      " number="27" value="0"/>
-      <parameter include="false" name="        Ystar0  " number="28" value="328.056605"/>
-      <parameter include="false" name="        Idete multiplier        " number="29" value="2.78614"/>
-      <parameter include="false" name="        critical age for comorbidity    " number="30" value="0.115906"/>
+      <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
+      <parameter name="        Estar   " number="2" value="0.03247"/>
+      <parameter name="        Simm    " number="3" value="0.1447"/>
+      <parameter name="        Xstar_p " number="4" value="2801.485664"/>
+      <parameter name="        gamma_p " number="5" value="2.061137"/>
+      <parameter name="        sigma2i " number="6" value="9.569774"/>
+      <parameter name="        CumulativeYstar " number="7" value="137595256.939881"/>
+      <parameter name="        CumulativeHstar " number="8" value="97.798358"/>
+      <parameter name="        '-ln(1-alpha_m)'        " number="9" value="2.306627"/>
+      <parameter name="        decay_m " number="10" value="2.587184"/>
+      <parameter name="        sigma2_0        " number="11" value="0.656515"/>
+      <parameter name="        Xstar_v " number="12" value="0.918108"/>
+      <parameter name="        Ystar2  " number="13" value="9696.340451"/>
+      <parameter name="        alpha   " number="14" value="157086.100088"/>
+      <parameter name="        Density bias (non Garki)        " number="15" value="0.172355"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="        log oddsr CF community  " number="17" value="0.729208"/>
+      <parameter name="        Indirect risk cofactor  " number="18" value="0.017543"/>
+      <parameter name="        Non-malaria infant mortality    " number="19" value="50.648162"/>
+      <parameter name="        Density bias (Garki)    " number="20" value="4.784096"/>
+      <parameter name="        Severe Malaria Threshhold       " number="21" value="346545.408899"/>
+      <parameter name="        Immunity Penalty        " number="22" value="1"/>
+      <parameter name="        Immune effector decay     " number="23" value="0"/>
+      <parameter name="        comorbidity intercept   " number="24" value="0.098975"/>
+      <parameter name="        Ystar half life " number="25" value="0.278909"/>
+      <parameter name="        Ystar1  " number="26" value="0.600517"/>
+      <parameter name="        asex immune decay      " number="27" value="0"/>
+      <parameter name="        Ystar0  " number="28" value="328.056605"/>
+      <parameter name="        Idete multiplier        " number="29" value="2.78614"/>
+      <parameter name="        critical age for comorbidity    " number="30" value="0.115906"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioVecFullTest.xml
+++ b/test/scenarioVecFullTest.xml
@@ -479,36 +479,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.385853233699891"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.173598698525799"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001039"/>
-      <parameter include="false" name="alpha" number="14" value="142601.912520000012591"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.302437899999973"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+      <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+      <parameter name="alpha" number="14" value="142601.912520000012591"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioVecMonthly.xml
+++ b/test/scenarioVecMonthly.xml
@@ -253,36 +253,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioVecTest.xml
+++ b/test/scenarioVecTest.xml
@@ -186,36 +186,36 @@
       </availabilityToMosquitoes>
     </human>
     <parameters interval="5" iseed="1" latentp="3">
-      <parameter include="false" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-      <parameter include="false" name="Estar" number="2" value="0.03247"/>
-      <parameter include="false" name="Simm" number="3" value="0.138161050830301"/>
-      <parameter include="false" name="Xstar_p" number="4" value="1514.3858532337"/>
-      <parameter include="false" name="gamma_p" number="5" value="2.03692533424484"/>
-      <parameter include="false" name="sigma2i" number="6" value="10.1735986985258"/>
-      <parameter include="false" name="CumulativeYstar" number="7" value="35158523.3113251"/>
-      <parameter include="false" name="CumulativeHstar" number="8" value="97.3346527238977"/>
-      <parameter include="false" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-      <parameter include="false" name="decay_m" number="10" value="2.53106547375805"/>
-      <parameter include="false" name="sigma2_0" number="11" value="0.655747311168152"/>
-      <parameter include="false" name="Xstar_v" number="12" value="0.916181104713054"/>
-      <parameter include="false" name="Ystar2" number="13" value="6502.26335600001"/>
-      <parameter include="false" name="alpha" number="14" value="142601.91252"/>
-      <parameter include="false" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-      <parameter include="false" name="        sigma2        " number="16" value="0.05"/>
-      <parameter include="false" name="log oddsr CF community" number="17" value="0.736202"/>
-      <parameter include="false" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-      <parameter include="false" name="Non-malaria infant mortality" number="19" value="49.5390466"/>
-      <parameter include="false" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-      <parameter include="false" name="Severe Malaria Threshhold" number="21" value="784455.6"/>
-      <parameter include="false" name="Immunity Penalty" number="22" value="1"/>
-      <parameter include="false" name="Immune effector decay" number="23" value="0"/>
-      <parameter include="false" name="comorbidity intercept" number="24" value="0.0968"/>
-      <parameter include="false" name="Ystar half life" number="25" value="0.275437402"/>
-      <parameter include="false" name="Ystar1" number="26" value="0.596539864"/>
-      <parameter include="false" name="Asexual immunity decay" number="27" value="0"/>
-      <parameter include="false" name="Ystar0" number="28" value="296.3024379"/>
-      <parameter include="false" name="Idete multiplier" number="29" value="2.797523626"/>
-      <parameter include="false" name="critical age for comorbidity" number="30" value="0.117383"/>
+      <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+      <parameter name="Estar" number="2" value="0.03247"/>
+      <parameter name="Simm" number="3" value="0.138161050830301"/>
+      <parameter name="Xstar_p" number="4" value="1514.3858532337"/>
+      <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+      <parameter name="sigma2i" number="6" value="10.1735986985258"/>
+      <parameter name="CumulativeYstar" number="7" value="35158523.3113251"/>
+      <parameter name="CumulativeHstar" number="8" value="97.3346527238977"/>
+      <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+      <parameter name="decay_m" number="10" value="2.53106547375805"/>
+      <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+      <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+      <parameter name="Ystar2" number="13" value="6502.26335600001"/>
+      <parameter name="alpha" number="14" value="142601.91252"/>
+      <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+      <parameter name="        sigma2        " number="16" value="0.05"/>
+      <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+      <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+      <parameter name="Non-malaria infant mortality" number="19" value="49.5390466"/>
+      <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+      <parameter name="Severe Malaria Threshhold" number="21" value="784455.6"/>
+      <parameter name="Immunity Penalty" number="22" value="1"/>
+      <parameter name="Immune effector decay" number="23" value="0"/>
+      <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+      <parameter name="Ystar half life" number="25" value="0.275437402"/>
+      <parameter name="Ystar1" number="26" value="0.596539864"/>
+      <parameter name="Asexual immunity decay" number="27" value="0"/>
+      <parameter name="Ystar0" number="28" value="296.3024379"/>
+      <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+      <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
     </parameters>
   </model>
 </om:scenario>

--- a/test/scenarioVivax.xml
+++ b/test/scenarioVivax.xml
@@ -548,15 +548,15 @@
     </vivax> 
      <parameters interval="5" iseed="0" latentp="10d"> 
       <!-- base --> 
-      <parameter include="false" name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/> 
-      <parameter include="false" name="        Estar   " number="2" value="0.03247"/> 
-      <parameter include="false" name="        Simm    " number="3" value="0.138161050830301"/> 
-      <parameter include="false" name="        Xstar_p " number="4" value="1514.385853233699891"/> 
-      <parameter include="false" name="        gamma_p " number="5" value="2.03692533424484"/> 
-      <parameter include="false" name="        sigma2i " number="16" value="0.3"/> 
+      <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/> 
+      <parameter name="        Estar   " number="2" value="0.03247"/> 
+      <parameter name="        Simm    " number="3" value="0.138161050830301"/> 
+      <parameter name="        Xstar_p " number="4" value="1514.385853233699891"/> 
+      <parameter name="        gamma_p " number="5" value="2.03692533424484"/> 
+      <parameter name="        sigma2i " number="16" value="0.3"/> 
       <!-- log odds 0 implies community CFR equals hospital CFR --> 
-      <parameter include="false" name="        log oddsr CF community  " number="17" value="0"/> 
-      <parameter include="false" name="        Non-malaria infant mortality    " number="19" value="49.539046599999999"/> 
+      <parameter name="        log oddsr CF community  " number="17" value="0"/> 
+      <parameter name="        Non-malaria infant mortality    " number="19" value="49.539046599999999"/> 
     </parameters> 
   </model> 
 </om:scenario>

--- a/util/example/example_scenario.xml
+++ b/util/example/example_scenario.xml
@@ -309,36 +309,36 @@
 
         <!-- DO NOT CHANGE THE MODEL PARAMETERS BELOW -->
         <parameters interval="5" iseed="1" latentp="15d">
-           <parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
-           <parameter include="0" name="Estar" number="2" value="0.03247"/>
-           <parameter include="0" name="Simm" number="3" value="0.138161050830301"/>
-           <parameter include="0" name="Xstar_p" number="4" value="1514.385853233699891"/>
-           <parameter include="0" name="gamma_p" number="5" value="2.03692533424484"/>
-           <parameter include="0" name="sigma2i" number="6" value="10.173598698525799"/>
-           <parameter include="0" name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
-           <parameter include="0" name="CumulativeHstar" number="8" value="97.334652723897705"/>
-           <parameter include="0" name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
-           <parameter include="0" name="decay_m" number="10" value="2.53106547375805"/>
-           <parameter include="0" name="sigma2_0" number="11" value="0.655747311168152"/>
-           <parameter include="0" name="Xstar_v" number="12" value="0.916181104713054"/>
-           <parameter include="0" name="Ystar2" number="13" value="6502.26335600001039"/>
-           <parameter include="0" name="alpha" number="14" value="142601.912520000012591"/>
-           <parameter include="0" name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
-           <parameter include="0" name=" sigma2 " number="16" value="1.0"/>
-           <parameter include="0" name="log oddsr CF community" number="17" value="0.736202"/>
-           <parameter include="0" name="Indirect risk cofactor" number="18" value="0.018777338"/>
-           <parameter include="0" name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
-           <parameter include="0" name="Density bias (Garki)" number="20" value="4.79610772546704"/>
-           <parameter include="0" name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
-           <parameter include="0" name="Immunity Penalty" number="22" value="1"/>
-           <parameter include="0" name="Immune effector decay" number="23" value="0"/>
-           <parameter include="0" name="comorbidity intercept" number="24" value="0.0968"/>
-           <parameter include="0" name="Ystar half life" number="25" value="0.275437402"/>
-           <parameter include="0" name="Ystar1" number="26" value="0.596539864"/>
-           <parameter include="0" name="Asexual immunity decay" number="27" value="0"/>
-           <parameter include="0" name="Ystar0" number="28" value="296.302437899999973"/>
-           <parameter include="0" name="Idete multiplier" number="29" value="2.797523626"/>
-           <parameter include="0" name="critical age for comorbidity" number="30" value="0.117383"/>
+           <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
+           <parameter name="Estar" number="2" value="0.03247"/>
+           <parameter name="Simm" number="3" value="0.138161050830301"/>
+           <parameter name="Xstar_p" number="4" value="1514.385853233699891"/>
+           <parameter name="gamma_p" number="5" value="2.03692533424484"/>
+           <parameter name="sigma2i" number="6" value="10.173598698525799"/>
+           <parameter name="CumulativeYstar" number="7" value="35158523.31132510304451"/>
+           <parameter name="CumulativeHstar" number="8" value="97.334652723897705"/>
+           <parameter name="'-ln(1-alpha_m)'" number="9" value="2.33031045876193"/>
+           <parameter name="decay_m" number="10" value="2.53106547375805"/>
+           <parameter name="sigma2_0" number="11" value="0.655747311168152"/>
+           <parameter name="Xstar_v" number="12" value="0.916181104713054"/>
+           <parameter name="Ystar2" number="13" value="6502.26335600001039"/>
+           <parameter name="alpha" number="14" value="142601.912520000012591"/>
+           <parameter name="Density bias (non Garki)" number="15" value="0.177378570987455"/>
+           <parameter name=" sigma2 " number="16" value="1.0"/>
+           <parameter name="log oddsr CF community" number="17" value="0.736202"/>
+           <parameter name="Indirect risk cofactor" number="18" value="0.018777338"/>
+           <parameter name="Non-malaria infant mortality" number="19" value="49.539046599999999"/>
+           <parameter name="Density bias (Garki)" number="20" value="4.79610772546704"/>
+           <parameter name="Severe Malaria Threshhold" number="21" value="784455.599999999976717"/>
+           <parameter name="Immunity Penalty" number="22" value="1"/>
+           <parameter name="Immune effector decay" number="23" value="0"/>
+           <parameter name="comorbidity intercept" number="24" value="0.0968"/>
+           <parameter name="Ystar half life" number="25" value="0.275437402"/>
+           <parameter name="Ystar1" number="26" value="0.596539864"/>
+           <parameter name="Asexual immunity decay" number="27" value="0"/>
+           <parameter name="Ystar0" number="28" value="296.302437899999973"/>
+           <parameter name="Idete multiplier" number="29" value="2.797523626"/>
+           <parameter name="critical age for comorbidity" number="30" value="0.117383"/>
        </parameters>
    </model>
 </om:scenario>


### PR DESCRIPTION
# Problem

Some minor cleanup is needed where model parameters are defined in OpenMalaria's input XML file.

The `include` attribute on `<parameter>` elements is not used by the simulation at all.

The attribute is a relic from when OpenMalaria used to run on a volunteer computing platform, which has not been a supported platform since https://github.com/SwissTPH/openmalaria/pull/236 .

# Solution

1. Removed the `include` attribute from the example scenario XML file.
2. Removed the `include` attribute from the XML schema.
3. Removed the `include` attribute from nearly all the XML files used by tests.
   -  To do this I ran `sed -i -E 's/include=\"(0|1|false|true)\" //' *.xml` then manually inspected all the results by eye.

I did not edit `unittest/scenario.xml`, which has not been touched in 16 years and appears to be using an old schema version anyway.

It is worth noting this PR will make it so that users have to remove all attribute specifications like the following from all of the `<parameter>` elements in any existing XML files they wish to use with newer OpenMalaria versions.

`include="0"`,
`include="1"`,
`include="false"`
`include="true"`

For example, `<parameter include="0" name="'-ln(1-Sinf)'" number="1" value="0.050736"/>` would have to be changed to `<parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>`.

The error message a user will see if any `include` attributes remain present in in their input XML file is shown below.  The error message is imperfect since a user may interpret "not declared" as meaning that there is some necessary thing missing from their `parameter` element.  But I think the message is acceptable.

```
XSD error: instance document parsing failed
:341:101 error: attribute 'include' is not declared for element 'parameter'
```

(line number/character number will vary)

# Testing

I ran the tests, which all pass now that all `include` attributes have been removed from the XML files they use.

After I made the schema change, but before I changed the XML files used by tests, nearly all the tests failed.  This shows the `include` attribute will not be permitted in the next version of OpenMalaria.

While I determined from inspecting the codebase that the `include` attribute is not used, I ran some scenarios to confirm this out of caution.

I ran:

- one scenario with `include="0"` on all `<parameter>` elements,
- one scenario with `include="1"` on all `<parameter>` elements, and
- one scenario with no `include` attribute specified on any `<parameter>` elements.

All three scenarios resulted in identical output files, which confirms the attribute is unused.