### PR TITLE
add detection of possible duplicate OutId

### DIFF
--- a/model/mon/OutputMeasures.h
+++ b/model/mon/OutputMeasures.h
@@ -127,10 +127,10 @@ void findNamedMeasuresUsing( Measure m, ostream& msg ){
 // outputs), type of output (integer or floating point), aggregation, and the
 // corresponding internal measure code.
 void defineOutMeasures(){
-    //NOTE: measures are ordered by their output codes.
-    // Add new outputs with next available code at end of list.
-    // Don't reuse old codes.
-    
+    /* Don't ever make an existing numerical identifier point to a new/different 
+    output measure because this would violate users' expectations */
+    // Don't reuse old numerical identifiers
+
     /// Total number of humans
     namedOutMeasures["nHost"] = OutMeasure::humanAC( 0, MHR_HOSTS, false );
     /** The number of human hosts with an infection (patent or not) at the time

--- a/model/mon/OutputMeasures.h
+++ b/model/mon/OutputMeasures.h
@@ -483,6 +483,14 @@ void defineOutMeasures(){
     namedOutMeasures["expectedSevereWithoutComorbidities"] =
         OutMeasure::humanAC( 82, MHF_EXPECTED_SEVERE_WITHOUT_COMORBIDITIES, true );
 
+    // Check for duplicate outId
+    std::set<int> seenIDs;
+    for (const auto& pair : namedOutMeasures) {
+        int id = pair.second.outId;
+        if (!seenIDs.insert(id).second)
+            throw std::runtime_error("Duplicate OutMeasure (outId) detected: " + std::to_string(id));
+    }
+
     // Now initialise valid condition measures:
     for( const NamedMeasureMapT::value_type& v : namedOutMeasures ){
         Measure m = v.second.m;


### PR DESCRIPTION
Follow up on: https://github.com/SwissTPH/openmalaria/pull/414#discussion_r2096872718

This will throw an error at runtime if duplicates exist.

This only affects developers but this will help avoid having duplicate outIds by mistake.

It would be better to have a detection at compile time, and while I'm sure it's possible with some clever templates, I'm not sure it's needed. The current code will throw an error and fail all the tests as expected, even if the outputMeasures are not used.