### PR TITLE
Add a default time step duration to the base model

### DIFF
--- a/model/main.cpp
+++ b/model/main.cpp
@@ -149,22 +149,22 @@ int main(int argc, char* argv[])
 
         util::XMLChecker().PerformPostValidationChecks(*scenario);
 
-        sim::init(*scenario); // also reads survey dates
-
         // 1) elements with no dependencies on other elements initialised here:
-        util::ModelNameProvider modelNameProvider(scenario->getModel());
         WithinHost::Genotypes::init( *scenario );
-
         util::master_RNG.seed( scenario->getModel().getComputationParameters().getIseed(), 0 ); // Init RNG with Iseed
+        util::ModelNameProvider modelNameProvider(scenario->getModel());
 
         // 2) elements depending on only elements initialised in (1):
+        sim::init(*scenario, modelNameProvider); // Also reads survey dates.
+
+        // 3) elements depending on only elements initialised in (2).
         Parameters parameters( scenario->getModel().getParameters(), modelNameProvider ); // Depends on ModelNameProvider.
         util::ModelOptions::init( scenario->getModel().getModelOptions(), modelNameProvider ); // Depends on ModelNameProvider.
-        
-        // 3) elements depending on only elements initialised in (2).
-        WithinHost::diagnostics::init( parameters, *scenario ); // Depends on Parameters.
 
         // 4) elements depending on only elements initialised in (3).
+        WithinHost::diagnostics::init( parameters, *scenario ); // Depends on Parameters.
+
+        // 5) elements depending on only elements initialised in (4).
         mon::initReporting( *scenario ); // Reporting init depends on diagnostics and monitoring
 
         // Init models used by humans

--- a/model/sim.cpp
+++ b/model/sim.cpp
@@ -81,7 +81,7 @@ void sim::initInterval(const scnXml::Scenario& scenario, util::ModelNameProvider
     if (parameterBlockExistsInScenario)
     {
         // Schema dictates that interval attribute is required if parameter element exists.
-        // So no need to check for existsence if interval attribute in this case.
+        // So no need to check for existsence of interval attribute in this case.
         SimData::interval = scenario.getModel().getParameters().get().getInterval();
     }
 }

--- a/model/sim.h
+++ b/model/sim.h
@@ -29,6 +29,7 @@
 
 #include "util/mod.h"
 #include "util/checkpoint.h"
+#include "util/ModelNameProvider.h"
 #include <memory>
 
 class UnittestUtil;
@@ -229,7 +230,13 @@ public:
     
 // private:
     // Initial set-up: called by Simulator
-    static void init( const scnXml::Scenario& scenario );
+    static void init( const scnXml::Scenario& scenario, util::ModelNameProvider mnp);
+
+    // Sets up time step duration.
+    // Assumes that the scenario either:
+    // (1) states to use a named model which has some value for interval, or
+    // (2) includes a <parameters> element, which sets an interval value.
+    static void initInterval(const scnXml::Scenario& scenario, util::ModelNameProvider mnp);
     
     // Start of update: called by Simulator
     static inline void start_update(){

--- a/schema/scenario.xsd
+++ b/schema/scenario.xsd
@@ -202,12 +202,6 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     </xs:attribute>
   </xs:complexType>
   <xs:complexType name="ComputationParameters">
-    <xs:attribute name="interval" type="xs:int" use="required">
-      <xs:annotation>
-        <xs:documentation>Simulation step</xs:documentation>
-        <xs:appinfo>units:Days;name:Simulation step;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="iseed" type="xs:int" use="required">
       <xs:annotation>
         <xs:documentation>Seed for RNG</xs:documentation>
@@ -219,6 +213,12 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
     <xs:sequence>
       <xs:element maxOccurs="unbounded" name="parameter" type="om:Parameter" />
     </xs:sequence>
+    <xs:attribute name="interval" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation>Simulation step</xs:documentation>
+        <xs:appinfo>units:Days;name:Simulation step;</xs:appinfo>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="latentp" type="xs:string" use="required">
       <xs:annotation>
         <xs:documentation>

--- a/test/scenario1.xml
+++ b/test/scenario1.xml
@@ -1101,8 +1101,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenario10.xml
+++ b/test/scenario10.xml
@@ -1007,8 +1007,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="         '-ln(1-Sinf)'    " number="1" value="0.050736"/>
       <parameter name="         Estar    " number="2" value="0.03247"/>
       <parameter name="         Simm     " number="3" value="0.157325"/>

--- a/test/scenario11.xml
+++ b/test/scenario11.xml
@@ -637,8 +637,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="10"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="10"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.1447"/>

--- a/test/scenario12.xml
+++ b/test/scenario12.xml
@@ -1234,8 +1234,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenario12a.xml
+++ b/test/scenario12a.xml
@@ -1240,8 +1240,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenario2ITNs.xml
+++ b/test/scenario2ITNs.xml
@@ -316,8 +316,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="2"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="2"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenario4.xml
+++ b/test/scenario4.xml
@@ -1071,8 +1071,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenario5.xml
+++ b/test/scenario5.xml
@@ -562,8 +562,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
       <parameter name="        Estar   " number="2" value="0.03247"/>
       <parameter name="        Simm    " number="3" value="0.1447"/>

--- a/test/scenario6.xml
+++ b/test/scenario6.xml
@@ -562,8 +562,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
       <parameter name="        Estar   " number="2" value="0.03247"/>
       <parameter name="        Simm    " number="3" value="0.1447"/>

--- a/test/scenario9.xml
+++ b/test/scenario9.xml
@@ -1006,8 +1006,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="         '-ln(1-Sinf)'    " number="1" value="0.050736"/>
       <parameter name="         Estar    " number="2" value="0.03247"/>
       <parameter name="         Simm     " number="3" value="0.157325"/>

--- a/test/scenarioAvailabilityHeterogeneity.xml
+++ b/test/scenarioAvailabilityHeterogeneity.xml
@@ -309,8 +309,8 @@
         </human>
 
         <!-- DO NOT CHANGE THE MODEL PARAMETERS BELOW -->
-        <computationParameters interval="5" iseed="1"/>
-        <parameters latentp="3d">
+        <computationParameters iseed="1"/>
+        <parameters interval="5" latentp="3d">
            <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
            <parameter name="Estar" number="2" value="0.03247"/>
            <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioBSV.xml
+++ b/test/scenarioBSV.xml
@@ -315,8 +315,8 @@
                 <group lowerbound="20.0" value="60.0"/>
             </weight>
         </human>
-        <computationParameters interval="5" iseed="1"/>
-        <parameters latentp="3t">
+        <computationParameters iseed="1"/>
+        <parameters interval="5" latentp="3t">
             <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
             <parameter name="Estar    " number="2" value="0.03247"/>
             <parameter name="Simm     " number="3" value="0.153741"/>

--- a/test/scenarioCohort.xml
+++ b/test/scenarioCohort.xml
@@ -1291,8 +1291,8 @@
         <group lowerbound="20.0" value="60.0"/>
       </weight>
     </human>
-    <computationParameters interval="1" iseed="1"/>
-    <parameters latentp="15t">
+    <computationParameters iseed="1"/>
+    <parameters interval="1" latentp="15t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioDecisionTree5DayDielmo.xml
+++ b/test/scenarioDecisionTree5DayDielmo.xml
@@ -240,8 +240,8 @@
                 make parameter continually increase and the "adult age" will be wrong. -->
               </availabilityToMosquitoes>
             </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioESTS.xml
+++ b/test/scenarioESTS.xml
@@ -1510,8 +1510,8 @@
         <group lowerbound="20.0" value="60.0"/>
       </weight>
     </human>
-    <computationParameters interval="1" iseed="0"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="0"/>
+    <parameters interval="1" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.267285"/>

--- a/test/scenarioEffectiveDrug.xml
+++ b/test/scenarioEffectiveDrug.xml
@@ -1078,8 +1078,8 @@
         <group lowerbound="20.0" value="60.0"/>
       </weight>
     </human>
-    <computationParameters interval="1" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="1" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioEmpirical.xml
+++ b/test/scenarioEmpirical.xml
@@ -1215,8 +1215,8 @@
         <group lowerbound="20.0" value="60.0"/>
       </weight>
     </human>
-    <computationParameters interval="1" iseed="1"/>
-    <parameters latentp="0t">
+    <computationParameters iseed="1"/>
+    <parameters interval="1" latentp="0t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0507360000000001"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioGenotypes.xml
+++ b/test/scenarioGenotypes.xml
@@ -320,8 +320,8 @@
       </weight>
     </human>
     <!-- run id=898 parameterization id=265074 sampling date=2011-02-23 00:09:18 lossfunction=68.507534 -->
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.198704"/>

--- a/test/scenarioHetVecDailyEIR.xml
+++ b/test/scenarioHetVecDailyEIR.xml
@@ -525,8 +525,8 @@
         make parameter continually increase and the "adult age" will be wrong. -->
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioIRS30.xml
+++ b/test/scenarioIRS30.xml
@@ -277,8 +277,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="2"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="2"/>
+    <parameters interval="5" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioInfectionOrigin.xml
+++ b/test/scenarioInfectionOrigin.xml
@@ -240,8 +240,8 @@
         </human>
 
         <!-- DO NOT CHANGE THE MODEL PARAMETERS BELOW -->
-        <computationParameters interval="5" iseed="1"/>
-        <parameters latentp="15d">
+        <computationParameters iseed="1"/>
+        <parameters interval="5" latentp="15d">
            <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
            <parameter name="Estar" number="2" value="0.03247"/>
            <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioKK_20150612.xml
+++ b/test/scenarioKK_20150612.xml
@@ -408,8 +408,8 @@
     </human>
     <!-- parameters: created_time: 2015-05-14 01:15:37, lossfunction (residual sum of squares): 102.422953 (log-likelyhood): 114.261551 run_id: 4301
      -->
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
       <parameter name="Estar    " number="2" value="0.03247"/>
       <parameter name="Simm     " number="3" value="0.153741"/>

--- a/test/scenarioLifeNet1.xml
+++ b/test/scenarioLifeNet1.xml
@@ -283,8 +283,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="11"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="11"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioLifeNet2.xml
+++ b/test/scenarioLifeNet2.xml
@@ -284,8 +284,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="11"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="11"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioMSAT.xml
+++ b/test/scenarioMSAT.xml
@@ -617,8 +617,8 @@
         <group lowerbound="20.0" value="60.0"/>
       </weight>
     </human>
-    <computationParameters interval="1" iseed="1"/>
-    <parameters latentp="15t">
+    <computationParameters iseed="1"/>
+    <parameters interval="1" latentp="15t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.267285"/>

--- a/test/scenarioMSAT_HRP2.xml
+++ b/test/scenarioMSAT_HRP2.xml
@@ -546,8 +546,8 @@
         <group lowerbound="20.0" value="60.0"/>
       </weight>
     </human>
-    <computationParameters interval="1" iseed="1"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="1"/>
+    <parameters interval="1" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.267285"/>

--- a/test/scenarioModelNameManyOverrides.xml
+++ b/test/scenarioModelNameManyOverrides.xml
@@ -306,8 +306,8 @@
             </availabilityToMosquitoes>
         </human>
 
-        <computationParameters interval="5" iseed="1"/>
-        <parameters latentp="15d">
+        <computationParameters iseed="1"/>
+        <parameters interval="5" latentp="15d">
            <parameter name="decay_m" number="10" value="2.55"/>
        </parameters>
    </model>

--- a/test/scenarioModelNameModelOptionOverrides.xml
+++ b/test/scenarioModelNameModelOptionOverrides.xml
@@ -306,6 +306,6 @@
             </availabilityToMosquitoes>
         </human>
 
-        <computationParameters interval="5" iseed="1"/>
+        <computationParameters iseed="1"/>
    </model>
 </om:scenario>

--- a/test/scenarioModelNameNoOverrides.xml
+++ b/test/scenarioModelNameNoOverrides.xml
@@ -303,6 +303,6 @@
             </availabilityToMosquitoes>
         </human>
 
-        <computationParameters interval="5" iseed="1"/>
+        <computationParameters iseed="1"/>
    </model>
 </om:scenario>

--- a/test/scenarioModelNameParamOverrides.xml
+++ b/test/scenarioModelNameParamOverrides.xml
@@ -303,8 +303,8 @@
             </availabilityToMosquitoes>
         </human>
 
-        <computationParameters interval="5" iseed="1"/>
-        <parameters latentp="15d">
+        <computationParameters iseed="1"/>
+        <parameters interval="5" latentp="15d">
            <parameter name="decay_m" number="10" value="2.7"/>
        </parameters>
    </model>

--- a/test/scenarioMolPairwise.xml
+++ b/test/scenarioMolPairwise.xml
@@ -564,8 +564,8 @@
       </weight>
     </human>
     <!-- run id=898 parameterization id=265074 sampling date=2011-02-23 00:09:18 lossfunction=68.507534 -->
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.198704"/>

--- a/test/scenarioMolineaux.xml
+++ b/test/scenarioMolineaux.xml
@@ -1057,8 +1057,8 @@
       </weight>
     </human>
     <!-- run id=898 parameterization id=265074 sampling date=2011-02-23 00:09:18 lossfunction=68.507534 -->
-    <computationParameters interval="1" iseed="0"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="0"/>
+    <parameters interval="1" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.198704"/>

--- a/test/scenarioNamawalaArabiensis.xml
+++ b/test/scenarioNamawalaArabiensis.xml
@@ -177,8 +177,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioNoInterv.xml
+++ b/test/scenarioNoInterv.xml
@@ -232,8 +232,8 @@
         <group lowerbound="5" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioNoMPDLarviciding.xml
+++ b/test/scenarioNoMPDLarviciding.xml
@@ -307,8 +307,8 @@
         <group lowerbound="5" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioNonHumanHosts.xml
+++ b/test/scenarioNonHumanHosts.xml
@@ -416,8 +416,8 @@
                 <group lowerbound="20.0" value="1.0"/>
             </availabilityToMosquitoes>
         </human>
-        <computationParameters interval="5" iseed="2"/>
-        <parameters latentp="3t">
+        <computationParameters iseed="2"/>
+        <parameters interval="5" latentp="3t">
             <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
             <parameter name="Estar" number="2" value="0.03247"/>
             <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioPEV.xml
+++ b/test/scenarioPEV.xml
@@ -315,8 +315,8 @@
                 <group lowerbound="20.0" value="60.0"/>
             </weight>
         </human>
-        <computationParameters interval="5" iseed="1"/>
-        <parameters latentp="3t">
+        <computationParameters iseed="1"/>
+        <parameters interval="5" latentp="3t">
             <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
             <parameter name="Estar    " number="2" value="0.03247"/>
             <parameter name="Simm     " number="3" value="0.153741"/>

--- a/test/scenarioPenny.xml
+++ b/test/scenarioPenny.xml
@@ -1010,8 +1010,8 @@
       </weight>
     </human>
     <!-- run id=1101 parameterization id=220288 sampling date=2011-04-10 13:58:03 lossfunction=4699975.42996 -->
-    <computationParameters interval="1" iseed="0"/>
-    <parameters latentp="15t">
+    <computationParameters iseed="0"/>
+    <parameters interval="1" latentp="15t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.184877"/>

--- a/test/scenarioRach5IC.xml
+++ b/test/scenarioRach5IC.xml
@@ -286,8 +286,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="2"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="2"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioSimpleMPDLarviciding.xml
+++ b/test/scenarioSimpleMPDLarviciding.xml
@@ -303,8 +303,8 @@
         <group lowerbound="5" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioSimpleMPDTest.xml
+++ b/test/scenarioSimpleMPDTest.xml
@@ -205,8 +205,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioSubPopRemoval.xml
+++ b/test/scenarioSubPopRemoval.xml
@@ -173,8 +173,8 @@
         <group lowerbound="90.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="61321"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="61321"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.0502"/>
       <parameter name="Estar" number="2" value="0.032"/>
       <parameter name="Simm" number="3" value="0.0809506710366894"/>

--- a/test/scenarioTBV.xml
+++ b/test/scenarioTBV.xml
@@ -315,8 +315,8 @@
                 <group lowerbound="20.0" value="60.0"/>
             </weight>
         </human>
-        <computationParameters interval="5" iseed="1"/>
-        <parameters latentp="3t">
+        <computationParameters iseed="1"/>
+        <parameters interval="5" latentp="3t">
             <parameter name="'-ln(1-Sinf)'    " number="1" value="0.050736"/>
             <parameter name="Estar    " number="2" value="0.03247"/>
             <parameter name="Simm     " number="3" value="0.153741"/>

--- a/test/scenarioTrapTest.xml
+++ b/test/scenarioTrapTest.xml
@@ -264,8 +264,8 @@ For simulating Rusinga
         <group lowerbound="5" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="15d">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioTriggeredMSAT.xml
+++ b/test/scenarioTriggeredMSAT.xml
@@ -553,8 +553,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="0"/>
-    <parameters latentp="15d">
+    <computationParameters iseed="0"/>
+    <parameters interval="5" latentp="15d">
       <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/>
       <parameter name="        Estar   " number="2" value="0.03247"/>
       <parameter name="        Simm    " number="3" value="0.1447"/>

--- a/test/scenarioVecFullTest.xml
+++ b/test/scenarioVecFullTest.xml
@@ -478,8 +478,8 @@
         <group lowerbound="5" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioVecMonthly.xml
+++ b/test/scenarioVecMonthly.xml
@@ -252,8 +252,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioVecTest.xml
+++ b/test/scenarioVecTest.xml
@@ -185,8 +185,8 @@
         <group lowerbound="20.0" value="1.0"/>
       </availabilityToMosquitoes>
     </human>
-    <computationParameters interval="5" iseed="1"/>
-    <parameters latentp="3t">
+    <computationParameters iseed="1"/>
+    <parameters interval="5" latentp="3t">
       <parameter name="'-ln(1-Sinf)'" number="1" value="0.050736"/>
       <parameter name="Estar" number="2" value="0.03247"/>
       <parameter name="Simm" number="3" value="0.138161050830301"/>

--- a/test/scenarioVivax.xml
+++ b/test/scenarioVivax.xml
@@ -546,8 +546,8 @@
         <vivaxClinOption>A2j</vivaxClinOption> 
       </clinicalEvents> 
     </vivax> 
-     <computationParameters interval="5" iseed="0"/>
-     <parameters latentp="10d"> 
+     <computationParameters iseed="0"/>
+     <parameters interval="5" latentp="10d"> 
       <!-- base --> 
       <parameter name="        '-ln(1-Sinf)'   " number="1" value="0.050736"/> 
       <parameter name="        Estar   " number="2" value="0.03247"/> 

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -236,10 +236,8 @@ namespace dummyXML{
     scnXml::Clinical modelClinical( "dummy" /* HS memory */ );
     scnXml::AgeGroupValues modelHumanAvailMosq;
     scnXml::Human modelHuman( modelHumanAvailMosq );
-    scnXml::ComputationParameters computationParams(
-        0 /* interval */,
-        0 /* iseed */);
-    scnXml::Parameters modelParams("dummy" /* latentP */);
+    scnXml::ComputationParameters computationParams(0 /* iseed */);
+    scnXml::Parameters modelParams(0 /* interval*/, "dummy" /* latentP */);
     scnXml::Model model(modelClinical, modelHuman, computationParams);
     
     scnXml::Scenario scenario(
@@ -257,15 +255,16 @@ class UnittestUtil {
 public:
     static void initTime(int daysPerStep){
         dummyXML::model.setModelOptions(dummyXML::modelOpts);
+        dummyXML::modelParams.setInterval( daysPerStep );
         dummyXML::model.setParameters(dummyXML::modelParams);
-        dummyXML::computationParams.setInterval( daysPerStep );
         dummyXML::model.setComputationParameters(dummyXML::computationParams);
         dummyXML::scenario.setModel(dummyXML::model);
         dummyXML::surveys.setDetectionLimit( numeric_limits<double>::quiet_NaN() );
         dummyXML::surveys.getSurveyTime().push_back( scnXml::SurveyTime ( "1t" ) );
         dummyXML::monitoring.setSurveys( dummyXML::surveys );
         dummyXML::scenario.setMonitoring( dummyXML::monitoring );
-        sim::init( dummyXML::scenario );
+        util::ModelNameProvider modelNameProvider(dummyXML::scenario.getModel());
+        sim::init( dummyXML::scenario, modelNameProvider );
         
         // we could just use zero, but we may spot more errors by using some weird number
         sim::s_t0 = sim::fromYearsN(83.2591);


### PR DESCRIPTION
## Problem

The `interval` value in XML scenarios represents the *number of days per timestep*.

We'd like `interval` to be an attribute that:

- users do not *have to* set manually, in order to use the base model, but
- users *can* set manually *if they need to*.

## Solution

1. In terms of the schema, I moved the `interval` attribute from the `<computationParameters>` element back to the `<parameters>` element.  I did this because #419  made it possible to omit the `<parameters>` element when using the base model, and we can use that functionality to accomplish most of what's needed for the feature in this PR.
2. I added a value for the `interval` (in particular, a default of a **5 day time step**) to the base model.  I did this by modifying the `sim` class, which already manages the `interval` value.  This required:
    - adding a dependency of the `sim` class on the `ModelNameProvider` class, and
    - changing the order we use to initialise things in `main()`.

3. I updated unit test code and black box test inputs to accommodate the above changes.

Note: this PR does not make any changes related to how the `latentp` attribute is treated in the schema or handled in the C++ code.

## Testing

- [x] Existing tests work fine now input scenarios are migrated and unit tests code has been updated (no change was made to outputs of black box tests).

### Manual testing

- [x] Verified that a helpful error message is printed when specifying a model name other than "base".  `Error: Unrecognized model name: base2` (I chose "base2" as an arbitrary example of an invalid model name).
- [x] Confirmed that a user can override base model `interval` value with custom value in parameters block.  I tested this using `scenarioEmpirical.xml`.  That scenario requires `interval` to have a value 1, otherwise OpenMalaria exits and prints "Error: Model option CLINICAL_EVENT_SCHEDULER is only compatible with a 1-day time step.".  I added `<ModelName name="base"/>` to `scenarioEmpirical.xml`, and unlike manually setting `interval="5"`, OpenMalaria did not crash with that error message - instead it ran successfully.  This indicates the mechanism for overriding the base model's `interval` value is working.

## Documentation

I've got a branch of the wiki repo with documentation updates related to this change.

To managed the task of merging the wiki update at the appropriate time, I have an issue https://github.com/SwissTPH/openmalaria/issues/420 .

## Notes

A couple of the scenario files for black box test have a massive diff.  I think this is probably due to a change in line endings.  I can make a more surgical change to those files if desired, to ease burden of reviewing.