### PR TITLE
Add ARM Linux image to GH actions workflow file.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,30 +51,33 @@ jobs:
             compiler: g++
             target: Linux
 
+          - os: ubuntu-24.04-arm
+            compiler: g++
+            target: Linux
+
           - os: macos-15
             compiler: clang
-          
+
           - os: macos-14
             compiler: clang
 
           - os: macos-13
             compiler: clang
-          
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Install - Ubuntu
         if: startsWith(matrix.os,'ubuntu')
         run: |
           sudo apt update
           sudo apt install -y build-essential git cmake libgsl-dev libxerces-c-dev xsdcxx || true
-      
+
       - name: Install - MacOS
         if: startsWith(matrix.os,'macos')
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install coreutils gsl xerces-c xsd || true
           HOMEBREW_NO_AUTO_UPDATE=1 brew link --overwrite xsd
-      
+
       - name: Infos
         run: |
           echo "Event: ${{ github.event_name }}"


### PR DESCRIPTION
# Problem

OpenMalaria does not compile on Linux on ARM with GCC.

Users wanting to run OpenMalaria on such a platform currently have to modify and compile OpenMalaria themselves.

## Solution

1. Add a new GitHub Actions runner `ubuntu-24.04-arm` (this is a third party runner maintained by ARM rather than GitHub) to cover the Linux on arm64/aarch64.
2. Remove from OpenMalaria's top-level CMakeLists.txt file the compilation flags that were causing compilation to fail.

## Testing

WIP

## Documentation

WIP

## Notes

I don't actually know why the compilation flags that this PR removes were originally present.

The comment suggests Raspberry Pi compatibility.  Actually OpenMalaria fails to compile due to those flags on a modern Raspberry Pi anyway.

So I'm reasonably confident we're better off without the relevant compilation flags at this point in time.