### PR TITLE
fix: Rectify gh action's effect on gh release page text.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,11 @@ artifacts:
 deploy:
   force_update: true
   provider: GitHub
-  description: "OpenMalaria build for Windows"
+  description: |
+    Release of OpenMalaria.
+    
+    Updates: https://github.com/SwissTPH/openmalaria/wiki/SchemaUpdateGuide
+    Changelog: https://github.com/SwissTPH/openmalaria/wiki/Changelog
   auth_token:
     secure: H6XDjpkpbS8cfYxfGwOwEDBQEuAqnIeDtnG3eHuqTf6gdOjge80AFM2h5iaqTLcw
   artifact: openMalaria-windows.zip


### PR DESCRIPTION
# Problem

The description on the GitHub Release page for OpenMalaria was being overwritten with "OpenMalaria build for Windows".  This text is meant to pertain to the whole release - for all platforms.

## Solution

This is a band-aid.

This PR does not stop the release's description text being overwritten.

This PR makes the release's description text get overwritten with the desired text.