### PR TITLE
refactor: Make Parameters class parse and provide latentp.

### DIFF
--- a/model/Host/WithinHost/WHFalciparum.cpp
+++ b/model/Host/WithinHost/WHFalciparum.cpp
@@ -101,22 +101,7 @@ void WHFalciparum::init( const OM::Parameters& parameters, const scnXml::Model& 
     
     //NOTE: should also call cleanup() on the PathogenesisModel, but it only frees memory which the OS does anyway
     Pathogenesis::PathogenesisModel::init( parameters, model.getClinical(), false );
-    
-    // Default value to use if no <parameters> element is present in XML.
-    SimTime latentP = UnitParse::readShortDuration("15d", UnitParse::DAYS);
-    try
-    {
-        if (model.getParameters().present())
-        {
-            latentP = UnitParse::readShortDuration(
-                model.getParameters().get().getLatentp(), UnitParse::NONE);
-        }
-    }
-    catch( const util::format_error& e )
-    {
-            throw util::xml_scenario_error( string("model/parameters/latentP: ").append(e.message()) );
-    }
-
+    SimTime latentP = parameters.GetLatentP();
     Infection::init( latentP );
 }
 

--- a/model/Host/WithinHost/WHVivax.cpp
+++ b/model/Host/WithinHost/WHVivax.cpp
@@ -84,7 +84,7 @@ private:
 // ———  parameters  ———
 
 // Set from the parameters block, or a default value is assumed.
-SimTime latentP = sim::never();       // attribute on <parameters> element.
+SimTime latentP = sim::never();
 
 // Set from <vivax .../> element:
 double probBloodStageInfectiousToMosq = numeric_limits<double>::signaling_NaN();
@@ -581,21 +581,7 @@ double WHVivax::getCumulative_h() const{ throw TRACED_EXCEPTION( not_impl, util:
 double WHVivax::getCumulative_Y() const{ throw TRACED_EXCEPTION( not_impl, util::Error::WHFeatures ); }
 
 void WHVivax::init( const OM::Parameters& parameters, const scnXml::Model& model ){
-
-    // Default value to use if no <parameters> element is present in XML.
-    latentP = UnitParse::readShortDuration("15d", UnitParse::DAYS);
-    try
-    {
-        if (model.getParameters().present())
-        {
-            latentP = UnitParse::readShortDuration(
-                model.getParameters().get().getLatentp(), UnitParse::NONE);
-        }
-    }
-    catch( const util::format_error& e )
-    {
-            throw util::xml_scenario_error( string("model/parameters/latentP: ").append(e.message()) );
-    }
+    latentP = parameters.GetLatentP();
 
     if( !model.getVivax().present() )
         throw util::xml_scenario_error( "no vivax model description in scenario XML" );

--- a/unittest/UnittestUtil.h
+++ b/unittest/UnittestUtil.h
@@ -237,7 +237,7 @@ namespace dummyXML{
     scnXml::AgeGroupValues modelHumanAvailMosq;
     scnXml::Human modelHuman( modelHumanAvailMosq );
     scnXml::ComputationParameters computationParams(0 /* iseed */);
-    scnXml::Parameters modelParams(0 /* interval*/, "dummy" /* latentP */);
+    scnXml::Parameters modelParams(0 /* interval*/, "15d" /* latentP */);
     scnXml::Model model(modelClinical, modelHuman, computationParams);
     
     scnXml::Scenario scenario(


### PR DESCRIPTION
# Problem

Pre-erythrocyctic latent period is currently parsed by within host models.

It might be reasonable for different within host models (falciparum, vivax) to treat the latentp value specified by the user slightly differently.  But they shouldn't each be implementing XML parsing behaviour.

## Solution

I made the Parameters class parse latentp from XML and provide it via a new method `GetLatentP`.

Within host models no longer parse latentp from XML.  They get the value from the Parameters class instead.

As a nice side effect, this makes it possible for named models to override the latentp value in future (by adding code inside the Parameters class).  While it is common to use 15 days ("15d") as a value for latentp, I have chosen not to make 15 days the default value _in general_ since it may be inappropriate with some model variants (see discussion on #419 ).

If no latentp value is set either:

1. explicitly in the scenario, or 
2. from a named model which is specified in the scenario,

then any attempt to get the latentp value from Parameters will throw.

TODO : actually implement the described behaviour.  Consider implementing this by initialising latentp at time of declaration with some sentinel value and throwing in GetLatentP if the sentinel value is held.

## Testing

- [ ] Automated tests all still run and pass.

Unit test code had to be updated since the string "dummy" is no longer accepted.

## Documentation

TODO : write wiki docs change explaining any user-facing changes resulting from this (e.g. possibly specifying units).

## Notes

Any value set for latentp must now conform to the format required by UnitParse (TODO : is this new or was it introduced by earlier PR?).  This has implications for migrating existing scenarios to the next version of OpenMalaria.