### PR TITLE
refactor: Remove unsupported growthRate for demography.

### DIFF
--- a/model/Population.cpp
+++ b/model/Population.cpp
@@ -81,8 +81,6 @@ void Population::update()
 {
     //NOTE: other parts of code are not set up to handle changing population size. Also
     // size is assumed to be the _actual and exact_ population size by other code.
-    //targetPop is the population size at time t allowing population growth
-    //int targetPop = (int) (size * exp( AgeStructure::rho * sim::ts1().inSteps() ));
     int cumPop = 0;
 
     for (auto it = humans.begin(); it != humans.end();) {

--- a/model/PopulationAgeStructure.cpp
+++ b/model/PopulationAgeStructure.cpp
@@ -36,12 +36,10 @@ namespace OM {
 vector<double> AgeStructure::ageGroupBounds;
 vector<double> AgeStructure::ageGroupPercent;
 
-double AgeStructure::initialRho = 0.0;
 double AgeStructure::mu0;
 double AgeStructure::mu1;
 double AgeStructure::alpha0;
 double AgeStructure::alpha1;
-double AgeStructure::rho;
 
 vector<double> AgeStructure::cumAgeProp;
 
@@ -137,14 +135,6 @@ void AgeStructure::estimateRemovalRates( const scnXml::Demography& demography ){
     for(size_t i = 0;i < ngroups; i++) {
 	ageGroupPercent[i]  = ageGroupPercent[i] * sumperc;
     }
-    /*
-    RSS between observed and predicted log percentage of population in age groups
-    is minimised for values of mu1 and alpha1
-    calls setDemoParameters to calculate the RSS
-    */
-    if( demography.getGrowthRate().present() ){
-        initialRho = demography.getGrowthRate().get();
-    }
 
     /* NOTE: unused --- why?
     double tol = 0.00000000001;
@@ -160,14 +150,6 @@ void AgeStructure::estimateRemovalRates( const scnXml::Demography& demography ){
 // Static method used by estimateRemovalRates
 double AgeStructure::setDemoParameters (double param1, double param2)
 {
-    rho = initialRho;
-
-    rho = rho * (0.01 * sim::yearsPerStep());
-    if (rho != 0.0)
-	// Issue: in this case the total population size differs from populationSize,
-	// however, some code currently uses this as the total population size.
-	throw util::xml_scenario_error ("Population growth rate provided.");
-    
     const double IMR = 0.1;
     double M_inf = -log (1 - IMR);
     

--- a/model/PopulationAgeStructure.h
+++ b/model/PopulationAgeStructure.h
@@ -73,7 +73,6 @@ namespace OM
         static vector<double> ageGroupBounds;
 	static vector<double> ageGroupPercent;
         //@}
-        static double initialRho;
         /** Parameters defining smooth curve of target age-distribution.
         *
         * Set by estimateRemovalRates() (via setDemoParameters()) and used by
@@ -83,7 +82,8 @@ namespace OM
 	static double mu1;
 	static double alpha0;
 	static double alpha1;
-	static double rho;
+        // rho is growth rate of human population.
+	constexpr static double rho = 0.0;
         //@}
 	//END
 	

--- a/model/PopulationAgeStructure.h
+++ b/model/PopulationAgeStructure.h
@@ -71,19 +71,19 @@ namespace OM
         * setDemoParameters()). */
         //@{
         static vector<double> ageGroupBounds;
-	static vector<double> ageGroupPercent;
+        static vector<double> ageGroupPercent;
         //@}
         /** Parameters defining smooth curve of target age-distribution.
         *
         * Set by estimateRemovalRates() (via setDemoParameters()) and used by
         * setupPyramid(). */
         //@{
-	static double mu0;
-	static double mu1;
-	static double alpha0;
-	static double alpha1;
+        static double mu0;
+        static double mu1;
+        static double alpha0;
+        static double alpha1;
         // rho is growth rate of human population.
-	constexpr static double rho = 0.0;
+        constexpr static double rho = 0.0;
         //@}
 	//END
 	

--- a/schema/demography.xsd
+++ b/schema/demography.xsd
@@ -42,15 +42,6 @@ Licence: GNU General Public Licence version 2 or later (see COPYING) -->
         <xs:appinfo>units:Years;min:0;max:100;name:Maximum age of simulated humans;</xs:appinfo>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="growthRate" type="xs:double" use="optional">
-      <xs:annotation>
-        <xs:documentation>
-          Growth rate of human population.
-            (we should be able to implement this with non-zero values)
-        </xs:documentation>
-        <xs:appinfo>units:Number;min:0;max:0;name:Growth rate of human population;</xs:appinfo>
-      </xs:annotation>
-    </xs:attribute>
   </xs:complexType>
   <!-- ageGroup -->
   <xs:complexType name="DemogAgeGroup">


### PR DESCRIPTION
# Problem

While reading some age structure code, I encountered an unexpected XML attribute.

This attribute is related to population growth.

For at least 10 years, OpenMalaria has just thrown an exception if this attribute is used.

## Solution

This PR removes schema-level support for the XML attribute and deletes code related to it.

## Testing

(macOS CI fails but this is addressed in a separate PR https://github.com/SwissTPH/openmalaria/pull/437)

Nonzero values for the growthRate attribute were not supported before this PR anyway.

**Before:**

When one added growthRate="0.1" to the <demography> node in the example, XML, the output when running OpenMalaria is:
Error: Population growth rate provided.
In: example_scenario.xml

**After:**

Now, if one adds growthRate="0.1" to the <demography> node in the example, XML, the output when running OpenMalaria is:
XSD error: instance document parsing failed
:29:83 error: attribute 'growthRate' is not declared for element 'demography'

## Documentation

Wiki docs are already  consistent with the behaviour before and after this PR, no update is needed.

https://github.com/SwissTPH/openmalaria/wiki/ModelDemography
 
> The simulations also run with constant population sizes

## Notes

I chose to leave a variable called `rho` instead of just hardcoding a value of 0 everywhere it's used because that seems more readable to me.