### PR TITLE
feat: Add error output to suggest possible causes when scenario parsing fails

### DIFF
--- a/model/main.cpp
+++ b/model/main.cpp
@@ -310,15 +310,20 @@ int main(int argc, char* argv[])
             exitStatus = e.getCode();
         }
     } catch (const ::xsd::cxx::tree::exception<char>& e) {
-        // e.what() returns a concise error message e.g. "instance document parsing failed".
-        // Whereas inserting e into a stream inserts the (possibly long and repetitive) list of error messages arising from the parsing attempt.
-        std::cerr << "XSD error: " << e.what() << '\n' << e << endl;
-
-        // We print this *after* the above since users are more likely to take note of the tail of stderr/stdout output than the head.
         if (errno == 2) // Errno value 2 corresponds to "No such file or directory" i.e. this is not a mismatch between scenario contents and schema rules.
+        {
+            // We don't print the content of the xsdcxx exception since the error messages are not relevant to the user in this case.
             std::cerr << "Parsing scenario file failed.\n\tLikely the XSD schema file is not present at an expected location/with expected filename." << std::endl;
+        }
         else
+        {
+            // e.what() returns a concise error message e.g. "instance document parsing failed".
+            // Whereas inserting e into a stream inserts the (possibly long and repetitive) list of error messages arising from the parsing attempt.
+            std::cerr << "XSD error: " << e.what() << '\n' << e << endl;
+
+            // We print this *after* the above since users are more likely to take note of the tail of stderr/stdout output than the head.
             std::cerr << "Parsing scenario file failed.\n\tLikely the XSD schema is named/located correctly but the scenario does not conform to the schema." << std::endl;
+        }
         exitStatus = OM::util::Error::XSD;
     } catch (const OM::util::checkpoint_error& e) {
         std::cerr << "Checkpoint error: " << e.what() << endl;

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -304,35 +304,41 @@ int main(int argc, char* argv[])
     } catch (const OM::util::cmd_exception& e) {
         if( e.getCode() == 0 ){
             // this is not an error, but exiting due to command line
-            cerr << e.what() << "; exiting..." << endl;
+            std::cerr << e.what() << "; exiting..." << endl;
         }else{
-            cerr << "Command-line error: "<<e.what();
+            std::cerr << "Command-line error: "<<e.what();
             exitStatus = e.getCode();
         }
     } catch (const ::xsd::cxx::tree::exception<char>& e) {
-        cerr << "XSD error: " << e.what() << '\n' << e << endl;
+        // e.what() returns a concise error message e.g. "instance document parsing failed".
+        // Whereas inserting e into a stream inserts the (possibly long and repetitive) list of error
+        // messages arising from the parsing attempt.
+        std::cerr << "XSD error: " << e.what() << '\n' << e << endl;
+        std::cerr << "Parsing scenario file failed."
+                << "\n\tLikely the XSD schema file is not present at an expected location/with expected filename,"
+                << "\n\tor the scenario file does not conform to the relevant XSD schema file." << std::endl;
         exitStatus = OM::util::Error::XSD;
     } catch (const OM::util::checkpoint_error& e) {
-        cerr << "Checkpoint error: " << e.what() << endl;
-        cerr << e << flush;
+        std::cerr << "Checkpoint error: " << e.what() << endl;
+        std::cerr << e << flush;
         exitStatus = e.getCode();
     } catch (const OM::util::traced_exception& e) {
-        cerr << "Code error: " << e.what() << endl;
-        cerr << e << flush;
-        cerr << "This is likely an error in the C++ code. Please report!" << endl;
+        std::cerr << "Code error: " << e.what() << endl;
+        std::cerr << e << flush;
+        std::cerr << "This is likely an error in the C++ code. Please report!" << endl;
         exitStatus = e.getCode();
     } catch (const OM::util::xml_scenario_error& e) {
-        cerr << "Error: " << e.what() << endl;
-        cerr << "In: " << scenarioFile << endl;
+        std::cerr << "Error: " << e.what() << endl;
+        std::cerr << "In: " << scenarioFile << endl;
         exitStatus = e.getCode();
     } catch (const OM::util::base_exception& e) {
-        cerr << "Error: " << e.message() << endl;
+        std::cerr << "Error: " << e.message() << endl;
         exitStatus = e.getCode();
     } catch (const exception& e) {
-        cerr << "Error: " << e.what() << endl;
+        std::cerr << "Error: " << e.what() << endl;
         exitStatus = EXIT_FAILURE;
     } catch (...) {
-        cerr << "Unknown error" << endl;
+        std::cerr << "Unknown error" << endl;
         exitStatus = EXIT_FAILURE;
     }
     

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -311,14 +311,14 @@ int main(int argc, char* argv[])
         }
     } catch (const ::xsd::cxx::tree::exception<char>& e) {
         // e.what() returns a concise error message e.g. "instance document parsing failed".
-        // Whereas inserting e into a stream inserts the (possibly long and repetitive) list of error
-        // messages arising from the parsing attempt.
+        // Whereas inserting e into a stream inserts the (possibly long and repetitive) list of error messages arising from the parsing attempt.
         std::cerr << "XSD error: " << e.what() << '\n' << e << endl;
-        // We print this *after* the above since users are more likely to take note of the tail of
-        // stderr/stdout output than the head.
-        std::cerr << "Parsing scenario file failed."
-                << "\n\tLikely the XSD schema file is not present at an expected location/with expected filename,"
-                << "\n\tor the scenario file does not conform to the relevant XSD schema file." << std::endl;
+
+        // We print this *after* the above since users are more likely to take note of the tail of stderr/stdout output than the head.
+        if (errno == 2) // Errno value 2 corresponds to "No such file or directory" i.e. this is not a mismatch between scenario contents and schema rules.
+            std::cerr << "Parsing scenario file failed.\n\tLikely the XSD schema file is not present at an expected location/with expected filename." << std::endl;
+        else
+            std::cerr << "Parsing scenario file failed.\n\tLikely the XSD schema is named/located correctly but the scenario does not conform to the schema." << std::endl;
         exitStatus = OM::util::Error::XSD;
     } catch (const OM::util::checkpoint_error& e) {
         std::cerr << "Checkpoint error: " << e.what() << endl;

--- a/model/main.cpp
+++ b/model/main.cpp
@@ -314,6 +314,8 @@ int main(int argc, char* argv[])
         // Whereas inserting e into a stream inserts the (possibly long and repetitive) list of error
         // messages arising from the parsing attempt.
         std::cerr << "XSD error: " << e.what() << '\n' << e << endl;
+        // We print this *after* the above since users are more likely to take note of the tail of
+        // stderr/stdout output than the head.
         std::cerr << "Parsing scenario file failed."
                 << "\n\tLikely the XSD schema file is not present at an expected location/with expected filename,"
                 << "\n\tor the scenario file does not conform to the relevant XSD schema file." << std::endl;

--- a/model/util/DocumentLoader.cpp
+++ b/model/util/DocumentLoader.cpp
@@ -42,16 +42,18 @@ namespace OM
                 string msg = "Error: unable to open " + lXmlFile;
                 throw util::xml_scenario_error(msg);
             }
-            unique_ptr<scnXml::Scenario> scenario;
+            std::unique_ptr<scnXml::Scenario> scenario;
             try
             {
                 scenario = scnXml::parseScenario (fileStream);
             }
             catch(const std::exception& e)
             {
-                std::cerr << "Error: parsing scenario file failed.\n\tPossibly the XSD file is not present at an expected location/with expected filename." << std::endl;
+                std::cerr << "Error: parsing scenario file failed."
+                << "\n\tLikely the XSD file is not present at an expected location/with expected filename,"
+                << "\n\tor the scenario file " << lXmlFile << " does not conform to the relevant schema." << std::endl;
                 std::cerr << e.what() << std::endl;
-                throw e;
+                throw;
             }
             fileStream.close ();
 
@@ -60,7 +62,7 @@ namespace OM
             if (scenarioVersion < SCHEMA_VERSION) {
                 // Don't bother aborting. Mostly if something really is incompatible
                 // loading will not succeed anyway.
-                cerr<<"Warning: "<<lXmlFile<<" uses an old schema version (latest is "<<SCHEMA_VERSION<<")."<<endl;
+                std::cerr<<"Warning: "<<lXmlFile<<" uses an old schema version (latest is "<<SCHEMA_VERSION<<")."<<endl;
             }
             else if (scenarioVersion > SCHEMA_VERSION)
                 throw util::xml_scenario_error ("Error: new schema version unsupported");

--- a/model/util/DocumentLoader.cpp
+++ b/model/util/DocumentLoader.cpp
@@ -28,7 +28,7 @@ namespace OM
 { 
     namespace util
     {
-        unique_ptr<scnXml::Scenario> loadScenario(std::string lXmlFile)
+        std::unique_ptr<scnXml::Scenario> loadScenario(std::string lXmlFile)
         {
             // Opening by filename causes a schema lookup in the scenario file's dir,
             // which does always work. Opening with a stream uses the working directory.
@@ -36,28 +36,16 @@ namespace OM
             // Note that the schema location can be set manually by passing properties,
             // but we won't necessarily have the right schema version associated with
             // the XML file in that case.
-            ifstream fileStream(lXmlFile.c_str(), ios::binary);
+            std::ifstream fileStream(lXmlFile.c_str(), ios::binary);
             if (!fileStream.good())
             {
-                string msg = "Error: unable to open " + lXmlFile;
+                std::string msg = "Error: unable to open " + lXmlFile;
                 throw util::xml_scenario_error(msg);
             }
-            std::unique_ptr<scnXml::Scenario> scenario;
-            try
-            {
-                scenario = scnXml::parseScenario (fileStream);
-            }
-            catch(const std::exception& e)
-            {
-                std::cerr << "Error: parsing scenario file failed."
-                << "\n\tLikely the XSD file is not present at an expected location/with expected filename,"
-                << "\n\tor the scenario file " << lXmlFile << " does not conform to the relevant schema." << std::endl;
-                std::cerr << e.what() << std::endl;
-                throw;
-            }
+            std::unique_ptr<scnXml::Scenario> scenario = scnXml::parseScenario (fileStream);
             fileStream.close ();
 
-            int scenarioVersion = scenario->getSchemaVersion();
+            const int scenarioVersion = scenario->getSchemaVersion();
 
             if (scenarioVersion < SCHEMA_VERSION) {
                 // Don't bother aborting. Mostly if something really is incompatible

--- a/model/util/DocumentLoader.cpp
+++ b/model/util/DocumentLoader.cpp
@@ -42,7 +42,17 @@ namespace OM
                 string msg = "Error: unable to open " + lXmlFile;
                 throw util::xml_scenario_error(msg);
             }
-            unique_ptr<scnXml::Scenario> scenario = scnXml::parseScenario (fileStream);
+            unique_ptr<scnXml::Scenario> scenario;
+            try
+            {
+                scenario = scnXml::parseScenario (fileStream);
+            }
+            catch(const std::exception& e)
+            {
+                std::cerr << "Error: parsing scenario file failed.\n\tPossibly the XSD file is not present at an expected location/with expected filename." << std::endl;
+                std::cerr << e.what() << std::endl;
+                throw e;
+            }
             fileStream.close ();
 
             int scenarioVersion = scenario->getSchemaVersion();

--- a/model/util/DocumentLoader.h
+++ b/model/util/DocumentLoader.h
@@ -37,7 +37,7 @@ namespace OM
     {
         static const int SCHEMA_VERSION = 48;
 
-        unique_ptr<scnXml::Scenario> loadScenario(std::string lXmlFile);
+        std::unique_ptr<scnXml::Scenario> loadScenario(std::string lXmlFile);
     }
 }
 


### PR DESCRIPTION
# Problem

A misplaced/misnamed/unlocatable XSD file is not easily identified by new users, from existing OpenMalaria stderr output.

This is a mostly a quality of life issue, where very experienced OpenMalaria users can generally infer the nature of the issue from existing stderr output contents.  But only because they've already spent the time to learn what the symptoms mean.

## Solution

Much of the code that gets called when parsing the scenario is **generated** (by xsdcxx) C++ code.

To avoid getting too involved with such generated code, I looked at what could be done in relevant code **within** OpenMalaria's source tree.

The solution presented in this PR is to simply print additional output to stderr when parsing fails, suggesting 2 possible causes to the user.

Additionally, in this solution we distinguish between failure modes in order to provide more targeted feedback to the user.

## Testing

I tested before/after for 3 cases:

1. Scenario conforms to schema, schema is appropriately named/located.
2. Scenario conforms to schema, schema is wrongly named/located.
3. Scenario does not conform to schema, schema is appropriately named/located.

### Scenario conforms to schema, schema is appropriately named/located.

This is the happy path.  No change in output occurs.

### Scenario conforms to schema, schema is wrongly named/located.

Before:

```
XSD error: instance document parsing failed
:0:0 warning: unable to open primary document entity 'scenario_48.xsd'
:22:234 error: no declaration found for element 'om:scenario'
:22:234 error: attribute '{http://www.w3.org/2000/xmlns/}om' is not declared for element 'om:scenario'
:22:234 error: attribute '{http://www.w3.org/2000/xmlns/}xsi' is not declared for element 'om:scenario'
:22:234 error: attribute 'name' is not declared for element 'om:scenario'
:22:234 error: attribute 'schemaVersion' is not declared for element 'om:scenario'
:22:234 error: attribute '{http://www.w3.org/2001/XMLSchema-instance}schemaLocation' is not declared for element 'om:scenario'
:29:66 error: no declaration found for element 'demography'
:29:66 error: attribute 'maximumAgeYrs' is not declared for element 'demography'

[...]

:341:55 error: attribute 'value' is not declared for element 'group'
:345:43 error: no declaration found for element 'computationParameters'
:345:43 error: attribute 'iseed' is not declared for element 'computationParameters'
OpenMalaria: No such file or directory
```

After:

```
Parsing scenario file failed.
        Likely the XSD schema file is not present at an expected location/with expected filename.
OpenMalaria: No such file or directory
```

### Scenario does not conform to schema, schema is appropriately named/located.

(For this test case, I used 48.0 schema, instead of scenario_current.xsd.)

Before:

```
XSD error: instance document parsing failed
:192:46 error: missing required attribute 'propInfected'
:192:46 error: missing required attribute 'propInfectious'
:222:23 error: missing required attribute 'minInfectedThreshold'
:243:44 error: missing required attribute 'propInfected'
:243:44 error: missing required attribute 'propInfectious'
:250:23 error: missing required attribute 'minInfectedThreshold'
:271:46 error: missing required attribute 'propInfected'
:271:46 error: missing required attribute 'propInfectious'
:278:23 error: missing required attribute 'minInfectedThreshold'
```

After:

```
XSD error: instance document parsing failed
:192:46 error: missing required attribute 'propInfected'
:192:46 error: missing required attribute 'propInfectious'
:222:23 error: missing required attribute 'minInfectedThreshold'
:243:44 error: missing required attribute 'propInfected'
:243:44 error: missing required attribute 'propInfectious'
:250:23 error: missing required attribute 'minInfectedThreshold'
:271:46 error: missing required attribute 'propInfected'
:271:46 error: missing required attribute 'propInfectious'
:278:23 error: missing required attribute 'minInfectedThreshold'
Parsing scenario file failed.
        Likely the XSD schema is named/located correctly but the scenario does not conform to the schema.
```

## Documentation

No wiki updates or other documentation changes needed for this PR.