### PR TITLE
chore: Fix macOS CI builds.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install - MacOS
         if: startsWith(matrix.os,'macos')
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install git coreutils cmake gcc gsl xerces-c xsd || true
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install coreutils gsl xerces-c xsd || true
           HOMEBREW_NO_AUTO_UPDATE=1 brew link --overwrite xsd
       
       - name: Infos


### PR DESCRIPTION
# Problem

Recently, macOS CI builds started failing, for all macOS versions that we target.

See issue https://github.com/SwissTPH/openmalaria/issues/436

This seems likely to be caused by a recent change to GitHub's runner images for macOS https://github.com/actions/runner-images/pull/12791 and there is an open issue related to cmake failing to install on actions that use those images https://github.com/actions/runner-images/issues/12912

## Solution

I was able to take the blame off any recent OpenMalaria changes by reproducing the issue with the commit tagged `schema-48.0`, which we know to have passed CI.

Updating the relevant GitHub Actions workflow config file to no longer install certain packages stops the relevant builds failing.

To some extent, this solution is a workaround, and I think it's better to have this workaround now than have failing CI until GitHub might fix the issue.

## Testing

As can be seen in the CI checks on this PR, the relevant builds now pass (green ticks).

Looking more closely at the logs for those builds, it is clear that there are still some warnings and one error.  I suggest we live with them.  They do not indicate any relevant defect in the macOS environments we're using for testing OpenMalaria.

**macOS 14 and macOS 15**

```
Warning: Already linked: /opt/homebrew/Cellar/xsd/4.2.0
To relink, run:
  brew unlink xsd && brew link xsd
```

**macOS 13**

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink share/man/man1/xsd.1
Target /usr/local/share/man/man1/xsd.1
already exists. You may want to remove it:
  rm '/usr/local/share/man/man1/xsd.1'

To force the link and overwrite all conflicting files:
  brew link --overwrite xsd

To list all files that would be deleted:
  brew link --overwrite xsd --dry-run

Possible conflicting files are:
/usr/local/share/man/man1/xsd.1 -> /Library/Frameworks/Mono.framework/Versions/Current/share/man/man1/xsd.1
```