### PR TITLE
chore: Fix cpp20 warning cause by bitwise ORing different enum types.

### DIFF
--- a/unittest/CMDecisionTreeSuite.h
+++ b/unittest/CMDecisionTreeSuite.h
@@ -119,26 +119,26 @@ public:
         // test that dt.exec chooses to treat 80% and no action 20% of the time:
 	TS_ASSERT_DELTA( propTreatmentsNReps( N, dt ), 0.8, LIM );
     }
-    
+
     void testUC2Test () {
         scnXml::DTTreatPKPD treat1( "sched1", "dosage1" );
         scnXml::DecisionTree simpleTreat;
         simpleTreat.getTreatPKPD().push_back( treat1 );
         scnXml::DecisionTree noAction;
         noAction.setNoTreatment( scnXml::DTNoTreatment() );
-        
+
         scnXml::DTCaseType ct( simpleTreat,  // first line: simple treatment
                             noAction );     // second line: no action
         scnXml::DecisionTree dt;
         dt.setCaseType( ct );
-        
-	hd->pgState = static_cast<Episode::State>( Pathogenesis::STATE_MALARIA );
-	TS_ASSERT_EQUALS( propTreatmentsNReps( 1, dt ), 1 );
-	hd->pgState = static_cast<Episode::State>( Pathogenesis::STATE_MALARIA |
-                Episode::SECOND_CASE );
-	TS_ASSERT_EQUALS( propTreatmentsNReps( 1, dt ), 0 );
+
+        hd->pgState = Episode::MALARIA;
+        TS_ASSERT_EQUALS( propTreatmentsNReps( 1, dt ), 1 );
+
+        hd->pgState = static_cast<Episode::State>( Episode::MALARIA | Episode::SECOND_CASE );
+        TS_ASSERT_EQUALS( propTreatmentsNReps( 1, dt ), 0 );
     }
-    
+
     void testParasiteTest () {
         scnXml::DTTreatPKPD treat1( "sched1", "dosage1" );
         scnXml::DecisionTree simpleTreat;


### PR DESCRIPTION
# Problem

At time of writing, OpenMalaria is built against the C++17 standard.

I tried to compile OpenMalaria with gcc using C++20 to observe warnings/errors.

Some warnings were addressed in #426 .

This PR addresses another such warning, in unit test code.

```
warning: bitwise operation between different enumeration types OM::WithinHost::Pathogenesis::State and OM::Clinical::Episode::State is deprecated [-Wdeprecated-enum-enum-conversion]
  137 |         hd->pgState = static_cast<Episode::State>( Pathogenesis::STATE_MALARIA |
      |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  138 |                 Episode::SECOND_CASE );
      |                 ~~~~~~~~~~~~~~~~~~~~

```

This PR does not actually make the switch to C++20.

## Solution

1. `Pathogenesis::STATE_MALARIA` was being implicitly cast to `Episode::MALARIA`, then being bitwise ORed with another Episode enum value.  This produces no warning when compiling with cpp17 but with cpp20 it does produce a warning.  I simply replaced the `Pathogenesis::STATE_MALARIA` value with `Episode::MALARIA`, removing the need for an implicit cast.
2. I also removed a redundant cast in an earlier operation.

## Testing

Automated tests still run and pass.

I'm unsure whether or not this addresses *all* remaining issues relating to compiling with C++20.  There are no other warnings with GCC but I've not tested any other compilers we support yet.