### PR TITLE
chore: Remove unnecessary enum.

### DIFF
--- a/model/sim.h
+++ b/model/sim.h
@@ -46,8 +46,6 @@ inline int floorToInt( double x ){
 /// Internal use only
 // Required to avoid use-before-definition
 class SimData {
-    enum { DAYS_IN_YEAR = 365 };
-    
     static inline int interval;        // days per time step
     static inline size_t steps_per_year;
     static inline double years_per_step;
@@ -79,12 +77,12 @@ public:
     ///@brief Simulation constants
     //@{
     /// Number of days in a year; defined as 365 (leap years are not simulated).
-    enum { DAYS_IN_YEAR = 365 };
+    static const int DAYS_IN_YEAR = 365;
     
     ///@brief Conversions to other types/units
     //@{
     /// Convert to years
-    static inline double inYears(SimTime d) { return d * (1.0 / SimData::DAYS_IN_YEAR); }
+    static inline double inYears(SimTime d) { return d * (1.0 / DAYS_IN_YEAR); }
     
     /// Convert to time steps (rounding down)
     static inline int inSteps(SimTime d) { return d / SimData::interval; }
@@ -118,8 +116,8 @@ public:
     /** One day. */
     static inline SimTime oneDay(){ return SimTime(1); }
     
-    /** One year. See SimData::DAYS_IN_YEAR. */
-    static inline SimTime oneYear(){ return SimTime(SimData::DAYS_IN_YEAR); }
+    /** One year. See DAYS_IN_YEAR. */
+    static inline SimTime oneYear(){ return SimTime(DAYS_IN_YEAR); }
     
     /** One time step (currently either one or five days). */
     static inline SimTime oneTS(){ return SimTime(SimData::interval); }
@@ -135,12 +133,12 @@ public:
     
     /** Convert from a whole number of years. */
     static inline SimTime fromYearsI(int years){
-        return SimTime(SimData::DAYS_IN_YEAR * years);
+        return SimTime(DAYS_IN_YEAR * years);
     }
     
     /** Convert from years to nearest time step. */
     static inline SimTime fromYearsN(double years){
-        return roundToTSFromDays(SimData::DAYS_IN_YEAR * years);
+        return roundToTSFromDays(DAYS_IN_YEAR * years);
     }
     
     /** Convert from years, rounding down to the next time step. */


### PR DESCRIPTION
# Problem

At time of writing, OpenMalaria is built against the C++17 standard.

https://github.com/SwissTPH/openmalaria/blob/107f4de5d1639271d3994031ea4fccbcc5a8be59/CMakeLists.txt#L15

I tried to compile OpenMalaria with gcc using C++20 to get a feel for what would be involved in upgrading.

Many warnings resulted because arithmetic operations between floating-point types and enumeration types are deprecated in C++20 (at least w.r.t. gcc)

E.g.

```
warning: arithmetic between floating-point type ‘double’ and enumeration type ‘OM::SimData::<unnamed enum>’ is deprecated [-Wdeprecated-enum-flo
at-conversion]                                                                                                                                                                                 
   88 |     static inline double inYears(SimTime d) { return d * (1.0 / SimData::DAYS_IN_YEAR); }   
```

This PR addresses the source of many of those warnings.

This PR does not:

- address *all* issues relating to building with C++20 (in particular, there appear to be warnings when building unit test with C++20, which are not addressed here, and I've not tested any other compilers we support), or
- actually make the switch to C++20.

## Solution

1. Removed redundant definition of DAYS_IN_YEAR.  (It was defined twice).
2. Made usage sites of DAYS_IN_YEAR use the other, remaining definition instead.
3. Replaced the single-entry enum with a `static const int`.

## Testing

Automated tests still run and pass.