### PR TITLE
feat: Build with C++20.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 # -----  Compile options  -----
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 set (OM_STD_LIBS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,6 @@ set(CMAKE_CXX_STANDARD 20)
 
 set (OM_STD_LIBS)
 
-# -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR
-# auto_ptr has been removed from c++17
-# This extension is needed because XSD still use auto_ptr in its headers
-# Note that is does not use auto_ptr in the generated code, only in the library headers
-
 if (NOT MSVC)
   # We almost always want optimisations enabled:
   set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O2")
@@ -51,9 +46,6 @@ endif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 
 # Statically link libgcc; isn't going to work when other C++ libraries are dynamically linked
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
-  # This doesn't show up in the cache, but it is passed to gcc:
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR")
-
   option (OM_COVERAGE "Produce coverage into binary.")
   if (OM_COVERAGE)
     # Add coverage
@@ -102,14 +94,12 @@ if (MSVC)
 endif (MSVC)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR")
   # These are actually only needed when using "clang" not "clang++" (same with
   # "gcc"), but adding here saves a user error:
   set (OM_STD_LIBS m stdc++)
 endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "AppleClang")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR")
   # These are actually only needed when using "clang" not "clang++" (same with
   # "gcc"), but adding here saves a user error:
   set (OM_STD_LIBS m stdc++)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set (OM_STD_LIBS)
 # -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR
 # auto_ptr has been removed from c++17
 # This extension is needed because XSD still use auto_ptr in its headers
-# Note that is doe snot use auto_ptr in the generated code, only in the library headers
+# Note that is does not use auto_ptr in the generated code, only in the library headers
 
 if (NOT MSVC)
   # We almost always want optimisations enabled:


### PR DESCRIPTION
# Problem

Some previous PRs prepared to switch to C++20.  https://github.com/OpenMalaria-Org/openmalaria/pull/431 https://github.com/OpenMalaria-Org/openmalaria/pull/426

Now that switching to C++20 is unblocked, we wish to proceed such that we can get access to latest language features.

This is not absolutely critical/blocking any other important tasks but rather represents a reasonable improvement.

## Solution

Tell CMake to build with C++20.

### Additional cleanup

While reviewing the top level CMakeLists.txt file, I also noticed some other settings which appeared to be a workaround to the fact that XSD headers used auto_ptr, which was removed in C++17.  These no longer appear to be necessary and so I have removed them, presumably XSD headers have been updated.

## Testing

Tested locally (Debian, GCC, X86_64): built ok, tests passed.
Tested on Setonix with GCC: built ok, tests passed.
CI builds: built ok, tests passed.

## Documentation

Only hits in the wiki for "C++17" or "CPP17: are in changelog, so no need for any wiki updates.